### PR TITLE
Defer to WP domain before checking $_SERVER

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Ensure the proper domain name is sent to PUE when validating licenses. [TCMN-122]
+
 = [4.14.5] 2021-09-14 =
 
 * Fix - Ensure all the content within the recent template changes section in the troubleshooting page is visible. [TEC-4062]

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -446,8 +446,11 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			$domain = self::$domain;
 
 			if ( empty( $domain ) ) {
-				if ( isset( $_SERVER['SERVER_NAME'] ) ) {
-				    $domain = $_SERVER['SERVER_NAME'];
+				$url = wp_parse_url( get_option( 'siteurl' ) );
+				if ( ! empty( $url ) && isset( $url['host'] ) ) {
+					$domain = $url['host'];
+				} elseif ( isset( $_SERVER['SERVER_NAME'] ) ) {
+					$domain = $_SERVER['SERVER_NAME'];
 				}
 
 				if ( is_multisite() ) {


### PR DESCRIPTION
This resolves an issue on sites hosted on servers whose `$_SERVER['SERVER_NAME']` differs from the domain specified in `get_option( 'siteurl' )`. For the purposes of license validation, we only care about the siteurl and should only default to the `$_SERVER['SERVER_NAME']` variable if siteurl is filtered such that it is empty.

:ticket: [TCMN-122]
:movie_camera: https://d.pr/v/s1NToE

[TCMN-122]: https://theeventscalendar.atlassian.net/browse/TCMN-122