### PR TITLE
Prevent PHP 8 warnings when running extensions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 = [4.14.9] TBD =
 
 * Feature - Add loader template for the admin views. [VE-435]
-* Fix - Prevent PHP 8 warnings when using extensions. [TEC-4165]
+* Fix - Prevent PHP 8 warnings when using extensions. (props to @huubl for this fix!) [TEC-4165]
 
 = [4.14.8] 2021-11-17 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [4.14.9] TBD =
 
 * Feature - Add loader template for the admin views. [VE-435]
+* Fix - Prevent PHP 8 warnings when using extensions. [TEC-4165]
 
 = [4.14.8] 2021-11-17 =
 

--- a/src/Tribe/Plugin_Meta_Links.php
+++ b/src/Tribe/Plugin_Meta_Links.php
@@ -124,7 +124,7 @@ class Tribe__Plugin_Meta_Links {
 	 *
 	 * @return void
 	 */
-	final private function __clone() {
+	final public function __clone() {
 		_doing_it_wrong(
 			__FUNCTION__,
 			'Can not use this method on singletons.',
@@ -137,7 +137,7 @@ class Tribe__Plugin_Meta_Links {
 	 *
 	 * @return void
 	 */
-	final private function __wakeup() {
+	final public function __wakeup() {
 		_doing_it_wrong(
 			__FUNCTION__,
 			'Can not use this method on singletons.',


### PR DESCRIPTION
This fix is non-impactful for the codebase at large as the fix is on `final private` methods being turned to `final public`. I've provided an artifact that shows the absence of warnings when running PHP 8.

Props to @huubl for this fix! (original fix can be found [here](https://github.com/the-events-calendar/tribe-common/pull/1675))

🎫 [TEC-4165]
🎥 https://d.pr/v/z4M30Q

[TEC-4165]: https://theeventscalendar.atlassian.net/browse/TEC-4165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