### PR TITLE
[TEC-3833] Remove setup call in Widget Abstract class

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,10 @@
 
 == Changelog ==
 
+= [TBD] 2021-04-05 =
+
+* Fix - Reduce overhead of widget setup on every page load by setting up the widgets only as needed. [TEC-3833]
+
 = [4.13.0] 2021-03-29 =
 
 * Feature - JavaScript and Styles can be set to be printed as soon as enqueued, allowing usages like shortcodes to not have jumpy styles.

--- a/src/Tribe/Widget/Widget_Abstract.php
+++ b/src/Tribe/Widget/Widget_Abstract.php
@@ -134,8 +134,6 @@ abstract class Widget_Abstract extends \WP_Widget implements Widget_Interface {
 			$this->parse_widget_options( $widget_options ),
 			$this->parse_control_options( $control_options )
 		);
-
-		$this->setup();
 	}
 
 	/**


### PR DESCRIPTION
[TEC-3833]

setup() will get called when the widget is needed via form() / widget() already. Calling it when defining the widgets with WP (via init >> widgets_init) is too early and happens on every single page load so it adds unnecessary overhead to each page request. Plus it's so early (pre init p10) that it causes compatibility issues elsewhere.

@bordoni This needs a release branch

[TEC-3833]: https://theeventscalendar.atlassian.net/browse/TEC-3833