### PR TITLE
Decode country names when localizing

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,14 +2,11 @@
 
 == Changelog ==
 
-= TBD =
-
-* Fix - Decode country picker names [TEC-3360]
-
 = [4.13.0] TBD =
 
 * Feature - JavaScript and Styles can be set to be printed as soon as enqueued, allowing usages like shortcodes to not have jumpy styles.
 * Fix - Makes sure Javascript extra data is loaded following WordPress architecture, respecting it's dependencies.
+* Fix - Decode country picker names [TEC-3360]
 * Tweak - Remove deprecated filter `tribe_events_{$asset->type}_version`
 
 = [4.12.18] 2021-02-24 =

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= TBD =
+
+* Fix - Decode country picker names [TEC-3360]
+
 = [4.13.0] TBD =
 
 * Feature - JavaScript and Styles can be set to be printed as soon as enqueued, allowing usages like shortcodes to not have jumpy styles.

--- a/src/Tribe/Editor/Configuration.php
+++ b/src/Tribe/Editor/Configuration.php
@@ -9,6 +9,18 @@
  */
 class Tribe__Editor__Configuration implements Tribe__Editor__Configuration_Interface {
 	/**
+	 * Convert HTML entities in country names to their corresponding characters 
+	 *
+	 * @param array $countries The array of countries
+	 * @return array
+	 */
+	public function decodeCountryNames( $countries ) {
+		return array_map( function( $country ) {
+			return html_entity_decode( $country, ENT_QUOTES );
+		}, $countries );
+	}
+	
+	/**
 	 * Localize variables that are part of common
 	 *
 	 * @since 4.8
@@ -36,7 +48,7 @@ class Tribe__Editor__Configuration implements Tribe__Editor__Configuration_Inter
 				'constants'    => [
 					'hideUpsell' => ( defined( 'TRIBE_HIDE_UPSELL' ) && TRIBE_HIDE_UPSELL ),
 				],
-				'countries'    => tribe( 'languages.locations' )->get_countries(),
+				'countries'    => $this->decodeCountryNames( tribe( 'languages.locations' )->get_countries() ),
 				'usStates'     => Tribe__View_Helpers::loadStates(),
 			],
 			'blocks' => [],

--- a/src/Tribe/Editor/Configuration.php
+++ b/src/Tribe/Editor/Configuration.php
@@ -10,21 +10,6 @@
 class Tribe__Editor__Configuration implements Tribe__Editor__Configuration_Interface {
 
 	/**
-	 * Convert HTML entities in country names to their corresponding characters.
-	 * 
-	 * @since TBD
-	 *
-	 * @param array $countries The list of countries.
-	 * 
-	 * @return array The list of countries.
-	 */
-	public function decodeCountryNames( $countries ) {
-		return array_map( function( $country ) {
-			return html_entity_decode( $country, ENT_QUOTES );
-		}, $countries );
-	}
-	
-	/**
 	 * Localize variables that are part of common
 	 *
 	 * @since 4.8
@@ -32,6 +17,10 @@ class Tribe__Editor__Configuration implements Tribe__Editor__Configuration_Inter
 	 * @return array
 	 */
 	public function localize() {
+		/**
+		 * @var Tribe__Languages__Locations $languages_locations
+		 */
+		$languages_locations = tribe( 'languages.locations' );
 		$editor_config = [
 			'common' => [
 				'adminUrl'     => admin_url(),
@@ -52,7 +41,7 @@ class Tribe__Editor__Configuration implements Tribe__Editor__Configuration_Inter
 				'constants'    => [
 					'hideUpsell' => ( defined( 'TRIBE_HIDE_UPSELL' ) && TRIBE_HIDE_UPSELL ),
 				],
-				'countries'    => $this->decodeCountryNames( tribe( 'languages.locations' )->get_countries() ),
+				'countries'    => $languages_locations->get_countries( true ),
 				'usStates'     => Tribe__View_Helpers::loadStates(),
 			],
 			'blocks' => [],

--- a/src/Tribe/Editor/Configuration.php
+++ b/src/Tribe/Editor/Configuration.php
@@ -8,11 +8,15 @@
  * @since 4.8
  */
 class Tribe__Editor__Configuration implements Tribe__Editor__Configuration_Interface {
+
 	/**
-	 * Convert HTML entities in country names to their corresponding characters 
+	 * Convert HTML entities in country names to their corresponding characters.
+	 * 
+	 * @since TBD
 	 *
-	 * @param array $countries The array of countries
-	 * @return array
+	 * @param array $countries The list of countries.
+	 * 
+	 * @return array The list of countries.
 	 */
 	public function decodeCountryNames( $countries ) {
 		return array_map( function( $country ) {

--- a/src/Tribe/Languages/Locations.php
+++ b/src/Tribe/Languages/Locations.php
@@ -16,14 +16,38 @@ class Tribe__Languages__Locations {
 	 *
 	 * Adds array to object cache to speed up subsequent retrievals.
 	 *
+	 * @since TBD add $escape param.
+	 *
+	 * @param bool $escape Weather to escape for translations or not.
+	 *
 	 * @return array {
 	 *      List of countries
 	 *
 	 *      @type string $country_code Country name.
 	 * }
 	 */
-	public function get_countries() {
-		return tribe( 'cache' )->get( 'tribe_country_list', '', [ $this, 'build_country_array' ] );
+	public function get_countries( $escape = false ) {
+		/**
+		 * @var Tribe__Cache $cache
+		 */
+		$cache     = tribe( 'cache' );
+		$cache_key = 'tribe_country_list' . ( $escape ? '-escaped' : '' );
+		$countries = $cache->get( $cache_key , '', null );
+
+		if ( null === $countries ) {
+			$countries = $this->build_country_array();
+
+			if ( $escape ) {
+				$countries = array_map( static function( $country ) {
+					return html_entity_decode( $country, ENT_QUOTES );
+				}, $countries );
+			}
+
+			// Actually set the cache in case it's not in place.
+			$cache->set( $cache_key, $countries );
+		}
+
+		return $countries;
 	}
 
 	/**


### PR DESCRIPTION
**Description:** Decodes the country names in the venue form so that they display correctly when having special characters.

**Ticket:** https://theeventscalendar.atlassian.net/browse/TEC-3360

**Screenshots:**

![Screen Shot 2021-03-01 at 3 11 07 PM](https://user-images.githubusercontent.com/5049893/109508795-85053880-7aa0-11eb-9a01-abf2f5de1835.png)
