### PR TITLE
Help  PHPStorm to resolve types from the container

### DIFF
--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,7 +1,7 @@
 <?php
 
 namespace PHPSTORM_META {
-	// Allow PHP Storm Editor to resolve return types when calling tribe( Object_Type::class ) or tribe( `Object_type` )
+	// Allow PhpStorm IDE to resolve return types when calling tribe( Object_Type::class ) or tribe( `Object_Type` )
 	override(
 		\tribe( 0 ),
 		map( [

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace PHPSTORM_META {
+	// Allow PHP Storm Editor to resolve return types when calling tribe( Object_Type::class ) or tribe( `Object_type` )
+	override(
+		\tribe( 0 ),
+		map( [
+			'' => '@',
+			'' => '@Class',
+		] )
+	);
+}

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -3,40 +3,51 @@
 namespace PHPSTORM_META {
 
 	// Allow PhpStorm IDE to resolve return types when calling tribe( Object_Type::class ) or tribe( `Object_Type` )
-
-
 	override(
 		\tribe(),
 		map( [
 			// Custom Alias with global namespace.
-			'promoter.auth'                   => \Tribe__Promoter__Auth::class,
-			'promoter.pue'                    => \Tribe__Promoter__PUE::class,
-			'promoter.view'                   => \Tribe__Promoter__View::class,
-			'feature-detection'               => \Tribe__Feature_Detection::class,
-			'settings.manager'                => \Tribe__Settings_Manager::class,
-			'settings'                        => \Tribe__Settings::class,
-			'ajax.dropdown'                   => \Tribe__Ajax__Dropdown::class,
-			'asssassets'                      => \Tribe__Assets::class,
-			'assets.pipeline'                 => \Tribe__Assets_Pipeline::class,
-			'asset.data'                      => \Tribe__Asset__Data::class,
-			'admin.helpers'                   => \Tribe__Admin__Helpers::class,
-			'tracker'                         => \Tribe__Tracker::class,
-			'chunker'                         => \Tribe__Meta__Chunker::class,
-			'cache'                           => \Tribe__Cache::class,
-			'languages.locations'             => \Tribe__Languages__Locations::class,
-			'plugins.api'                     => \Tribe__Plugins_API::class,
-			'logger'                          => \Tribe__Log::class,
-			'cost-utils'                      => \Tribe__Cost_Utils::class,
-			'post-duplicate.strategy-factory' => \Tribe__Duplicate__Strategy_Factory::class,
-			'post-duplicate'                  => \Tribe__Duplicate__Post::class,
-			'context'                         => \Tribe__Context::class,
+			'promoter.auth'                         => \Tribe__Promoter__Auth::class,
+			'promoter.pue'                          => \Tribe__Promoter__PUE::class,
+			'promoter.view'                         => \Tribe__Promoter__View::class,
+			'promoter.connector'                    => \Tribe__Promoter__Connector::class,
+			'feature-detection'                     => \Tribe__Feature_Detection::class,
+			'settings.manager'                      => \Tribe__Settings_Manager::class,
+			'settings'                              => \Tribe__Settings::class,
+			'ajax.dropdown'                         => \Tribe__Ajax__Dropdown::class,
+			'asssassets'                            => \Tribe__Assets::class,
+			'assets.pipeline'                       => \Tribe__Assets_Pipeline::class,
+			'asset.data'                            => \Tribe__Asset__Data::class,
+			'admin.helpers'                         => \Tribe__Admin__Helpers::class,
+			'tracker'                               => \Tribe__Tracker::class,
+			'chunker'                               => \Tribe__Meta__Chunker::class,
+			'cache'                                 => \Tribe__Cache::class,
+			'languages.locations'                   => \Tribe__Languages__Locations::class,
+			'plugins.api'                           => \Tribe__Plugins_API::class,
+			'logger'                                => \Tribe__Log::class,
+			'cost-utils'                            => \Tribe__Cost_Utils::class,
+			'post-duplicate.strategy-factory'       => \Tribe__Duplicate__Strategy_Factory::class,
+			'post-duplicate'                        => \Tribe__Duplicate__Post::class,
+			'context'                               => \Tribe__Context::class,
+			'post-transient'                        => \Tribe__Post_Transient::class,
+			'db'                                    => \Tribe__Db::class,
+			'freemius'                              => \Tribe__Freemius::class,
+			'customizer'                            => \Tribe__Customizer::class,
+			'callback'                              => \Tribe__Utils__Callback::class,
+			'pue.notices'                           => \Tribe__PUE__Notices::class,
+			'admin.notice.php.version'              => \Tribe__Admin__Notice__Php_Version::class,
+			'admin.notice.marketing'                => \Tribe__Admin__Notice__Marketing::class,
 
 			// Custom alias with tribe namespace.
-			'tooltip.view'                    => \Tribe\Tooltip\View::class,
+			'tooltip.view'                          => \Tribe\Tooltip\View::class,
+			'db-lock'                               => \Tribe\DB_Lock::class,
+			'common.service_providers.body_classes' => \Tribe\Utils\Body_Classes::class,
+			'dialog.view'                           => \Tribe\Dialog\View::class,
+			'monolog'                               => \Tribe\Log\Monolog_Logger::class,
 
 			// Global to match the class name or using the full qualified file name as the class.
-			''                                => '@',
-			''                                => '@Class',
+			''                                      => '@',
+			''                                      => '@class',
 		] )
 	);
 }

--- a/.phpstorm.meta.php
+++ b/.phpstorm.meta.php
@@ -1,12 +1,42 @@
 <?php
 
 namespace PHPSTORM_META {
+
 	// Allow PhpStorm IDE to resolve return types when calling tribe( Object_Type::class ) or tribe( `Object_Type` )
+
+
 	override(
-		\tribe( 0 ),
+		\tribe(),
 		map( [
-			'' => '@',
-			'' => '@Class',
+			// Custom Alias with global namespace.
+			'promoter.auth'                   => \Tribe__Promoter__Auth::class,
+			'promoter.pue'                    => \Tribe__Promoter__PUE::class,
+			'promoter.view'                   => \Tribe__Promoter__View::class,
+			'feature-detection'               => \Tribe__Feature_Detection::class,
+			'settings.manager'                => \Tribe__Settings_Manager::class,
+			'settings'                        => \Tribe__Settings::class,
+			'ajax.dropdown'                   => \Tribe__Ajax__Dropdown::class,
+			'asssassets'                      => \Tribe__Assets::class,
+			'assets.pipeline'                 => \Tribe__Assets_Pipeline::class,
+			'asset.data'                      => \Tribe__Asset__Data::class,
+			'admin.helpers'                   => \Tribe__Admin__Helpers::class,
+			'tracker'                         => \Tribe__Tracker::class,
+			'chunker'                         => \Tribe__Meta__Chunker::class,
+			'cache'                           => \Tribe__Cache::class,
+			'languages.locations'             => \Tribe__Languages__Locations::class,
+			'plugins.api'                     => \Tribe__Plugins_API::class,
+			'logger'                          => \Tribe__Log::class,
+			'cost-utils'                      => \Tribe__Cost_Utils::class,
+			'post-duplicate.strategy-factory' => \Tribe__Duplicate__Strategy_Factory::class,
+			'post-duplicate'                  => \Tribe__Duplicate__Post::class,
+			'context'                         => \Tribe__Context::class,
+
+			// Custom alias with tribe namespace.
+			'tooltip.view'                    => \Tribe\Tooltip\View::class,
+
+			// Global to match the class name or using the full qualified file name as the class.
+			''                                => '@',
+			''                                => '@Class',
 		] )
 	);
 }


### PR DESCRIPTION
Allow PHPStorm Editor to resolve the different types when using the
container to get an instance to an object, this works only when the
container is called with a string that is either the full quailified
class of the object or when the name is used on the container such as:

```php
tribe( Object_Type::class )->resolves_names_of_method_or_properties();
tribe( 'Object_Type' )->resolves_names_of_method_or_properties();
```