### PR TITLE
[CE-97] Fix ampersands displaying encoded

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,7 @@
 == Changelog ==
 
+* Fix - Updated dropdowns controlled via ajax to return unescaped html entities instead of the escaped version. [CE-97]
+
 = [4.14.0] 2021-07-01 =
 
 * Feature - Add new custom Customizer controls.

--- a/src/Tribe/Ajax/Dropdown.php
+++ b/src/Tribe/Ajax/Dropdown.php
@@ -88,6 +88,10 @@ class Tribe__Ajax__Dropdown {
 			}
 		}
 
+		foreach ( $results as $result ) {
+			$result->text = htmlspecialchars_decode( $result->text );
+		}
+
 		$data['results']    = $results;
 		$data['taxonomies'] = get_taxonomies();
 

--- a/src/Tribe/Ajax/Dropdown.php
+++ b/src/Tribe/Ajax/Dropdown.php
@@ -89,7 +89,7 @@ class Tribe__Ajax__Dropdown {
 		}
 
 		foreach ( $results as $result ) {
-			$result->text = htmlspecialchars_decode( $result->text );
+			$result->text = wp_kses_post( htmlspecialchars_decode( $result->text ) );
 		}
 
 		$data['results']    = $results;


### PR DESCRIPTION
[CE-97]

Ampersands were displaying encoded. This change displays them properly for all drop-downs that gather the data via Ajax. The change was made because of a bug reported in CE. If you had any categories or tags with an ampersand they would display escaped.

![image](https://user-images.githubusercontent.com/12241059/125508185-74a90624-dd3f-49a5-828d-241a4eb37cde.png)

![image](https://user-images.githubusercontent.com/12241059/125508475-d38b51e3-7e71-41ae-be3b-fbd15be4069d.png)



[CE-97]: https://theeventscalendar.atlassian.net/browse/CE-97