### PR TITLE
TCMN-107: Display `draft` posts as part of the events

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -8,6 +8,7 @@
 * Fix - Compatibility with Avada themes and third party plugins or themes loading `selectWoo` at the same time. [ECP-737]
 * Tweak - Adjust the actions used to register and load the styles for the tooltip component [TEC-3796]
 * Tweak - Update lodash to 4.17.21. [TEC-3885]
+* Tweak - Display draft events if the current user is able to read private posts [TCMN-107]
 
 = [4.13.2] 2021-04-29 =
 

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -3120,6 +3120,7 @@ abstract class Tribe__Repository
 		$default_post_status = [ 'publish' ];
 		if ( current_user_can( 'read_private_posts' ) ) {
 			$default_post_status[] = 'private';
+			$default_post_status[] = 'draft';
 		}
 
 		$query_args['post_status'] = Tribe__Utils__Array::get( $query_args, 'post_status', $default_post_status );


### PR DESCRIPTION
The events are displayed only if the user is able to `read_private_posts`.

Ticket: TCMN-107

This would display all draft events to the current user only if the
user is able to `read_private_posts`.

Artifact: https://d.pr/v/zO4CH9