### PR TITLE
This commit adds another level of checks to

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 * Fix - Ensure all SVG elements have unique IDs to improve accessibility. [TEC-4064]
 * Fix - Ensure the proper domain name is sent to PUE when validating licenses. [TCMN-122]
+* Fix - Correct block use checks around the Classic Editor plugin. [TEC-4099]
 
 = [4.14.5] 2021-09-14 =
 

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -29,7 +29,7 @@ class Tribe__Editor {
 	public function should_load_blocks() {
 		$gutenberg = $this->is_gutenberg_active() || $this->is_wp_version();
 		$blocks    = $this->is_blocks_editor_active();
-		$classic   = $this->is_classic_plugin_active() || $this->is_classic_option_active();
+		$classic   = $this->is_classic_option_active();
 
 		$should_load_blocks = $gutenberg && $blocks && ! $classic;
 
@@ -173,7 +173,16 @@ class Tribe__Editor {
 	 * @return bool
 	 */
 	public function is_classic_plugin_active() {
-		$is_plugin_active = function_exists( 'classic_editor_replace' ) || class_exists( 'Classic_Editor' );
+		// Timing means we can't rely on `is_plugin_active()` here.
+		$classic_editor_active = in_array(
+			'classic-editor/classic-editor.php',
+			apply_filters( 'active_plugins', get_option( 'active_plugins' ) )
+		);
+
+		$is_plugin_active = $classic_editor_active
+			|| class_exists( 'Classic_Editor' )
+			|| function_exists( 'classic_editor_replace' );
+
 		/**
 		 * Filter to change the output of calling: `is_classic_plugin_active`
 		 *
@@ -196,6 +205,11 @@ class Tribe__Editor {
 	 * @return bool
 	 */
 	public function is_classic_option_active() {
+		// Since the plugin leaves the `classic-editor-replace` value in the database on deactivation, let's make sure it's active first.
+		if ( ! $this->is_classic_plugin_active() ) {
+			return false;
+		}
+
 		$valid_values = [ 'replace', 'classic' ];
 
 		return in_array( (string) get_option( 'classic-editor-replace' ), $valid_values, true );

--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -176,7 +176,7 @@ class Tribe__Editor {
 		// Timing means we can't rely on `is_plugin_active()` here.
 		$classic_editor_active = in_array(
 			'classic-editor/classic-editor.php',
-			apply_filters( 'active_plugins', get_option( 'active_plugins' ) )
+			apply_filters( 'active_plugins', get_option( 'active_plugins', [] ) )
 		);
 
 		$is_plugin_active = $classic_editor_active


### PR DESCRIPTION
the `is_classic_plugin_active()` and `is_classic_option_active()` functions.

The first checks the actual `active_plugins` option for the Classic Editor plugin. The second checks that the plugin is active before checking for the option. Thus ignoring the option if the plugin is inactive.

[TEC-4099]

:camera: https://d.pr/v/e5PNO6

[TEC-4099]: https://theeventscalendar.atlassian.net/browse/TEC-4099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