### PR TITLE
[CE-130] Dropdown not unescaping ampersand - revised for anon submission

### DIFF
--- a/src/Tribe/Ajax/Dropdown.php
+++ b/src/Tribe/Ajax/Dropdown.php
@@ -89,7 +89,7 @@ class Tribe__Ajax__Dropdown {
 		}
 
 		foreach ( $results as $result ) {
-			$result->text = wp_kses_post( htmlspecialchars_decode( $result->text ) );
+			$result->text = wp_kses_decode_entities( htmlspecialchars_decode( $result->text ) );
 		}
 
 		$data['results']    = $results;

--- a/src/Tribe/Ajax/Dropdown.php
+++ b/src/Tribe/Ajax/Dropdown.php
@@ -89,7 +89,7 @@ class Tribe__Ajax__Dropdown {
 		}
 
 		foreach ( $results as $result ) {
-			$result->text = wp_specialchars_decode( $result->text ) ;
+			$result->text = wp_specialchars_decode( $result->text );
 		}
 
 		$data['results']    = $results;

--- a/src/Tribe/Ajax/Dropdown.php
+++ b/src/Tribe/Ajax/Dropdown.php
@@ -89,7 +89,7 @@ class Tribe__Ajax__Dropdown {
 		}
 
 		foreach ( $results as $result ) {
-			$result->text =  wp_specialchars_decode( $result->text ) ;
+			$result->text = wp_specialchars_decode( $result->text ) ;
 		}
 
 		$data['results']    = $results;

--- a/src/Tribe/Ajax/Dropdown.php
+++ b/src/Tribe/Ajax/Dropdown.php
@@ -89,7 +89,7 @@ class Tribe__Ajax__Dropdown {
 		}
 
 		foreach ( $results as $result ) {
-			$result->text = wp_kses_decode_entities( htmlspecialchars_decode( $result->text ) );
+			$result->text =  wp_specialchars_decode( $result->text ) ;
 		}
 
 		$data['results']    = $results;


### PR DESCRIPTION
[CE-130]

This PR fixes an issue Victor found while QA'ing where `wp_kses_post` did not work work for users logged out. By removing `htmlspecialchars_decode` and switching to `wp_specialchars_decode` the output will work properly and run with less code.

Logged in screenshot: 
![image](https://user-images.githubusercontent.com/12241059/133451448-64e30c1d-d201-40cd-9176-c64e50e9b31b.png)


Logged out screenshot:
![image](https://user-images.githubusercontent.com/12241059/133451353-64f5e5b0-987d-4ff3-b975-e45f180583e2.png)


[CE-97]: https://theeventscalendar.atlassian.net/browse/CE-97

[CE-130]: https://theeventscalendar.atlassian.net/browse/CE-130