### PR TITLE
Updated paths in docs to reflect the correct path  

### DIFF
--- a/src/views/v2/components/icons/arrow-right.php
+++ b/src/views/v2/components/icons/arrow-right.php
@@ -3,7 +3,7 @@
  * View: Arrow Right Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/arrow-right.php
+ * [your-theme]/tribe/events/v2/components/icons/arrow-right.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/caret-down.php
+++ b/src/views/v2/components/icons/caret-down.php
@@ -3,7 +3,7 @@
  * View: Caret Down Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/caret-down.php
+ * [your-theme]/tribe/events/v2/components/icons/caret-down.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/caret-left.php
+++ b/src/views/v2/components/icons/caret-left.php
@@ -3,7 +3,7 @@
  * View: Caret Left Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/caret-left.php
+ * [your-theme]/tribe/events/v2/components/icons/caret-left.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/caret-right.php
+++ b/src/views/v2/components/icons/caret-right.php
@@ -3,7 +3,7 @@
  * View: Caret Right Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/caret-right.php
+ * [your-theme]/tribe/events/v2/components/icons/caret-right.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/close-alt.php
+++ b/src/views/v2/components/icons/close-alt.php
@@ -3,7 +3,7 @@
  * View: Close Alt Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/close-alt.php
+ * [your-theme]/tribe/events/v2/components/icons/close-alt.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/close.php
+++ b/src/views/v2/components/icons/close.php
@@ -3,7 +3,7 @@
  * View: Close Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/close.php
+ * [your-theme]/tribe/events/v2/components/icons/close.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/day.php
+++ b/src/views/v2/components/icons/day.php
@@ -3,7 +3,7 @@
  * View: Day Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/day.php
+ * [your-theme]/tribe/events/v2/components/icons/day.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/dot.php
+++ b/src/views/v2/components/icons/dot.php
@@ -3,7 +3,7 @@
  * View: Dot Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/dot.php
+ * [your-theme]/tribe/events/v2/components/icons/dot.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/error.php
+++ b/src/views/v2/components/icons/error.php
@@ -3,7 +3,7 @@
  * View: Error Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/error.php
+ * [your-theme]/tribe/events/v2/components/icons/error.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/featured.php
+++ b/src/views/v2/components/icons/featured.php
@@ -3,7 +3,7 @@
  * View: Featured Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/featured.php
+ * [your-theme]/tribe/events/v2/components/icons/featured.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/filter.php
+++ b/src/views/v2/components/icons/filter.php
@@ -3,7 +3,7 @@
  * View: Filter Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/filter.php
+ * [your-theme]/tribe/events/v2/components/icons/filter.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/hybrid.php
+++ b/src/views/v2/components/icons/hybrid.php
@@ -3,7 +3,7 @@
  * View: Hybrid Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/hybrid.php
+ * [your-theme]/tribe/events/v2/components/icons/hybrid.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/list.php
+++ b/src/views/v2/components/icons/list.php
@@ -3,7 +3,7 @@
  * View: List Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/list.php
+ * [your-theme]/tribe/events/v2/components/icons/list.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/location.php
+++ b/src/views/v2/components/icons/location.php
@@ -3,7 +3,7 @@
  * View: Location Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/location.php
+ * [your-theme]/tribe/events/v2/components/icons/location.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/mail.php
+++ b/src/views/v2/components/icons/mail.php
@@ -3,7 +3,7 @@
  * View: Mail Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/mail.php
+ * [your-theme]/tribe/events/v2/components/icons/mail.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/map-pin.php
+++ b/src/views/v2/components/icons/map-pin.php
@@ -3,7 +3,7 @@
  * View: Map Pin Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/map-pin.php
+ * [your-theme]/tribe/events/v2/components/icons/map-pin.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/map.php
+++ b/src/views/v2/components/icons/map.php
@@ -3,7 +3,7 @@
  * View: Map Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/map.php
+ * [your-theme]/tribe/events/v2/components/icons/map.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/messages-not-found.php
+++ b/src/views/v2/components/icons/messages-not-found.php
@@ -3,7 +3,7 @@
  * View: Messages Not Found Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/messages-not-found.php
