### PR TITLE
Fix block editor time utility function

### DIFF
--- a/src/modules/utils/time.js
+++ b/src/modules/utils/time.js
@@ -76,10 +76,10 @@ export const formatTime = ( time, format ) => {
 	const sss = zeroFill( 3, time.miliseconds );
 
 	let formattedTime = time.negative ? '-' : '';
-	formattedTime += showHr ? hh : '';
+	formattedTime += showHr ? `${ hh }:` : '';
 	formattedTime += mm;
-	formattedTime += showSc ? ss : '';
-	formattedTime += showMs ? sss : '';
+	formattedTime += showSc ? `:${ ss }` : '';
+	formattedTime += showMs ? `.${ sss }` : '';
 
 	return formattedTime;
 };


### PR DESCRIPTION
**Ticket:** N/A

Fixed broken formatting for time utility in block editor introduced when fixing lint issues.

**Artifact:** 

Before:
![image](https://user-images.githubusercontent.com/16699941/128077494-2e7e7c91-ed2b-417a-918a-96495566b463.png)

After:
![image](https://user-images.githubusercontent.com/16699941/128077455-5916611e-b816-4f3e-8d66-811938d85a7c.png)
