### PR TITLE
[ET-1023] Fix Tribe__Cache non_persistent_keys checks so they always reference the correct cache key

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 
 = [4.12.19] TBD =
 
-* Fix - Prevent problems when using longer array keys in `Tribe__Cache` so the correct non-persistent groups are referenced.
+* Fix - Prevent problems when using longer array keys in `Tribe__Cache` so the correct non-persistent groups are referenced. [ET-1023]
 
 = [4.12.18] 2021-02-24 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [4.12.19] TBD =
+
+* Fix - Prevent problems when using longer array keys in `Tribe__Cache` so the correct non-persistent groups are referenced.
+
 = [4.12.18] 2021-02-24 =
 
 * Feature - JavaScript Assets can now be marked for async or defer, giving the asset manager more flexibility.

--- a/src/Tribe/Cache.php
+++ b/src/Tribe/Cache.php
@@ -70,7 +70,7 @@ class Tribe__Cache implements ArrayAccess {
 			$expiration = 1;
 
 			// Add so we know what group to use in the future.
-			$this->non_persistent_keys[] = $key;
+			$this->non_persistent_keys[ $id ] = $id;
 		} else {
 			$group = 'tribe-events';
 		}
@@ -108,8 +108,7 @@ class Tribe__Cache implements ArrayAccess {
 	 * @return mixed
 	 */
 	public function get( $id, $expiration_trigger = '', $default = false, $expiration = 0, $args = [] ) {
-		$flipped = array_flip( $this->non_persistent_keys );
-		$group   = isset( $flipped[ $id ] ) ? 'tribe-events-non-persistent' : 'tribe-events';
+		$group   = isset( $this->non_persistent_keys[ $id ] ) ? 'tribe-events-non-persistent' : 'tribe-events';
 		$value   = wp_cache_get( $this->get_id( $id, $expiration_trigger ), $group );
 
 		// Value found.
@@ -150,14 +149,11 @@ class Tribe__Cache implements ArrayAccess {
 	 * @return bool
 	 */
 	public function delete( $id, $expiration_trigger = '' ) {
-		$flipped = array_flip( $this->non_persistent_keys );
-		$group   = isset( $flipped[ $id ] ) ? 'tribe-events-non-persistent' : 'tribe-events';
+		$group   = isset( $this->non_persistent_keys[ $id ] ) ? 'tribe-events-non-persistent' : 'tribe-events';
 
 		// Delete from non-persistent keys list.
 		if ( 'tribe-events-non-persistent' === $group ) {
-			$index = $flipped[ $id ];
-
-			unset( $this->non_persistent_keys[ $index ] );
+			unset( $this->non_persistent_keys[ $id ] );
 		}
 
 		return wp_cache_delete( $this->get_id( $id, $expiration_trigger ), $group );
@@ -385,9 +381,7 @@ class Tribe__Cache implements ArrayAccess {
 	 * @return boolean Whether the offset exists in the cache.
 	 */
 	public function offsetExists( $offset ) {
-		$flipped = array_flip( $this->non_persistent_keys );
-
-		return isset( $flipped[ $offset ] );
+		return isset( $this->non_persistent_keys[ $offset ] );
 	}
 
 	/**

--- a/tests/wpunit/Tribe/CacheTest.php
+++ b/tests/wpunit/Tribe/CacheTest.php
@@ -60,6 +60,48 @@ class CacheTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * It should allow setting many different values using ArrayAccess API with long cache keys.
+	 *
+	 * @test
+	 */
+	public function it_should_allow_setting_many_different_values_using_array_access_api_with_long_cache_keys() {
+		$cache = $this->make_instance();
+
+		$expected = [
+			'foo1'  => '',
+			'foo2'  => '0',
+			'foo3'  => '-1',
+			'foo4'  => '100',
+			'foo5'  => 0,
+			'foo6'  => - 1,
+			'foo7'  => 100,
+			'foo8'  => [],
+			'foo9'  => 'false',
+			'foo10' => 'null',
+			'foo11' => false,
+			'foo12' => null,
+		];
+
+		foreach ( $expected as $key => $value ) {
+			// Attempt to add a longer cache key to trigger the md5() cache key logic.
+			$key .= __METHOD__ . '-' . $key;
+
+			$cache[ $key ] = $value;
+		}
+
+		foreach ( $expected as $key => $value ) {
+			// Attempt to add a longer cache key to trigger the md5() cache key logic.
+			$key .= __METHOD__ . '-' . $key;
+
+			// Any value set will always come back as 'set' because it exists in the non-persistent keys list.
+			$this->assertTrue( isset( $cache[ $key ] ) );
+
+			// The value will always match the type and value what we set.
+			$this->assertSame( $value, $cache[ $key ] );
+		}
+	}
+
+	/**
 	 * It should allow removing value using ArrayAccess API
 	 *
 	 * @test


### PR DESCRIPTION
[ET-1023]

This is a simple PR in it's intent: Ensure non-persistent keys get set to the non-md5'd key properly in the `set()` method so subsequent calls do not lead to the incorrect **persistent** cache group used.

The `isset()` logic for non-persistent keys has also been updated to reduce overhead and complexity.

This PR includes a new test that confirms this fix and provides checks for various values/types to confirm they work as *currently* expected.

[ET-1023]: https://theeventscalendar.atlassian.net/browse/ET-1023