### PR TITLE
Make sure cache is retrived correctly

### DIFF
--- a/src/Tribe/Cache.php
+++ b/src/Tribe/Cache.php
@@ -564,7 +564,7 @@ class Tribe__Cache implements ArrayAccess {
 		} while ( ! empty( $chunk ) );
 
 		// Remove any piece of data that was added but is not relevant.
-		$chunks = array_filter($chunks);
+		$chunks = array_filter( $chunks );
 
 		if ( empty( $chunks ) ) {
 			return false;

--- a/src/Tribe/Cache.php
+++ b/src/Tribe/Cache.php
@@ -556,14 +556,17 @@ class Tribe__Cache implements ArrayAccess {
 		}
 
 		$chunks = [];
-		$i      = 1;
+		$i      = 0;
 		do {
 			$chunk_transient            = $transient . '_' . $i++;
 			$chunk                      = get_transient( $chunk_transient );
 			$chunks[ $chunk_transient ] = (string) $chunk;
 		} while ( ! empty( $chunk ) );
 
-		if ( empty( array_filter( $chunks ) ) ) {
+		// Remove any piece of data that was added but is not relevant.
+		$chunks = array_filter($chunks);
+
+		if ( empty( $chunks ) ) {
 			return false;
 		}
 
@@ -571,12 +574,13 @@ class Tribe__Cache implements ArrayAccess {
 			$data          = implode( '', $chunks );
 			$is_serialized = preg_match( '/^[aO]:\\d+:/', $data );
 			$unserialized  = maybe_unserialize( implode( '', $chunks ) );
+
 			if ( is_string( $unserialized ) && $unserialized === $data && $is_serialized ) {
 				// Something was messed up.
 				return false;
 			}
 
-			return true;
+			return $unserialized;
 		} catch ( Exception $e ) {
 			return false;
 		}


### PR DESCRIPTION
Make sure the pieces from the cache start at `0` as all the index start
on that number we need to make sure we get the first element in this
case the element with index `zero` from there we build the subsequent
pieces.

Then the function if was able to build the elements out of the cache it
should return the values from the cache instead of returning `true`.

As the caller to the `chunkable_transient` should build the results out
of the cache.

Requires: https://github.com/the-events-calendar/tribe-common/pull/1606