### PR TITLE
Tweak some of the Troubleshooting page optin code.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 * Fix - Ensure all the content within the recent template changes section in the troubleshooting page is visible. [TEC-4062]
 * Fix - Updated dropdowns controlled via ajax to return unescaped html entities instead of the escaped version. [CE-97]
+* Fix - Ensure Troubleshooting page has the required DOM pieces and the call to TEC.com works as expected. [TEC-4052]
 
 = [4.14.4] 2021-08-31 =
 

--- a/src/Tribe/Admin/Help_Page.php
+++ b/src/Tribe/Admin/Help_Page.php
@@ -52,10 +52,13 @@ class Tribe__Admin__Help_Page {
 				'localize' => [
 					'name' => 'tribe_system_info',
 					'data' => [
-						'sysinfo_optin_nonce'   => wp_create_nonce( 'sysinfo_optin_nonce' ),
-						'clipboard_btn_text'    => __( 'Copy to clipboard', 'tribe-common' ),
-						'clipboard_copied_text' => __( 'System info copied', 'tribe-common' ),
-						'clipboard_fail_text'   => __( 'Press "Cmd + C" to copy', 'tribe-common' ),
+						'sysinfo_optin_nonce'        => wp_create_nonce( 'sysinfo_optin_nonce' ),
+						'clipboard_btn_text'         => _x( 'Copy to clipboard', 'Copy to clipboard button text.', 'tribe-common' ),
+						'clipboard_copied_text'      => __( 'System info copied', 'Copy to clipboard success message', 'tribe-common' ),
+						'clipboard_fail_text'        => __( 'Press "Cmd + C" to copy', 'Copy to clipboard instructions', 'tribe-common' ),
+						'sysinfo_error_message_text' => __( 'Something has gone wrong!', 'Default error message for system info optin', 'tribe-common' ),
+						'sysinfo_error_code_text'    => __( 'Code:', 'Error code label for system info optin', 'tribe-common'),
+						'sysinfo_error_status_text'  => __( 'Status:', 'Error status label for system info optin', 'tribe-common'),
 					],
 				],
 			]

