### PR TITLE
Move Taxonomy file from TEC to common, as it will aid all plugins on shortcode

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -9,6 +9,7 @@
 * Fix - Decode country picker names [TEC-3360]
 * Tweak - Include a way for the context locations to be regenerated, with plenty of warnings about the risk [FBAR-36]
 * Tweak - Remove deprecated filter `tribe_events_{$asset->type}_version`
+* Tweak - Include Utils for dealing with Taxonomies with two methods, one for translating terms query into a repository arguments and another for translating shortcode arguments to term IDs. [ECP-728]
 
 = [4.12.19] 2021-03-02 =
 

--- a/src/Tribe/Utils/Taxonomy.php
+++ b/src/Tribe/Utils/Taxonomy.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tribe\Utils;
+
+/**
+ * Class Taxonomy.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Utils
+ */
+class Taxonomy {
+	/**
+	 * Match any operand.
+	 *
+	 * @since TBD
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const OPERAND_OR = 'OR';
+
+	/**
+	 * Match all operand.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const OPERAND_AND = 'AND';
+
+	/**
+	 * Default operand for taxonomy filters.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const DEFAULT_OPERAND = self::OPERAND_OR;
+
+	/**
+	 * Translates a given argument to repository arguments.
+	 *
+	 * @since TBD
+	 *
+	 * @param string       $taxonomy Which taxonomy we are using to setup.
+	 * @param string|array $terms    Which terms we are going to use here.
+	 * @param string       $operand  Which is the operand we should use.
+	 *
+	 * @return array A fully qualified `tax_query` array, merge using `array_merge_recursively`.
+	 */
+	public static function translate_to_repo( $taxonomy, $terms, $operand = self::OPERAND_OR ) {
+		$tax_query = [];
+		// Prevent empty values from even trying.
+		if ( empty( $taxonomy ) ) {
+			return $tax_query;
+		}
+
+		// Prevent empty values from even trying.
+		if ( empty( $terms ) ) {
+			return $tax_query;
+		}
+
+		$repo = tribe_events();
+
+		$operation = static::OPERAND_AND === $operand ? 'term_and' : 'term_in';
+
+		$repo->by( $operation, $taxonomy, $terms );
+
+		// This will only build the query not execute it.
+		$built_query = $repo->build_query();
+
+		if ( ! empty( $built_query->query_vars['tax_query'] ) ) {
+			$tax_query = $built_query->query_vars['tax_query'];
+		}
+
+		return $tax_query;
+	}
+
+	/**
+	 * Transform all Term IDs and Slugs into IDs of existing terms in a given taxonomy.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|int|array $terms Terms to be cleaned up.
+	 * @param string           $taxonomy Which taxonomy we are querying for.
+	 *
+	 * @return array List of IDs of terms.
+	 */
+	public static function sanitize_shortcode_terms_to_id( $terms, $taxonomy ) {
+		if ( empty( $terms ) ) {
+			return $terms;
+		}
+
+		$terms = array_map( static function ( $param ) use ( $taxonomy ) {
+			$param   = preg_replace( '/^#/', '', $param );
+			$term_by = is_numeric( $param ) ? 'ID' : 'slug';
+			$term    = get_term_by( $term_by, $param, $taxonomy );
+
+			if ( ! $term instanceof \WP_Term ) {
+				return false;
+			}
+
+			return $term->term_id;
+		}, (array) $terms );
+
+		$terms = array_filter( $terms );
+		$terms = array_unique( $terms );
+
+		return $terms;
+	}
+}

