### PR TITLE
Fix issue of time selector for recurring rules not working for the block editor. [ECP-918]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 
 = [TBD] TBD =
 
-* Fix - Fix issue of time selector for recurring rules not working for the block editor. [ECP-918]
 * Feature - Redesign In-App help and troubleshooting pages. [TEC-3741]
+* Fix - Fix issue of time selector for recurring rules not working for the block editor. [ECP-918]
 * Fix - Ensure that $wp_query->is_search is false for calendar views that have no search term. [TEC-4012]
 * Fix - Fix issue of month names not being translatable. This was caused by a missing moment js localization dependency. [ECP-739]
 * Tweak - Change label of API Settings tab to "Integrations". [TEC_4015]

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 
 = [TBD] TBD =
 
+* Fix - Fix issue of time selector for recurring rules not working for the block editor. [ECP-918]
 * Feature - Redesign In-App help and troubleshooting pages. [TEC-3741]
 * Fix - Ensure that $wp_query->is_search is false for calendar views that have no search term. [TEC-4012]
 * Fix - Fix issue of month names not being translatable. This was caused by a missing moment js localization dependency. [ECP-739]


### PR DESCRIPTION
Ticket: https://theeventscalendar.atlassian.net/secure/RapidBoard.jspa?rapidView=163&projectKey=BTPLAN&modal=detail&selectedIssue=ECP-918&assignee=5feb71d1332c3a0107acdab7

This fix for this issue was merged into release/B21.danish through this PR: https://github.com/the-events-calendar/tribe-common/pull/1627