--- a/src/Tribe/Support.php
+++ b/src/Tribe/Support.php
@@ -417,13 +417,13 @@ if ( ! class_exists( 'Tribe__Support' ) ) {
 		public static function send_sysinfo_key( $optin_key = null, $url = null, $remove = null, $pueadd = false ) {
 			$url = $url ? $url : urlencode( str_replace( [ 'http://', 'https://' ], '', get_site_url() ) );
 
-			$teccom_url = 'https://theeventscalendar.com/';
+			$teccom_url = 'https://support-api.tri.be';
 
 			if ( defined( 'TEC_URL' ) ) {
 				$teccom_url = trailingslashit( TEC_URL );
 			}
 
-			$query = $teccom_url . 'wp-json/tribe_system/v2/customer-info/' . $optin_key . '/' . $url;
+			$query = $teccom_url . 'sysinfo/optin/' . $optin_key . '/' . $url;
 
 			if ( $remove ) {
 				$query .= '?status=remove';

--- a/src/Tribe/Support.php
+++ b/src/Tribe/Support.php
@@ -415,15 +415,14 @@ if ( ! class_exists( 'Tribe__Support' ) ) {
 		 * @param null $pueadd boolean to disable messaging when coming from pue script
 		 */
 		public static function send_sysinfo_key( $optin_key = null, $url = null, $remove = null, $pueadd = false ) {
-			$url = $url ? $url : urlencode( str_replace( [ 'http://', 'https://' ], '', get_site_url() ) );
-
-			$teccom_url = 'https://support-api.tri.be';
+			$url        = $url ? $url : urlencode( str_replace( [ 'http://', 'https://' ], '', get_site_url() ) );
+			$teccom_url = 'https://theeventscalendar.com';
 
 			if ( defined( 'TEC_URL' ) ) {
-				$teccom_url = trailingslashit( TEC_URL );
+				$teccom_url = TEC_URL;
 			}
 
-			$query = $teccom_url . 'sysinfo/optin/' . $optin_key . '/' . $url;
+			$query = trailingslashit( $teccom_url ) . 'wp-json/tribe_system/v2/customer-info/' . $optin_key . '/' . $url;
 
 			if ( $remove ) {
 				$query .= '?status=remove';

--- a/src/Tribe/Support.php
+++ b/src/Tribe/Support.php
@@ -416,13 +416,8 @@ if ( ! class_exists( 'Tribe__Support' ) ) {
 		 */
 		public static function send_sysinfo_key( $optin_key = null, $url = null, $remove = null, $pueadd = false ) {
 			$url        = $url ? $url : urlencode( str_replace( [ 'http://', 'https://' ], '', get_site_url() ) );
-			$teccom_url = 'https://theeventscalendar.com';
-
-			if ( defined( 'TEC_URL' ) ) {
-				$teccom_url = TEC_URL;
-			}
-
-			$query = trailingslashit( $teccom_url ) . 'wp-json/tribe_system/v2/customer-info/' . $optin_key . '/' . $url;
+			$teccom_url = defined( 'TEC_URL' ) ? TEC_URL : 'https://theeventscalendar.com';
+			$query      = trailingslashit( $teccom_url ) . 'wp-json/tribe_system/v2/customer-info/' . $optin_key . '/' . $url;
 
 			if ( $remove ) {
 				$query .= '?status=remove';

--- a/src/admin-views/troubleshooting/system-information.php
+++ b/src/admin-views/troubleshooting/system-information.php
@@ -27,6 +27,7 @@ $optin_key = ! empty( get_option( $support::$option_key ) );
 		<small>
 			<?php esc_html_e( '* Your system information will only be used by The Events Calendar support team. All information is stored securely. We do not share this information with any third parties.', 'tribe-common' ); ?>
 		</small>
+		<p class="tribe-sysinfo-optin-msg"></p>
 	</div>
 
 	<div class="tribe-events-admin__system-information-widget">

--- a/src/resources/js/admin/help-page.js
+++ b/src/resources/js/admin/help-page.js
@@ -88,7 +88,9 @@ tribe.helpPage = tribe.helpPage || {};
 				if ( results.success ) {
 					obj.$system_info_opt_in_msg.html( "<p class='optin-success'>" + results.data + "</p>" );
 				} else {
-					var html = "<p class='optin-fail'>Something has gone wrong!</p>";
+					var html = "<p class='optin-fail'>"
+						+ tribe_system_info.sysinfo_error_message_text
+						+ "</p>";
 
 					if ( results.data ) {
 						if ( results.data.message ) {
@@ -98,11 +100,18 @@ tribe.helpPage = tribe.helpPage || {};
 						}
 
 						if ( results.data.code ) {
-							html += '<p>Code:' + results.data.code + '</p>';
+							html += '<p>'
+							+ tribe_system_info.sysinfo_error_code_text
+							+ ' '
+							+ results.data.code
+							+ '</p>';
 						}
 
 						if ( results.data.status ) {
-							html += '<p>Status:' + results.data.status + '</p>';
+							html += '<p>'
+							+ tribe_system_info.sysinfo_error_status_text
+							+ results.data.status
+							+ '</p>';
 						}
 
 					}

--- a/src/resources/js/admin/help-page.js
+++ b/src/resources/js/admin/help-page.js
@@ -92,8 +92,8 @@ tribe.helpPage = tribe.helpPage || {};
 
 					if ( results.data ) {
 						if ( results.data.message ) {
-							html += ' ' + results.data.message;
-						} else if (  results.message) {
+							html += '<p>' + results.data.message + '</p>';
+						} else if (  results.message ) {
 							html += '<p>' + results.message + '</p>';
 						}
 
@@ -107,7 +107,7 @@ tribe.helpPage = tribe.helpPage || {};
 
 					}
 
-					obj.$system_info_opt_in_msg.html(  html ); // eslint-disable-line max-len
+					obj.$system_info_opt_in_msg.html( html ); // eslint-disable-line max-len
 					$( obj.selectors.autoInfoOptIn ).prop( "checked", false );
 				}
 			}

--- a/src/resources/js/admin/help-page.js
+++ b/src/resources/js/admin/help-page.js
@@ -84,10 +84,30 @@ tribe.helpPage = tribe.helpPage || {};
 			ajaxurl,
 			request,
 			function ( results ) {
+
 				if ( results.success ) {
 					obj.$system_info_opt_in_msg.html( "<p class='optin-success'>" + results.data + "</p>" );
 				} else {
-					obj.$system_info_opt_in_msg.html( "<p class='optin-fail'>" + results.data.message + " Code:" + results.data.code + " Status:" + results.data.data.status + "</p>" ); // eslint-disable-line max-len
+					var html = "<p class='optin-fail'>Something has gone wrong!</p>";
+
+					if ( results.data ) {
+						if ( results.data.message ) {
+							html += ' ' + results.data.message;
+						} else if (  results.message) {
+							html += '<p>' + results.message + '</p>';
+						}
+
+						if ( results.data.code ) {
+							html += '<p>Code:' + results.data.code + '</p>';
+						}
+
+						if ( results.data.status ) {
+							html += '<p>Status:' + results.data.status + '</p>';
+						}
+
+					}
+
+					obj.$system_info_opt_in_msg.html(  html ); // eslint-disable-line max-len
 					$( obj.selectors.autoInfoOptIn ).prop( "checked", false );
 				}
 			}


### PR DESCRIPTION
~Prior to this, all calls to set the optin key would fail.~

~The old code made calls to https://theeventscalendar.com/wp-json/tribe_system/v2/customer-info/XXX~

~It should be going to https://support-api.tri.be/sysinfo/optin/XXX~

~There is a redirect for that in the code base for tec.com - but it is not working apparently.~

~tec.com refs:~
~https://github.com/the-events-calendar/theeventscalendar.com/blob/2f1dc6e9d4d186148eaf9d74302ec580003a64a0/systems/nginx/default#L104~
~https://github.com/the-events-calendar/theeventscalendar.com/blob/2f1dc6e9d4d186148eaf9d74302ec580003a64a0/ansible/group_vars/all/nginx.yml#L56~
~https://github.com/the-events-calendar/theeventscalendar.com/blob/2f1dc6e9d4d186148eaf9d74302ec580003a64a0/content/plugins/pue-glue/src/Admin/Legacy_Rewrite.php#L25~

📷 https://d.pr/i/5EjitG

Note: the URL "fix" has been ported to tec.com - so all that remains here is some tweaked handling of the response, and the addition of the missing DOM element.


[TEC-4052]

[TEC-4052]: https://theeventscalendar.atlassian.net/browse/TEC-4052