+ * [your-theme]/tribe/events/v2/components/icons/messages-not-found.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/minus.php
+++ b/src/views/v2/components/icons/minus.php
@@ -3,7 +3,7 @@
  * View: Minus Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/minus.php
+ * [your-theme]/tribe/events/v2/components/icons/minus.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/month.php
+++ b/src/views/v2/components/icons/month.php
@@ -3,7 +3,7 @@
  * View: Month Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/month.php
+ * [your-theme]/tribe/events/v2/components/icons/month.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/no-map.php
+++ b/src/views/v2/components/icons/no-map.php
@@ -3,7 +3,7 @@
  * View: No Map Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/no-map.php
+ * [your-theme]/tribe/events/v2/components/icons/no-map.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/phone.php
+++ b/src/views/v2/components/icons/phone.php
@@ -3,7 +3,7 @@
  * View: Phone Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/phone.php
+ * [your-theme]/tribe/events/v2/components/icons/phone.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/photo.php
+++ b/src/views/v2/components/icons/photo.php
@@ -3,7 +3,7 @@
  * View: Photo Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/photo.php
+ * [your-theme]/tribe/events/v2/components/icons/photo.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/play.php
+++ b/src/views/v2/components/icons/play.php
@@ -3,7 +3,7 @@
  * View: Play Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/play.php
+ * [your-theme]/tribe/events/v2/components/icons/play.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/plus.php
+++ b/src/views/v2/components/icons/plus.php
@@ -3,7 +3,7 @@
  * View: Plus Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/plus.php
+ * [your-theme]/tribe/events/v2/components/icons/plus.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/recurring.php
+++ b/src/views/v2/components/icons/recurring.php
@@ -3,7 +3,7 @@
  * View: Recurring Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/recurring.php
+ * [your-theme]/tribe/events/v2/components/icons/recurring.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/reset.php
+++ b/src/views/v2/components/icons/reset.php
@@ -3,7 +3,7 @@
  * View: Reset Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/reset.php
+ * [your-theme]/tribe/events/v2/components/icons/reset.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/search.php
+++ b/src/views/v2/components/icons/search.php
@@ -3,7 +3,7 @@
  * View: Search Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/search.php
+ * [your-theme]/tribe/events/v2/components/icons/search.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/summary.php
+++ b/src/views/v2/components/icons/summary.php
@@ -3,7 +3,7 @@
  * View: Summary Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/summary.php
+ * [your-theme]/tribe/events/v2/components/icons/summary.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/video.php
+++ b/src/views/v2/components/icons/video.php
@@ -3,7 +3,7 @@
  * View: Video Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/video.php
+ * [your-theme]/tribe/events/v2/components/icons/video.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/virtual.php
+++ b/src/views/v2/components/icons/virtual.php
@@ -3,7 +3,7 @@
  * View: Virtual Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/virtual.php
+ * [your-theme]/tribe/events/v2/components/icons/virtual.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/website.php
+++ b/src/views/v2/components/icons/website.php
@@ -3,7 +3,7 @@
  * View: Website Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/website.php
+ * [your-theme]/tribe/events/v2/components/icons/website.php
  *
  * See more documentation about our views templating system.
  *

--- a/src/views/v2/components/icons/week.php
+++ b/src/views/v2/components/icons/week.php
@@ -3,7 +3,7 @@
  * View: Week Icon
  *
  * Override this template in your own theme by creating a file at:
- * [your-theme]/tribe/v2/components/icons/week.php
+ * [your-theme]/tribe/events/v2/components/icons/week.php
  *
  * See more documentation about our views templating system.
  *


### PR DESCRIPTION
 [TEC-4111]

Simply updating docs with the correct override path:

![image](https://user-images.githubusercontent.com/2826045/142686023-731b4b0e-9b5c-4c3c-b128-2c5aff9a13e6.png)


[TEC-4111]: https://theeventscalendar.atlassian.net/browse/TEC-4111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