--- a/src/Tribe/Utils/Taxonomy.php
+++ b/src/Tribe/Utils/Taxonomy.php
@@ -49,7 +49,7 @@ class Taxonomy {
 	 *
 	 * @return array A fully qualified `tax_query` array, merge using `array_merge_recursively`.
 	 */
-	public static function translate_to_repo( $taxonomy, $terms, $operand = self::OPERAND_OR ) {
+	public static function translate_to_repository_args( $taxonomy, $terms, $operand = self::OPERAND_OR ) {
 		$tax_query = [];
 		// Prevent empty values from even trying.
 		if ( empty( $taxonomy ) ) {
@@ -87,7 +87,7 @@ class Taxonomy {
 	 *
 	 * @return array List of IDs of terms.
 	 */
-	public static function sanitize_shortcode_terms_to_id( $terms, $taxonomy ) {
+	public static function normalize_to_term_ids( $terms, $taxonomy ) {
 		if ( empty( $terms ) ) {
 			return $terms;
 		}

--- a/tests/wpunit/Tribe/Utils/TaxonomyTest.php
+++ b/tests/wpunit/Tribe/Utils/TaxonomyTest.php
@@ -30,23 +30,82 @@ class TaxonomyTest extends WPTestCase {
 		$term_5 = wp_insert_term( 'Event Category 2', 'category', [ 'slug' => 'event-category-2' ] );
 		$term_6 = wp_insert_term( 'Event Category 3', 'category', [ 'slug' => 'event-category-3' ] );
 
-		$tax_query = Taxonomy::translate_to_repo( 'category', [ $term_4->term_id, 'event-category-2', 'event-category-3' ] );
-		codecept_debug( $tax_query );
+		$tax_query = Taxonomy::translate_to_repo( 'category', [ $term_4['term_id'], 'event-category-2', 'event-category-3' ] );
+		$this->assertEquals(
+			[
+				'taxonomy' => 'category',
+				'field'    => 'term_id',
+				'terms'    => [ $term_4['term_id'], $term_5['term_id'], $term_6['term_id'], ],
+				'operator' => 'IN',
+			],
+			$tax_query['category_term_id_in']
+		);
 
-//		$this->assertEquals(
-//			[
-//				'tax_query' => [
-//					'' => [
-//						'taxonomy' => 'category',
-//						'field'    => 'term_id',
-//						'terms'    => $terms,
-//						'operator' => Taxonomy::OPERAND_OR,
-//					],
-//				],
-//			],
-//			$tax_query
-//		);
+		$tax_query = Taxonomy::translate_to_repo( 'post_tag', [ $term_1['term_id'], 'event-tag-2', 'event-tag-3' ] );
+		$this->assertEquals(
+			[
+				'taxonomy' => 'post_tag',
+				'field'    => 'term_id',
+				'terms'    => [ $term_1['term_id'], $term_2['term_id'], $term_3['term_id'], ],
+				'operator' => 'IN',
+			],
+			$tax_query['post_tag_term_id_in']
+		);
 
+		$tax_query = Taxonomy::translate_to_repo( 'category', [ $term_4['term_id'] ], Taxonomy::OPERAND_AND );
+		$this->assertEquals(
+			[
+				'taxonomy' => 'category',
+				'field'    => 'term_id',
+				'terms'    => [ $term_4['term_id'] ],
+				'operator' => 'AND',
+			],
+			$tax_query['category_term_id_and']
+		);
+
+		$tax_query = Taxonomy::translate_to_repo( 'category', [ 948192, 'non-existent-category-foo' ], Taxonomy::OPERAND_AND );
+		$this->assertEquals(
+			[
+				'taxonomy' => 'category',
+				'field'    => 'term_id',
+				'terms'    => [],
+				'operator' => 'AND',
+			],
+			$tax_query['category_term_id_and']
+		);
+
+	}
+
+	/**
+	 * @test
+	 * @group        utils
+	 */
+	public function it_should_sanitize_shortcode_terms_to_id() {
+		$term_1 = wp_insert_term( 'Event Tag 4', 'post_tag', [ 'slug' => 'event-tag-4' ] );
+		$term_2 = wp_insert_term( 'Event Tag 5', 'post_tag', [ 'slug' => 'event-tag-5' ] );
+		$term_3 = wp_insert_term( 'Event Tag 6', 'post_tag', [ 'slug' => 'event-tag-6' ] );
+
+		$term_4 = wp_insert_term( 'Event Category 4', 'category', [ 'slug' => 'event-category-4' ] );
+		$term_5 = wp_insert_term( 'Event Category 5', 'category', [ 'slug' => 'event-category-5' ] );
+		$term_6 = wp_insert_term( 'Event Category 6', 'category', [ 'slug' => 'event-category-6' ] );
+
+		$tax_query = Taxonomy::sanitize_shortcode_terms_to_id( [ $term_4['term_id'], 'event-category-5', 'event-category-6' ], 'category' );
+		$this->assertEquals(
+			[ $term_4['term_id'], $term_5['term_id'], $term_6['term_id'], ],
+			$tax_query
+		);
+
+		$tax_query = Taxonomy::sanitize_shortcode_terms_to_id( [ $term_1['term_id'], 'event-tag-5', 'event-tag-6' ], 'post_tag' );
+		$this->assertEquals(
+			[ $term_1['term_id'], $term_2['term_id'], $term_3['term_id'], ],
+			$tax_query
+		);
+
+		$tax_query = Taxonomy::sanitize_shortcode_terms_to_id( [ 948192, 'non-existent-category-foo' ], 'post_tag' );
+		$this->assertEquals(
+			[],
+			$tax_query
+		);
 	}
 
 }

--- a/tests/wpunit/Tribe/Utils/TaxonomyTest.php
+++ b/tests/wpunit/Tribe/Utils/TaxonomyTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tribe\Utils;
+
+use Codeception\TestCase\WPTestCase;
+
+class TaxonomyTest extends WPTestCase {
+
+
+	/**
+	 * @test
+	 *
+	 * @group utils
+	 */
+	public function it_should_be_instantiatable() {
+		$tax = new Taxonomy;
+		$this->assertInstanceOf( Taxonomy::class, $tax );
+	}
+
+	/**
+	 * @test
+	 * @group        utils
+	 */
+	public function it_should_translate_terms_to_tax_query() {
+		$term_1 = wp_insert_term( 'Event Tag 1', 'post_tag', [ 'slug' => 'event-tag-1' ] );
+		$term_2 = wp_insert_term( 'Event Tag 2', 'post_tag', [ 'slug' => 'event-tag-2' ] );
+		$term_3 = wp_insert_term( 'Event Tag 3', 'post_tag', [ 'slug' => 'event-tag-3' ] );
+
+		$term_4 = wp_insert_term( 'Event Category 1', 'category', [ 'slug' => 'event-category-1' ] );
+		$term_5 = wp_insert_term( 'Event Category 2', 'category', [ 'slug' => 'event-category-2' ] );
+		$term_6 = wp_insert_term( 'Event Category 3', 'category', [ 'slug' => 'event-category-3' ] );
+
+		$tax_query = Taxonomy::translate_to_repo( 'category', [ $term_4->term_id, 'event-category-2', 'event-category-3' ] );
+		codecept_debug( $tax_query );
+
+//		$this->assertEquals(
+//			[
+//				'tax_query' => [
+//					'' => [
+//						'taxonomy' => 'category',
+//						'field'    => 'term_id',
+//						'terms'    => $terms,
+//						'operator' => Taxonomy::OPERAND_OR,
+//					],
+//				],
+//			],
+//			$tax_query
+//		);
+
+	}
+
+}

--- a/tests/wpunit/Tribe/Utils/TaxonomyTest.php
+++ b/tests/wpunit/Tribe/Utils/TaxonomyTest.php
@@ -30,7 +30,7 @@ class TaxonomyTest extends WPTestCase {
 		$term_5 = wp_insert_term( 'Event Category 2', 'category', [ 'slug' => 'event-category-2' ] );
 		$term_6 = wp_insert_term( 'Event Category 3', 'category', [ 'slug' => 'event-category-3' ] );
 
-		$tax_query = Taxonomy::translate_to_repo( 'category', [ $term_4['term_id'], 'event-category-2', 'event-category-3' ] );
+		$tax_query = Taxonomy::translate_to_repository_args( 'category', [ $term_4['term_id'], 'event-category-2', 'event-category-3' ] );
 		$this->assertEquals(
 			[
 				'taxonomy' => 'category',
@@ -41,7 +41,7 @@ class TaxonomyTest extends WPTestCase {
 			$tax_query['category_term_id_in']
 		);
 
-		$tax_query = Taxonomy::translate_to_repo( 'post_tag', [ $term_1['term_id'], 'event-tag-2', 'event-tag-3' ] );
+		$tax_query = Taxonomy::translate_to_repository_args( 'post_tag', [ $term_1['term_id'], 'event-tag-2', 'event-tag-3' ] );
 		$this->assertEquals(
 			[
 				'taxonomy' => 'post_tag',
@@ -52,7 +52,7 @@ class TaxonomyTest extends WPTestCase {
 			$tax_query['post_tag_term_id_in']
 		);
 
-		$tax_query = Taxonomy::translate_to_repo( 'category', [ $term_4['term_id'] ], Taxonomy::OPERAND_AND );
+		$tax_query = Taxonomy::translate_to_repository_args( 'category', [ $term_4['term_id'] ], Taxonomy::OPERAND_AND );
 		$this->assertEquals(
 			[
 				'taxonomy' => 'category',
@@ -63,7 +63,7 @@ class TaxonomyTest extends WPTestCase {
 			$tax_query['category_term_id_and']
 		);
 
-		$tax_query = Taxonomy::translate_to_repo( 'category', [ 948192, 'non-existent-category-foo' ], Taxonomy::OPERAND_AND );
+		$tax_query = Taxonomy::translate_to_repository_args( 'category', [ 948192, 'non-existent-category-foo' ], Taxonomy::OPERAND_AND );
 		$this->assertEquals(
 			[
 				'taxonomy' => 'category',
@@ -80,7 +80,7 @@ class TaxonomyTest extends WPTestCase {
 	 * @test
 	 * @group        utils
 	 */
-	public function it_should_sanitize_shortcode_terms_to_id() {
+	public function it_should_normalize_to_term_ids() {
 		$term_1 = wp_insert_term( 'Event Tag 4', 'post_tag', [ 'slug' => 'event-tag-4' ] );
 		$term_2 = wp_insert_term( 'Event Tag 5', 'post_tag', [ 'slug' => 'event-tag-5' ] );
 		$term_3 = wp_insert_term( 'Event Tag 6', 'post_tag', [ 'slug' => 'event-tag-6' ] );
@@ -89,19 +89,19 @@ class TaxonomyTest extends WPTestCase {
 		$term_5 = wp_insert_term( 'Event Category 5', 'category', [ 'slug' => 'event-category-5' ] );
 		$term_6 = wp_insert_term( 'Event Category 6', 'category', [ 'slug' => 'event-category-6' ] );
 
-		$tax_query = Taxonomy::sanitize_shortcode_terms_to_id( [ $term_4['term_id'], 'event-category-5', 'event-category-6' ], 'category' );
+		$tax_query = Taxonomy::normalize_to_term_ids( [ $term_4['term_id'], 'event-category-5', 'event-category-6' ], 'category' );
 		$this->assertEquals(
 			[ $term_4['term_id'], $term_5['term_id'], $term_6['term_id'], ],
 			$tax_query
 		);
 
-		$tax_query = Taxonomy::sanitize_shortcode_terms_to_id( [ $term_1['term_id'], 'event-tag-5', 'event-tag-6' ], 'post_tag' );
+		$tax_query = Taxonomy::normalize_to_term_ids( [ $term_1['term_id'], 'event-tag-5', 'event-tag-6' ], 'post_tag' );
 		$this->assertEquals(
 			[ $term_1['term_id'], $term_2['term_id'], $term_3['term_id'], ],
 			$tax_query
 		);
 
-		$tax_query = Taxonomy::sanitize_shortcode_terms_to_id( [ 948192, 'non-existent-category-foo' ], 'post_tag' );
+		$tax_query = Taxonomy::normalize_to_term_ids( [ 948192, 'non-existent-category-foo' ], 'post_tag' );
 		$this->assertEquals(
 			[],
 			$tax_query


### PR DESCRIPTION
🎫 [ECP-728]
---
All shortcodes should now be using the new system in V2, allows much more flexibility when passing params and validating them. 

[ECP-728]: https://theeventscalendar.atlassian.net/browse/ECP-728