### PR TITLE
Don't use wp-editor as a dependency on non-post block editor pages.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -7,6 +7,7 @@
 * Fix - Ensure that $wp_query->is_search is false for calendar views that have no search term. [TEC-4012]
 * Fix - Fix issue of month names not being translatable. This was caused by a missing moment js localization dependency. [ECP-739]
 * Fix - Ensure that block editor scripts don't enqueue wp-editor on non-post block editor pages (widgets) [TEC-4028]
+* Tweak - Alter Assets->register and tribe_asset() to accept a callable for assets. [TEC-4028]
 * Tweak - Change label of API Settings tab to "Integrations". [TEC_4015]
 
 = [4.14.1] 2021-07-21 =

--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@
 * Fix - Fix issue of time selector for recurring rules not working for the block editor. [ECP-918]
 * Fix - Ensure that $wp_query->is_search is false for calendar views that have no search term. [TEC-4012]
 * Fix - Fix issue of month names not being translatable. This was caused by a missing moment js localization dependency. [ECP-739]
+* Fix - Ensure that block editor scripts don't enqueue wp-editor on non-post block editor pages (widgets) [TEC-4028]
 * Tweak - Change label of API Settings tab to "Integrations". [TEC_4015]
 
 = [4.14.1] 2021-07-21 =

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -159,6 +159,7 @@ class Tribe__Assets {
 	 * Register the Assets on the correct hooks.
 	 *
 	 * @since 4.3
+	 * @param array|object|null $assets Array of asset objects, single asset object, or null.
 	 *
 	 * @return void
 	 */
@@ -183,7 +184,15 @@ class Tribe__Assets {
 					continue;
 				}
 
-				wp_register_script( $asset->slug, $asset->url, $asset->deps, $asset->version, $asset->in_footer );
+				$dependencies = $asset->deps;
+
+				// If the asset is a callable, we call the function,
+				// passing it the asset and expecting back an array of dependencies.
+				if ( is_callable( $asset->deps ) ) {
+					$dependencies = call_user_func( $asset->deps, [ $asset ] );
+				}
+
+				wp_register_script( $asset->slug, $asset->url, $dependencies, $asset->version, $asset->in_footer );
 
 				// Register that this asset is actually registered on the WP methods.
 				$asset->is_registered = wp_script_is( $asset->slug, 'registered' );
@@ -473,7 +482,7 @@ class Tribe__Assets {
 	 * @param object            $origin    The main object for the plugin you are enqueueing the asset for.
 	 * @param string            $slug      Slug to save the asset - passes through `sanitize_title_with_dashes()`.
 	 * @param string            $file      The asset file to load (CSS or JS), including non-minified file extension.
-	 * @param array             $deps      The list of dependencies.
+	 * @param array             $deps      The list of dependencies or callable function that will return a list of dependencies.
 	 * @param string|array|null $action    The WordPress action(s) to enqueue on, such as `wp_enqueue_scripts`,
 	 *                                     `admin_enqueue_scripts`, or `login_enqueue_scripts`.
 	 * @param string|array      $arguments {

--- a/src/Tribe/Editor/Assets.php
+++ b/src/Tribe/Editor/Assets.php
@@ -36,17 +36,7 @@ class Tribe__Editor__Assets {
 			/**
 			 * @todo revise this dependencies
 			 */
-			[
-				'react',
-				'react-dom',
-				'wp-components',
-				'wp-api',
-				'wp-api-request',
-				'wp-blocks',
-				'wp-i18n',
-				'wp-element',
-				'wp-editor',
-			],
+			[ $this, 'filter_event_blocks_editor_deps' ],
 			'enqueue_block_editor_assets',
 			[
 				'in_footer' => false,
@@ -71,20 +61,7 @@ class Tribe__Editor__Assets {
 			$plugin,
 			'tribe-common-gutenberg-utils',
 			'app/utils.js',
-			/**
-			 * @todo revise this dependencies
-			 */
-			[
-				'react',
-				'react-dom',
-				'wp-components',
-				'wp-api',
-				'wp-api-request',
-				'wp-blocks',
-				'wp-i18n',
-				'wp-element',
-				'wp-editor',
-			],
+			[ $this, 'filter_event_blocks_editor_deps' ],
 			'enqueue_block_editor_assets',
 			[
 				'in_footer' => false,
@@ -92,24 +69,12 @@ class Tribe__Editor__Assets {
 				'priority'  => 12,
 			]
 		);
+
 		tribe_asset(
 			$plugin,
 			'tribe-common-gutenberg-store',
 			'app/store.js',
-			/**
-			 * @todo revise this dependencies
-			 */
-			[
-				'react',
-				'react-dom',
-				'wp-components',
-				'wp-api',
-				'wp-api-request',
-				'wp-blocks',
-				'wp-i18n',
-				'wp-element',
-				'wp-editor',
-			],
+			[ $this, 'filter_event_blocks_editor_deps' ],
 			'enqueue_block_editor_assets',
 			[
 				'in_footer' => false,
@@ -117,24 +82,12 @@ class Tribe__Editor__Assets {
 				'priority'  => 13,
 			]
 		);
+
 		tribe_asset(
 			$plugin,
 			'tribe-common-gutenberg-icons',
 			'app/icons.js',
-			/**
-			 * @todo revise this dependencies
-			 */
-			[
-				'react',
-				'react-dom',
-				'wp-components',
-				'wp-api',
-				'wp-api-request',
-				'wp-blocks',
-				'wp-i18n',
-				'wp-element',
-				'wp-editor',
-			],
+			[ $this, 'filter_event_blocks_editor_deps' ],
 			'enqueue_block_editor_assets',
 			[
 				'in_footer' => false,
@@ -142,24 +95,12 @@ class Tribe__Editor__Assets {
 				'priority'  => 14,
 			]
 		);
+
 		tribe_asset(
 			$plugin,
 			'tribe-common-gutenberg-hoc',
 			'app/hoc.js',
-			/**
-			 * @todo revise this dependencies
-			 */
-			[
-				'react',
-				'react-dom',
-				'wp-components',
-				'wp-api',
-				'wp-api-request',
-				'wp-blocks',
-				'wp-i18n',
-				'wp-element',
-				'wp-editor',
-			],
+			[ $this, 'filter_event_blocks_editor_deps' ],
 			'enqueue_block_editor_assets',
 			[
 				'in_footer' => false,
@@ -167,24 +108,12 @@ class Tribe__Editor__Assets {
 				'priority'  => 15,
 			]
 		);
+
 		tribe_asset(
 			$plugin,
 			'tribe-common-gutenberg-components',
 			'app/components.js',
-			/**
-			 * @todo revise this dependencies
-			 */
-			[
-				'react',
-				'react-dom',
-				'wp-components',
-				'wp-api',
-				'wp-api-request',
-				'wp-blocks',
-				'wp-i18n',
-				'wp-element',
-				'wp-editor',
-			],
+			[ $this, 'filter_event_blocks_editor_deps' ],
 			'enqueue_block_editor_assets',
 			[
 				'in_footer' => false,
@@ -192,24 +121,12 @@ class Tribe__Editor__Assets {
 				'priority'  => 16,
 			]
 		);
+
 		tribe_asset(
 			$plugin,
 			'tribe-common-gutenberg-elements',
 			'app/elements.js',
-			/**
-			 * @todo revise this dependencies
-			 */
-			[
-				'react',
-				'react-dom',
-				'wp-components',
-				'wp-api',
-				'wp-api-request',
-				'wp-blocks',
-				'wp-i18n',
-				'wp-element',
-				'wp-editor',
-			],
+			[ $this, 'filter_event_blocks_editor_deps' ],
 			'enqueue_block_editor_assets',
 			[
 				'in_footer' => false,
@@ -217,6 +134,7 @@ class Tribe__Editor__Assets {
 				'priority'  => 17,
 			]
 		);
+
 		/**
 		 * @todo: figure out why element styles are loading for tickets but not events.
 		 */
@@ -224,20 +142,7 @@ class Tribe__Editor__Assets {
 			$plugin,
 			'tribe-common-gutenberg-components',
 			'app/components.js',
-			/**
-			 * @todo revise this dependencies
-			 */
-			[
-				'react',
-				'react-dom',
-				'wp-components',
-				'wp-api',
-				'wp-api-request',
-				'wp-blocks',
-				'wp-i18n',
-				'wp-element',
-				'wp-editor',
-			],
+			[ $this, 'filter_event_blocks_editor_deps' ],
 			'enqueue_block_editor_assets',
 			[
 				'in_footer' => false,
@@ -255,5 +160,38 @@ class Tribe__Editor__Assets {
 				'in_footer' => false,
 			]
 		);
+	}
+
+	/**
+	 * Filter the dependencies for event blocks
+	 *
+	 * @since TBD
+	 *
+	 * @param array|object|null $assets Array of asset objects, single asset object, or null.
+	 *
+	 * @return array An array of dependency slugs.
+	 */
+	public function filter_event_blocks_editor_deps( $asset ) {
+		global $pagenow;
+
+		$deps = [
+			'react',
+			'react-dom',
+			'wp-components',
+			'wp-api',
+			'wp-api-request',
+			'wp-blocks',
+			'wp-i18n',
+			'wp-element',
+			'wp-editor',
+		];
+
+		if ( $pagenow !== 'post.php' && $pagenow !== 'post-new.php'  ) {
+			if ( ( $key = array_search( 'wp-editor', $deps ) ) !== false) {
+				unset($deps[$key]);
+			}
+		}
+
+		return $deps;
 	}
 }

--- a/src/Tribe/Editor/Assets.php
+++ b/src/Tribe/Editor/Assets.php
@@ -186,9 +186,9 @@ class Tribe__Editor__Assets {
 			'wp-editor',
 		];
 
-		if ( $pagenow !== 'post.php' && $pagenow !== 'post-new.php'  ) {
-			if ( ( $key = array_search( 'wp-editor', $deps ) ) !== false) {
-				unset($deps[$key]);
+		if ( $pagenow !== 'post.php' && $pagenow !== 'post-new.php' ) {
+			if ( ( $key = array_search( 'wp-editor', $deps ) ) !== false ) {
+				unset( $deps[ $key ] );
 			}
 		}
 

--- a/src/Tribe/Editor/Assets.php
+++ b/src/Tribe/Editor/Assets.php
@@ -186,7 +186,7 @@ class Tribe__Editor__Assets {
 			'wp-editor',
 		];
 
-		if ( $pagenow !== 'post.php' && $pagenow !== 'post-new.php' ) {
+		if ( 'post.php' !== $pagenow && 'post-new.php' !== $pagenow ) {
 			if ( ( $key = array_search( 'wp-editor', $deps ) ) !== false ) {
 				unset( $deps[ $key ] );
 			}

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -621,7 +621,7 @@ function tribe_register_error( $indexes, $message ) {
  * @param object            $origin    The main object for the plugin you are enqueueing the asset for.
  * @param string            $slug      Slug to save the asset - passes through `sanitize_title_with_dashes()`.
  * @param string            $file      The asset file to load (CSS or JS), including non-minified file extension.
- * @param array             $deps      The list of dependencies.
+ * @param array             $deps      The list of dependencies or callable function that will return a list of dependencies.
  * @param string|array|null $action    The WordPress action(s) to enqueue on, such as `wp_enqueue_scripts`,
  *                                     `admin_enqueue_scripts`, or `login_enqueue_scripts`.
  * @param array             $arguments See `Tribe__Assets::register()` for more info.


### PR DESCRIPTION
[TEC-4028]

Working widget page: https://d.pr/i/41gBtt
Working new event page: https://d.pr/i/aNWA1H
Working edit event page: https://d.pr/i/tHp6GA

For the sake of argument - I think it might be better to just not register the script(s) in question, since they are useless on other pages anyway?


[TEC-4028]: https://theeventscalendar.atlassian.net/browse/TEC-4028