### PR TITLE
Fix / TEC-3564 datepicker text wrapping

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/resources/postcss/utilities"]
 	path = src/resources/postcss/utilities
-	url = https://github.com/moderntribe/tribe-common-styles.git
+	url = https://github.com/the-events-calendar/tribe-common-styles.git

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 = [4.12.17] TBD =
 
+* Fix - Increase the minimum width of the datetime dropdown when editing an event with the block editor. [TEC-3126]
 
 = [4.12.16] TBD =
 

--- a/src/modules/elements/time-picker/style.pcss
+++ b/src/modules/elements/time-picker/style.pcss
@@ -43,7 +43,7 @@
 	&.components-popover {
 
 		.components-popover__content {
-			min-width: 110px;
+			min-width: 140px;
 		}
 	}
 


### PR DESCRIPTION
**Description:** Increases the minimum width of the popover component's content element in the block editor, so that the options text doesn't wrap.

**Ticket:** https://moderntribe.atlassian.net/browse/TEC-3126

**Screenshots:**

<img width="415" alt="Screen Shot 2020-12-22 at 2 42 16 PM" src="https://user-images.githubusercontent.com/5049893/102895138-7416c600-4464-11eb-97db-2aa9385b151c.png">
