### PR TITLE
Add visual notice for number inputs that are out of range.

### DIFF
--- a/src/resources/postcss/tribe-common-admin.pcss
+++ b/src/resources/postcss/tribe-common-admin.pcss
@@ -1,6 +1,7 @@
 /* = Shared CSS Elements
 =============================================*/
-.invalid input {
+.invalid input,
+input:out-of-range {
 	border: 2px solid red !important;
 }
 


### PR DESCRIPTION
We can't prevent them from trying to manually put in a number too large, but we can tell them they did

https://d.pr/i/RQAy9x

[ECP-579]

[ECP-579]: https://theeventscalendar.atlassian.net/browse/ECP-579