### PR TITLE
dev: fix `$default` param types for `tribe_get_option()`

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -19,8 +19,8 @@ if ( ! function_exists( 'tribe_get_option' ) ) {
 	 * Retrieve specific key from options array, optionally provide a default return value
 	 *
 	 * @category Events
-	 * @param string $optionName Name of the option to retrieve.
-	 * @param string $default    Value to return if no such option is found.
+	 * @param string      $optionName Name of the option to retrieve.
+	 * @param bool|string $default    Value to return if no such option is found.
 	 *
 	 * @return mixed Value of the option if found.
 	 * @todo Abstract this function out of template tags or otherwise secure it from other namespace conflicts.


### PR DESCRIPTION
This PR changes the `$default` param in `tribe_get_option()` to `string|bool`, considering that's how TEC core uses the function.

Fixes:
![image](https://user-images.githubusercontent.com/29322304/147897409-99bfb6fa-18ca-41fe-a902-5830b966a1f1.png)

Justification:
![image](https://user-images.githubusercontent.com/29322304/147897378-88272fb8-b93d-4db5-83f4-99fb545e5653.png)
