### PR TITLE
Add a new warning dialog

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Feature - Added a new Warning dialog for the Dialog API. [ECP-901]
+
 = [4.14.1] 2021-07-21 =
 
 * Feature - Add new notice for Stellar Sale. [TCMN-111]

--- a/src/Tribe/Dialog/View.php
+++ b/src/Tribe/Dialog/View.php
@@ -244,6 +244,77 @@ class View extends \Tribe__Template {
 	}
 
 	/**
+	 * Syntactic sugar for `render_dialog()` to make creating custom confirmation dialogs easier.
+	 * Adds sensible defaults for warning dialogs.
+	 *
+	 * @since TBD
+	 *
+	 * @param string  $content Content as an HTML string.
+	 * @param array   $args    {
+	 *     List of arguments to override dialog template.
+	 *
+	 *     @type string  $button_id               The ID for the trigger button (optional).
+	 *     @type array   $button_classes          Any desired classes for the trigger button (optional).
+	 *     @type array   $button_attributes       Any desired attributes for the trigger button (optional).
+	 *     @type boolean $button_disabled         Should the button be disabled (optional).
+	 *     @type string  $button_text             The text for the dialog trigger button ("Open the dialog window").
+	 *     @type string  $button_type             The type for the trigger button (optional).
+	 *     @type string  $button_value            The value for the trigger button (optional).
+	 *     @type boolean $button_display          If the dialog button should be displayed or not (optional).
+	 *     @type string  $cancel_button_text      Text for the "Cancel" button ("Cancel").
+	 *     @type string  $content_classes         The dialog content classes ("tribe-dialog__content tribe-confirm__content").
+	 *     @type string  $continue_button_text    Text for the "Continue" button ("Confirm").
+	 *     @type array   $context                 Any additional context data you need to expose to this file (optional).
+	 *     @type string  $id                      The unique ID for this dialog (`uniqid()`).
+	 *     @type string  $template                The dialog template name (confirm).
+	 *     @type string  $title                   The dialog title (optional).
+	 *     @type string  $trigger_classes         Classes for the dialog trigger ("tribe_dialog_trigger").
+	 *
+	 *     Dialog script option overrides.
+	 *
+	 *     @type string  $append_target           The dialog will be inserted after the button, you could supply a selector string here to override (optional).
+	 *     @type boolean $body_lock               Whether to lock the body while dialog open (true).
+	 *     @type string  $close_button_aria_label Aria label for the close button (optional).
+	 *     @type string  $close_button_classes    Classes for the close button ("tribe-dialog__close-button--hidden").
+	 *     @type string  $close_event             The dialog close event hook name (`tribe_dialog_close_confirm`).
+	 *     @type string  $content_wrapper_classes Dialog content wrapper classes. This wrapper includes the close button ("tribe-dialog__wrapper tribe-confirm__wrapper").
+	 *     @type string  $effect                  CSS effect on open. none or fade (optional).
+	 *     @type string  $effect_easing           A css easing string to apply ("ease-in-out").
+	 *     @type int     $effect_speed            CSS effect speed in milliseconds (optional).
+	 *     @type string  $overlay_classes         The dialog overlay classes ("tribe-dialog__overlay tribe-confirm__overlay").
+	 *     @type boolean $overlay_click_closes    If clicking the overlay closes the dialog (false).
+	 *     @type string  $show_event              The dialog event hook name (`tribe_dialog_show_confirm`).
+	 *     @type string  $wrapper_classes         The wrapper class for the dialog ("tribe-dialog").
+	 * }
+	 * @param string  $id      The unique ID for this dialog. Gets prepended to the data attributes. Generated if not passed (`uniqid()`).
+	 * @param boolean $echo    Whether to echo the script or to return it (default: true).
+	 *
+	 * @return string An HTML string of the dialog.
+	 */
+	public function render_warning( $content, $args = [], $id = null, $echo = true ) {
+		$default_args = [
+			'body_lock'               => true,
+			'button_display'          => false,
+			'cancel_button_text'      => __( 'Cancel', 'tribe-common' ),
+			'continue_button_text'    => __( 'OK', 'tribe-common' ),
+			'close_button_aria_label' => '',
+			'close_button_classes'    => 'tribe-dialog__close-button--hidden',
+			'close_event'             => 'tribe_dialog_close_confirm',
+			'content_classes'         => 'tribe-dialog__content tribe-confirm__content',
+			'content_wrapper_classes' => 'tribe-dialog__wrapper tribe-confirm__wrapper',
+			'overlay_classes'         => 'tribe-dialog__overlay tribe-modal__overlay tribe-warning__overlay',
+			'overlay_click_closes'    => false,
+			'show_event'              => 'tribe_dialog_show_confirm',
+			'template'                => 'warning',
+			'title_classes'           => [ 'tribe-dialog__title', 'tribe-confirm__title' ],
+		];
+
+		$args = wp_parse_args( $args, $default_args );
+
+		$this->render_dialog( $content, $args, $id, $echo );
+	}
+
+	/**
 	 * Syntactic sugar for `render_dialog()` to make creating custom alerts easier.
 	 * Adds sensible defaults for alerts.
 	 *

--- a/src/Tribe/Dialog/View.php
+++ b/src/Tribe/Dialog/View.php
@@ -171,7 +171,7 @@ class View extends \Tribe__Template {
 
 		$args = wp_parse_args( $args, $default_args );
 
-		$this->render_dialog( $content, $args, $id, $echo );
+		return $this->render_dialog( $content, $args, $id, $echo );
 	}
 
 	/**
@@ -240,7 +240,7 @@ class View extends \Tribe__Template {
 
 		$args = wp_parse_args( $args, $default_args );
 
-		$this->render_dialog( $content, $args, $id, $echo );
+		return $this->render_dialog( $content, $args, $id, $echo );
 	}
 
 	/**
@@ -262,8 +262,10 @@ class View extends \Tribe__Template {
 	 *     @type string  $button_value            The value for the trigger button (optional).
 	 *     @type boolean $button_display          If the dialog button should be displayed or not (optional).
 	 *     @type string  $cancel_button_text      Text for the "Cancel" button ("Cancel").
+	 *     @type string  $cancel_button_classes   Any desired classes for the cancel button (optional).
 	 *     @type string  $content_classes         The dialog content classes ("tribe-dialog__content tribe-confirm__content").
 	 *     @type string  $continue_button_text    Text for the "Continue" button ("Confirm").
+	 *     @type string  $continue_button_classes Any desired classes for the continue button (optional).
 	 *     @type array   $context                 Any additional context data you need to expose to this file (optional).
 	 *     @type string  $id                      The unique ID for this dialog (`uniqid()`).
 	 *     @type string  $template                The dialog template name (confirm).
@@ -296,7 +298,9 @@ class View extends \Tribe__Template {
 			'body_lock'               => true,
 			'button_display'          => false,
 			'cancel_button_text'      => __( 'Cancel', 'tribe-common' ),
+			'cancel_button_classes'   => 'tribe-dialog__button tribe-dialog__button-cancel tribe-common-c-btn tribe-common-c-btn-border',
 			'continue_button_text'    => __( 'OK', 'tribe-common' ),
+			'continue_button_classes'  => 'tribe-dialog__button tribe-dialog__button-continue tribe-common-c-btn-border tribe-common-c-btn-border--alt',
 			'close_button_aria_label' => '',
 			'close_button_classes'    => 'tribe-dialog__close-button--hidden',
 			'close_event'             => 'tribe_dialog_close_confirm',
@@ -311,7 +315,7 @@ class View extends \Tribe__Template {
 
 		$args = wp_parse_args( $args, $default_args );
 
-		$this->render_dialog( $content, $args, $id, $echo );
+		return $this->render_dialog( $content, $args, $id, $echo );
 	}
 
 	/**
@@ -379,7 +383,7 @@ class View extends \Tribe__Template {
 
 		$args = wp_parse_args( $args, $default_args );
 
-		$this->render_dialog( $content, $args, $id, $echo );
+		return $this->render_dialog( $content, $args, $id, $echo );
 	}
 
 	/**
@@ -400,8 +404,10 @@ class View extends \Tribe__Template {
 	 *     @type string  $button_type             The type for the trigger button (optional).
 	 *     @type string  $button_value            The value for the trigger button (optional).
 	 *     @type boolean $button_display          If the dialog button should be displayed or not (optional).
+	 *     @type string  $cancel_button_classes   Any desired classes for the cancel button (optional).
 	 *     @type string  $close_event             The dialog event hook name (`tribe_dialog_close_dialog`).
 	 *     @type string  $content_classes         The dialog content classes ("tribe-dialog__content").
+	 *     @type string  $continue_button_classes Any desired classes for the continue button (optional).
 	 *     @type string  $title_classes           The dialog title classes ("tribe-dialog__title").
 	 *     @type array   $context                 Any additional context data you need to expose to this file (optional).
 	 *     @type string  $id                      The unique ID for this dialog (`uniqid()`).
@@ -438,6 +444,8 @@ class View extends \Tribe__Template {
 			'button_type'             => '',
 			'button_value'            => '',
 			'button_display'          => true,
+			'cancel_button_classes'   => 'tribe-dialog__button tribe-dialog__button-cancel tribe-common-c-btn-border tribe-common-c-btn-border--alt',
+			'continue_button_classes' => 'tribe-dialog__button tribe-dialog__button-continue tribe-common-c-btn tribe-common-c-btn-border',
 			'close_event'             => 'tribe_dialog_close_dialog',
 			'content_classes'         => 'tribe-dialog__content',
 			'context'                 => '',

--- a/src/resources/postcss/dialog.pcss
+++ b/src/resources/postcss/dialog.pcss
@@ -61,7 +61,7 @@ This can include modals, toasters, confirms. alerts.
 		border-radius: var(--tribe-dialog-border-radius);
 		box-shadow: 0 2px 54px 0 var(--tribe-modal-overlay-color);
 		width: 800px;
-		overflow-y: scroll;
+		overflow-y: auto;
 		padding: var(--tribe-dialog-padding);
 		max-height: 100vh;
 		max-width: 100vw;
@@ -149,6 +149,10 @@ This can include modals, toasters, confirms. alerts.
 		padding: 0;
 	}
 
+	.tribe-dialog__content p {
+		font-size: var(--font-size-2);
+	}
+
 	@media screen and (max-width:768px) {
 		.tribe-dialog__content:last-of-type {
 			padding-bottom: 36px;
@@ -171,6 +175,12 @@ This can include modals, toasters, confirms. alerts.
 		display: flex;
 		flex-flow: row wrap;
 		justify-content: flex-end;
+		margin-top: 1rem;
+	}
+
+	.tribe-dialog__button {
+		margin-left: var(--spacer-1);
+		width: auto;
 	}
 
 	/* -------------------------------------------------------------------------

--- a/src/resources/postcss/dialog.pcss
+++ b/src/resources/postcss/dialog.pcss
@@ -33,7 +33,7 @@ This can include modals, toasters, confirms. alerts.
 		position: fixed;
 		top: 0;
 		width: 100vw;
-		z-index: 1;
+		z-index: 100;
 
 		&[aria-hidden='true'] {
 			display: none;
@@ -52,7 +52,7 @@ This can include modals, toasters, confirms. alerts.
 		position: fixed;
 		top: 0;
 		width: 100vw;
-		z-index: 1000;
+		z-index: 100;
 	}
 
 	/* Content wrapper - includes close button*/
