### PR TITLE
Revert "TCMN-107: Display `draft` posts as part of the events"

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,6 @@
 * Fix - Compatibility with Avada themes and third party plugins or themes loading `selectWoo` at the same time. [ECP-737]
 * Tweak - Adjust the actions used to register and load the styles for the tooltip component [TEC-3796]
 * Tweak - Update lodash to 4.17.21. [TEC-3885]
-* Tweak - Display draft events if the current user is able to read private posts [TCMN-107]
 * Language - 0 new strings added, 2 updated, 1 fuzzied, and 0 obsoleted
 
 = [4.13.2] 2021-04-29 =

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -3120,7 +3120,6 @@ abstract class Tribe__Repository
 		$default_post_status = [ 'publish' ];
 		if ( current_user_can( 'read_private_posts' ) ) {
 			$default_post_status[] = 'private';
-			$default_post_status[] = 'draft';
 		}
 
 		$query_args['post_status'] = Tribe__Utils__Array::get( $query_args, 'post_status', $default_post_status );


### PR DESCRIPTION
This reverts commit bf411aceafd8cb2a4f342df1e396f893899cd839.

Ticket: TCMN-107