### PR TITLE
Fixing warnings PHP8: change __clone() & __wakeup() to public

### DIFF
--- a/src/Tribe/Plugin_Meta_Links.php
+++ b/src/Tribe/Plugin_Meta_Links.php
@@ -124,7 +124,7 @@ class Tribe__Plugin_Meta_Links {
 	 *
 	 * @return void
 	 */
-	final private function __clone() {
+	final public function __clone() {
 		_doing_it_wrong(
 			__FUNCTION__,
 			'Can not use this method on singletons.',
@@ -137,7 +137,7 @@ class Tribe__Plugin_Meta_Links {
 	 *
 	 * @return void
 	 */
-	final private function __wakeup() {
+	final public function __wakeup() {
 		_doing_it_wrong(
 			__FUNCTION__,
 			'Can not use this method on singletons.',


### PR DESCRIPTION
Change __clone() & __wakeup() from private to public

Fixing: warnings in PHP8:
- Private methods cannot be final as they are never overridden by other classes in
- The magic method Tribe__Plugin_Meta_Links::__wakeup() must have public visibility in

Related:
https://github.com/mt-support/tribe-ext-remove-export-links/issues/4