@@ -65,7 +65,7 @@ This can include modals, toasters, confirms. alerts.
 		padding: var(--tribe-dialog-padding);
 		max-height: 100vh;
 		max-width: 100vw;
-		z-index: 2;
+		z-index: 200;
 		-webkit-transform: translateZ(0px);
 		-webkit-transform: translate3d(0,0,0);
 		-webkit-perspective: 1000;
@@ -179,7 +179,7 @@ This can include modals, toasters, confirms. alerts.
 	}
 
 	.tribe-dialog__button-cancel,
-	.tribe-dialog__button-confirm {
+	.tribe-dialog__button-continue {
 		margin-left: var(--spacer-1);
 		width: auto;
 	}

--- a/src/resources/postcss/dialog.pcss
+++ b/src/resources/postcss/dialog.pcss
@@ -178,7 +178,8 @@ This can include modals, toasters, confirms. alerts.
 		margin-top: 1rem;
 	}
 
-	.tribe-dialog__button {
+	.tribe-dialog__button-cancel,
+	.tribe-dialog__button-confirm {
 		margin-left: var(--spacer-1);
 		width: auto;
 	}

--- a/src/resources/postcss/dialog.pcss
+++ b/src/resources/postcss/dialog.pcss
@@ -52,7 +52,7 @@ This can include modals, toasters, confirms. alerts.
 		position: fixed;
 		top: 0;
 		width: 100vw;
-		z-index: 1;
+		z-index: 1000;
 	}
 
 	/* Content wrapper - includes close button*/

