### PR TITLE
ECP-737: ECP > Conflict with Avada

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 
 = [4.13.3] TBD =
 
-
+* Fix - Compatibility with Avada themes and third party plugins or themes loading `selectWoo` at the same time. [ECP-737]
 
 = [4.13.2] 2021-04-29 =
 

--- a/vendor/tribe-selectWoo/dist/js/select2.full.js
+++ b/vendor/tribe-selectWoo/dist/js/select2.full.js
@@ -6506,11 +6506,11 @@ S2.define('jquery.select2',[
   './select2/core',
   './select2/defaults'
 ], function ($, _, Select2, Defaults) {
-  if ($.fn.selectWoo == null) {
+  if ($.fn.select2TEC == null) {
     // All methods that should return the element
     var thisMethods = ['open', 'close', 'destroy'];
 
-    $.fn.selectWoo = function (options) {
+    $.fn.select2TEC = function (options) {
       options = options || {};
 
       if (typeof options === 'object') {
@@ -6551,15 +6551,15 @@ S2.define('jquery.select2',[
   }
 
   if ($.fn.select2 != null && $.fn.select2.defaults != null) {
-    $.fn.selectWoo.defaults = $.fn.select2.defaults;
+    $.fn.select2TEC.defaults = $.fn.select2.defaults;
   }
 
-  if ($.fn.selectWoo.defaults == null) {
-    $.fn.selectWoo.defaults = Defaults;
+  if ($.fn.select2TEC.defaults == null) {
+    $.fn.select2TEC.defaults = Defaults;
   }
 
-  // Also register selectWoo under select2 if select2 is not already present.
-  $.fn.select2 = $.fn.select2 || $.fn.selectWoo;
+  // Also register select2TEC under select2 if select2 is not already present.
+  $.fn.select2 = $.fn.select2 || $.fn.select2TEC;
 
   return Select2;
 });
@@ -6579,7 +6579,7 @@ S2.define('jquery.select2',[
   // This allows Select2 to use the internal loader outside of this file, such
   // as in the language files.
   jQuery.fn.select2.amd = S2;
-  jQuery.fn.selectWoo.amd = S2;
+  jQuery.fn.select2TEC.amd = S2;
 
   // Return the Select2 instance for anyone who is importing it.
   return select2;

--- a/vendor/tribe-selectWoo/dist/js/select2.js
+++ b/vendor/tribe-selectWoo/dist/js/select2.js
@@ -5795,11 +5795,11 @@ S2.define('jquery.select2',[
   './select2/core',
   './select2/defaults'
 ], function ($, _, Select2, Defaults) {
-  if ($.fn.selectWoo == null) {
+  if ($.fn.select2TEC == null) {
     // All methods that should return the element
     var thisMethods = ['open', 'close', 'destroy'];
 
-    $.fn.selectWoo = function (options) {
+    $.fn.select2TEC = function (options) {
       options = options || {};
 
       if (typeof options === 'object') {
@@ -5840,15 +5840,15 @@ S2.define('jquery.select2',[
   }
 
   if ($.fn.select2 != null && $.fn.select2.defaults != null) {
-    $.fn.selectWoo.defaults = $.fn.select2.defaults;
+    $.fn.select2TEC.defaults = $.fn.select2.defaults;
   }
 
-  if ($.fn.selectWoo.defaults == null) {
-    $.fn.selectWoo.defaults = Defaults;
+  if ($.fn.select2TEC.defaults == null) {
+    $.fn.select2TEC.defaults = Defaults;
   }
 
-  // Also register selectWoo under select2 if select2 is not already present.
-  $.fn.select2 = $.fn.select2 || $.fn.selectWoo;
+  // Also register select2TEC under select2 if select2 is not already present.
+  $.fn.select2 = $.fn.select2 || $.fn.select2TEC;
 
   return Select2;
 });
@@ -5868,7 +5868,7 @@ S2.define('jquery.select2',[
   // This allows Select2 to use the internal loader outside of this file, such
   // as in the language files.
   jQuery.fn.select2.amd = S2;
-  jQuery.fn.selectWoo.amd = S2;
+  jQuery.fn.select2TEC.amd = S2;
 
   // Return the Select2 instance for anyone who is importing it.
   return select2;

--- a/vendor/tribe-selectWoo/dist/js/selectWoo.full.js
+++ b/vendor/tribe-selectWoo/dist/js/selectWoo.full.js
@@ -6510,11 +6510,11 @@ S2.define('jquery.select2',[
   './select2/core',
   './select2/defaults'
 ], function ($, _, Select2, Defaults) {
-  if ($.fn.selectWoo == null) {
+  if ($.fn.select2TEC == null) {
     // All methods that should return the element
     var thisMethods = ['open', 'close', 'destroy'];
 
-    $.fn.selectWoo = function (options) {
+    $.fn.select2TEC = function (options) {
       options = options || {};
 
       if (typeof options === 'object') {
@@ -6555,15 +6555,15 @@ S2.define('jquery.select2',[
   }
 
   if ($.fn.select2 != null && $.fn.select2.defaults != null) {
-    $.fn.selectWoo.defaults = $.fn.select2.defaults;
+    $.fn.select2TEC.defaults = $.fn.select2.defaults;
   }
 
-  if ($.fn.selectWoo.defaults == null) {
-    $.fn.selectWoo.defaults = Defaults;
+  if ($.fn.select2TEC.defaults == null) {
+    $.fn.select2TEC.defaults = Defaults;
   }
 
   // Also register selectWoo under select2 if select2 is not already present.
-  $.fn.select2 = $.fn.select2 || $.fn.selectWoo;
+  $.fn.select2 = $.fn.select2 || $.fn.select2TEC;
 
   return Select2;
 });
@@ -6583,7 +6583,7 @@ S2.define('jquery.select2',[
   // This allows Select2 to use the internal loader outside of this file, such
   // as in the language files.
   jQuery.fn.select2.amd = S2;
-  jQuery.fn.selectWoo.amd = S2;
+  jQuery.fn.select2TEC.amd = S2;
 
   // Return the Select2 instance for anyone who is importing it.
   return select2;

--- a/vendor/tribe-selectWoo/dist/js/selectWoo.js
+++ b/vendor/tribe-selectWoo/dist/js/selectWoo.js
@@ -5799,11 +5799,11 @@ S2.define('jquery.select2',[
   './select2/core',
   './select2/defaults'
 ], function ($, _, Select2, Defaults) {
-  if ($.fn.selectWoo == null) {
+  if ($.fn.select2TEC == null) {
     // All methods that should return the element
     var thisMethods = ['open', 'close', 'destroy'];
 
-    $.fn.selectWoo = function (options) {
+    $.fn.select2TEC = function (options) {
       options = options || {};
 
       if (typeof options === 'object') {
@@ -5844,15 +5844,15 @@ S2.define('jquery.select2',[
   }
 
   if ($.fn.select2 != null && $.fn.select2.defaults != null) {
-    $.fn.selectWoo.defaults = $.fn.select2.defaults;
+    $.fn.select2TEC.defaults = $.fn.select2.defaults;
   }
 
-  if ($.fn.selectWoo.defaults == null) {
-    $.fn.selectWoo.defaults = Defaults;
+  if ($.fn.select2TEC.defaults == null) {
+    $.fn.select2TEC.defaults = Defaults;
   }
 
-  // Also register selectWoo under select2 if select2 is not already present.
-  $.fn.select2 = $.fn.select2 || $.fn.selectWoo;
+  // Also register select2TEC under select2 if select2 is not already present.
+  $.fn.select2 = $.fn.select2 || $.fn.select2TEC;
 
   return Select2;
 });
@@ -5872,7 +5872,7 @@ S2.define('jquery.select2',[
   // This allows Select2 to use the internal loader outside of this file, such
   // as in the language files.
   jQuery.fn.select2.amd = S2;
-  jQuery.fn.selectWoo.amd = S2;
+  jQuery.fn.select2TEC.amd = S2;
 
   // Return the Select2 instance for anyone who is importing it.
   return select2;


### PR DESCRIPTION
Prevent to deal with conflicts when `selectWoo` is rendered and used
along side another plugins that uses `selectWoo` with
different versions.

Instead all the `selectWoo` references are replaced with the
existing `select2TEC`

Artifact: https://d.pr/v/nfjMNu
Ticket: [ECP-737]

[ECP-737]: https://theeventscalendar.atlassian.net/browse/ECP-737