### PR TITLE
Use _x() rather than __() when describing translations

### DIFF
--- a/src/Tribe/Admin/Help_Page.php
+++ b/src/Tribe/Admin/Help_Page.php
@@ -54,11 +54,11 @@ class Tribe__Admin__Help_Page {
 					'data' => [
 						'sysinfo_optin_nonce'        => wp_create_nonce( 'sysinfo_optin_nonce' ),
 						'clipboard_btn_text'         => _x( 'Copy to clipboard', 'Copy to clipboard button text.', 'tribe-common' ),
-						'clipboard_copied_text'      => __( 'System info copied', 'Copy to clipboard success message', 'tribe-common' ),
-						'clipboard_fail_text'        => __( 'Press "Cmd + C" to copy', 'Copy to clipboard instructions', 'tribe-common' ),
-						'sysinfo_error_message_text' => __( 'Something has gone wrong!', 'Default error message for system info optin', 'tribe-common' ),
-						'sysinfo_error_code_text'    => __( 'Code:', 'Error code label for system info optin', 'tribe-common'),
-						'sysinfo_error_status_text'  => __( 'Status:', 'Error status label for system info optin', 'tribe-common'),
+						'clipboard_copied_text'      => _x( 'System info copied', 'Copy to clipboard success message', 'tribe-common' ),
+						'clipboard_fail_text'        => _x( 'Press "Cmd + C" to copy', 'Copy to clipboard instructions', 'tribe-common' ),
+						'sysinfo_error_message_text' => _x( 'Something has gone wrong!', 'Default error message for system info optin', 'tribe-common' ),
+						'sysinfo_error_code_text'    => _x( 'Code:', 'Error code label for system info optin', 'tribe-common'),
+						'sysinfo_error_status_text'  => _x( 'Status:', 'Error status label for system info optin', 'tribe-common'),
 					],
 				],
 			]


### PR DESCRIPTION
This is a follow-up to https://github.com/the-events-calendar/tribe-common/pull/1650 to use the right translation function.

:ticket: [TEC-4052]

[TEC-4052]: https://theeventscalendar.atlassian.net/browse/TEC-4052