--- a/src/resources/postcss/dialog.pcss
+++ b/src/resources/postcss/dialog.pcss
@@ -188,7 +188,7 @@ This can include modals, toasters, confirms. alerts.
 	 * Theme Overrides - Avada
 	 * ------------------------------------------------------------------------- */
 
-	 .tribe-theme-avada & {
+	.tribe-theme-avada & {
 
 		div.tribe-dialog {
 			z-index: 99999;
@@ -199,7 +199,7 @@ This can include modals, toasters, confirms. alerts.
 	 * Theme Overrides - Divi
 	 * ------------------------------------------------------------------------- */
 
-	 .tribe-theme-divi & {
+	.tribe-theme-divi & {
 
 		div.tribe-dialog {
 			z-index: 99999;

--- a/src/views/dialog/confirm.php
+++ b/src/views/dialog/confirm.php
@@ -25,8 +25,8 @@ $vars        = get_defined_vars();
 
 		<?php echo $content; ?>
 		<div class="tribe-dialog__button_wrap">
-			<button class="tribe-dialog__button tribe-dialog__button-cancel tribe-common-c-btn-border tribe-common-c-btn-border--alt"><?php echo esc_html( $cancel_button_text ); ?></button>
-			<button class="tribe-dialog__button tribe-dialog__button-confirm tribe-common-c-btn tribe-common-c-btn-border"><?php echo esc_html( $continue_button_text ); ?></button>
+			<button <?php tribe_classes( $cancel_button_classes ); ?>><?php echo esc_html( $cancel_button_text ); ?></button>
+			<button <?php tribe_classes( $continue_button_classes ); ?>><?php echo esc_html( $continue_button_text ); ?></button>
 		</div>
 	</div>
 </script>

--- a/src/views/dialog/warning.php
+++ b/src/views/dialog/warning.php
@@ -25,8 +25,8 @@ $vars        = get_defined_vars();
 
 		<?php echo $content; ?>
 		<div class="tribe-dialog__button_wrap">
-			<button class="tribe-dialog__button tribe-dialog__button-confirm tribe-common-c-btn-border tribe-common-c-btn-border--alt"><?php echo esc_html( $continue_button_text ); ?></button>
-			<button class="tribe-dialog__button tribe-dialog__button-cancel tribe-common-c-btn tribe-common-c-btn-border"><?php echo esc_html( $cancel_button_text ); ?></button>
+			<button <?php tribe_classes( $continue_button_classes ); ?>><?php echo esc_html( $continue_button_text ); ?></button>
+			<button <?php tribe_classes( $cancel_button_classes ); ?>><?php echo esc_html( $cancel_button_text ); ?></button>
 		</div>
 	</div>
 </script>

--- a/src/views/dialog/warning.php
+++ b/src/views/dialog/warning.php
@@ -23,7 +23,7 @@ $vars        = get_defined_vars();
 			<h2 <?php tribe_classes( $title_classes ) ?>><?php echo esc_html( $title ); ?></h2>
 		<?php endif; ?>
 
-		<?php echo $content; ?>
+		<?php echo wp_kses_post( $content ); ?>
 		<div class="tribe-dialog__button_wrap">
 			<button <?php tribe_classes( $continue_button_classes ); ?>><?php echo esc_html( $continue_button_text ); ?></button>
 			<button <?php tribe_classes( $cancel_button_classes ); ?>><?php echo esc_html( $cancel_button_text ); ?></button>

--- a/src/views/dialog/warning.php
+++ b/src/views/dialog/warning.php
@@ -1,14 +1,14 @@
 <?php
 /**
- * Confirmation Dialog View Template
+ * Warn Dialog View Template
  * The confirmation template for tribe-dialog.
  *
- * Override this template in your own theme by creating a file at [your-theme]/tribe/dialogs/confirm.php
+ * Override this template in your own theme by creating a file at [your-theme]/tribe/dialogs/warn.php
  *
- * @since 4.10.0
+ * @since TBD
  *
  * @package Tribe
- * @version 4.10.0
+ * @version TBD
  */
 
 /** @var \Tribe\Dialog\View $dialog_view */
@@ -25,8 +25,8 @@ $vars        = get_defined_vars();
 
 		<?php echo $content; ?>
 		<div class="tribe-dialog__button_wrap">
-			<button class="tribe-dialog__button tribe-dialog__button-cancel tribe-common-c-btn-border tribe-common-c-btn-border--alt"><?php echo esc_html( $cancel_button_text ); ?></button>
-			<button class="tribe-dialog__button tribe-dialog__button-confirm tribe-common-c-btn tribe-common-c-btn-border"><?php echo esc_html( $continue_button_text ); ?></button>
+			<button class="tribe-dialog__button tribe-dialog__button-confirm tribe-common-c-btn-border tribe-common-c-btn-border--alt"><?php echo esc_html( $continue_button_text ); ?></button>
+			<button class="tribe-dialog__button tribe-dialog__button-cancel tribe-common-c-btn tribe-common-c-btn-border"><?php echo esc_html( $cancel_button_text ); ?></button>
 		</div>
 	</div>
 </script>


### PR DESCRIPTION
This PR does two things of note:

1. It adjusts the Confirm dialog to use properly styled buttons. I'm not worried about making this change as we do not use the confirm dialog anywhere in our plugins at this time.
2. It adds a new Warning dialog where the Cancel button is the button of emphasis rather than the OK button.

🎫 [ECP-901]
🎥 
![Capture](https://user-images.githubusercontent.com/430385/129917829-eb302fa6-8fb9-4126-ba61-56055c0b1626.PNG)

Related: https://github.com/the-events-calendar/events-pro/pull/1811

[ECP-901]: https://theeventscalendar.atlassian.net/browse/ECP-901