### PR TITLE
Correctly handle falsy directory names

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@
 
 = [4.12.16] TBD =
 
+* Fix - Correctly handle *nix and Windows server paths that contain falsy values (e.g. `0` or spaces) when building template paths. [TEC-3712]
 
 
 = [4.12.15] 2020-12-15 =

--- a/src/Tribe/Utils/Paths.php
+++ b/src/Tribe/Utils/Paths.php
@@ -39,15 +39,15 @@ class Paths {
 			$paths = array_merge( $slice, [ static::merge( ...$paths ) ] );
 		}
 
-		$path_1             = isset( $paths[0] ) ? $paths[0] : '';
-		$lead_slash         = is_string( $path_1 ) && $path_1 !== ltrim( $path_1, '\\/' ) ? DIRECTORY_SEPARATOR : '';
-		$path_2             = isset( $paths[1] ) ? $paths[1] : '';
-		$trail_slash        = is_string( $path_2 ) && $path_2 !== rtrim( $path_2, '\\/' ) ? DIRECTORY_SEPARATOR : '';
-		$drop_empty_strings = static function ( $frag ) {
-			return $frag !== '';
-		};
+		$path_1      = isset( $paths[0] ) ? $paths[0] : '';
+		$lead_slash  = is_string( $path_1 ) && $path_1 !== ltrim( $path_1, '\\/' ) ? DIRECTORY_SEPARATOR : '';
+		$path_2      = isset( $paths[1] ) ? $paths[1] : '';
+		$trail_slash = is_string( $path_2 ) && $path_2 !== rtrim( $path_2, '\\/' ) ? DIRECTORY_SEPARATOR : '';
 		// Handle *nix spacing escape sequence (`\ `) correctly. The Windows one (`^ `) is already handled.
 		$break_pattern          = '/[\\\\\\/](?!\\s)/';
+		$drop_empty_strings     = static function ( $frag ) {
+			return $frag !== '';
+		};
 		$path_1_frags           = is_array( $path_1 )
 			? $path_1
 			: array_filter( (array) preg_split( $break_pattern, $path_1 ), $drop_empty_strings );
@@ -55,14 +55,17 @@ class Paths {
 			? $path_2
 			: array_filter( (array) preg_split( $break_pattern, $path_2 ), $drop_empty_strings );
 		$non_consecutive_common = array_intersect( $path_1_frags, $path_2_frags );
-		$trimmed_path_2         = trim(
+
+		$trimmed_path_2 = trim(
 			preg_replace(
 				'#^' . preg_quote( implode( DIRECTORY_SEPARATOR, $non_consecutive_common ), '#' ) . '#', '',
 				implode( DIRECTORY_SEPARATOR, $path_2_frags )
 			),
 			'\\/'
 		);
-		$merged_paths           .= $lead_slash . implode( DIRECTORY_SEPARATOR, $path_1_frags );
+
+		$merged_paths .= $lead_slash . implode( DIRECTORY_SEPARATOR, $path_1_frags );
+
 		if ( $trimmed_path_2 ) {
 			$merged_paths .= DIRECTORY_SEPARATOR . $trimmed_path_2 . $trail_slash;
 		}

--- a/tests/unit/Tribe/Utils/Paths_Test.php
+++ b/tests/unit/Tribe/Utils/Paths_Test.php
@@ -45,4 +45,42 @@ class Paths_Test extends \Codeception\Test\Unit {
 	public function test_merge( $expected, ...$paths ) {
 		$this->assertEquals( $expected, Paths::merge( ...$paths ) );
 	}
+
+	public function valid_falsy_paths_data_provider(  ) {
+	return [
+		'dir called 0' => [
+			'/home/vps-49f1a7/0/staging_html/wp-content/plugins/the-events-calendar/common/src/views',
+			'/home/vps-49f1a7/0/staging_html/wp-content/plugins/the-events-calendar/common/src/views/v2/base'
+		],
+		'dir called space on *nix' => [
+			'/home/vps-49f1a7/\ /staging_html/wp-content/plugins/the-events-calendar/common/src/views',
+			'/home/vps-49f1a7/\ /staging_html/wp-content/plugins/the-events-calendar/common/src/views/v2/base'
+		],
+		'dir called space on win' => [
+			'/home/vps-49f1a7/^ /staging_html/wp-content/plugins/the-events-calendar/common/src/views',
+			'/home/vps-49f1a7/^ /staging_html/wp-content/plugins/the-events-calendar/common/src/views/v2/base'
+		],
+		'dir name contains one *nix escaped space' => [
+			'/home/vps-49f1a7/html\ root/staging_html/wp-content/plugins/the-events-calendar/common/src/views',
+			'/home/vps-49f1a7/html\ root/staging_html/wp-content/plugins/the-events-calendar/common/src/views/v2/base'
+		],
+		'dir name contains two *nix escaped spaces' => [
+			'/home/vps-49f1a7/html\ root/staging_html/the\ content/plugins/the-events-calendar/common/src/views',
+			'/home/vps-49f1a7/html\ root/staging_html/the\ content/plugins/the-events-calendar/common/src/views/v2/base'
+		],
+		'dir name contains two win escaped spaces' => [
+			'Z:\home\vps-49f1a7\html^ root\staging_html\the^ content\plugins\the-events-calendar\common\src\views',
+			'Z:/home/vps-49f1a7/html^ root/staging_html/the^ content/plugins/the-events-calendar/common/src/views/v2/base'
+		],
+	];
+}
+
+	/**
+	 * @dataProvider valid_falsy_paths_data_provider
+	 */
+	public function test_merge_of_paths_with_valid_falsy_paths(  $path_1, $expected ) {
+		$merged = Paths::merge( $path_1, 'v2/base' );
+
+		$this->assertEquals( $expected, $merged );
+	}
 }


### PR DESCRIPTION
Issue: https://theeventscalendar.atlassian.net/browse/TEC-3712 

This PR fixes an issue that some customers where encountering since version `5.3` of TEC; in that version, in Common, I've added the `Utils/Path` class to add a more flexible merging of the template paths to allow the following:

Merge `/var/www/html/wp-content/plugins/tec/src/views/v2` and `v2/comp/sub-comp.php` => `/var/www/html/wp-content/plugins/tec/src/views/v2/comp/sub-comp.php`; the `v2`, present in both paths is nicely merged.
All nice and dandy, was it not that the "chopping" and filtering of the paths would drop path components that evaluate to "empty".

E.g. (from a customer VPS hosting site) `/home/vps-49f1a7/0/staging_html/wp-content/plugins/the-events-calendar/common/src/views` -- that directory called `/0/` in the path would be dropped by the `array_filter`.

The fix in this PR introduces a more robust filtering (only drop what equals the empty string `''`) and adds support for *nix space escaping (e.g. `/var/www/html\ root/...`).
The Windows space in dir name escaping (`Z:\var\www\html^ rooot\...`) is tested, but was already handled.

Artifacts: see the tests and [Screencap](https://drive.google.com/open?id=1JbtZ5MGNIstYdifVLiaadWNKH_Khnrph&authuser=luca%40tri.be&usp=drive_fs)

I'm not sharing video or pics of the fix on the staging site provided by the client to avoid privacy issues.
