### PR TITLE
[ET-1249] Fixed template path not working for installations with `v2` in dir path.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 
 = [TBD] TBD =
 
+* Fix - Fixed template paths for WP installs with `v2` in directory path. [ET-1249]
 * Fix - Remove incorrect reference for moment.min.js.map [TEC-4148]
 
 = [4.14.12] 2022-01-17 =

--- a/src/Tribe/Utils/Paths.php
+++ b/src/Tribe/Utils/Paths.php
@@ -56,6 +56,12 @@ class Paths {
 			: array_filter( (array) preg_split( $break_pattern, $path_2 ), $drop_empty_strings );
 		$non_consecutive_common = array_intersect( $path_1_frags, $path_2_frags );
 
+		$has_v2 = array_search( 'v2', $non_consecutive_common, true );
+
+		if ( false !== $has_v2 ) {
+			unset( $non_consecutive_common[ $has_v2 ] );
+		}
+
 		$trimmed_path_2 = trim(
 			preg_replace(
 				'#^' . preg_quote( implode( DIRECTORY_SEPARATOR, $non_consecutive_common ), '#' ) . '#', '',

--- a/tests/unit/Tribe/Utils/Paths_Test.php
+++ b/tests/unit/Tribe/Utils/Paths_Test.php
@@ -48,6 +48,10 @@ class Paths_Test extends \Codeception\Test\Unit {
 
 	public function valid_falsy_paths_data_provider(  ) {
 	return [
+		'dir with v2' => [
+			'/home/vps-49f1a7/v2/staging_html/wp-content/plugins/the-events-calendar/common/src/views',
+			'/home/vps-49f1a7/v2/staging_html/wp-content/plugins/the-events-calendar/common/src/views/v2/base'
+		],
 		'dir called 0' => [
 			'/home/vps-49f1a7/0/staging_html/wp-content/plugins/the-events-calendar/common/src/views',
 			'/home/vps-49f1a7/0/staging_html/wp-content/plugins/the-events-calendar/common/src/views/v2/base'


### PR DESCRIPTION
[ET-1249]
[BTRIA-920]

**Description:**
If the WordPress installation directory had `v2` in the path then templates that are coming from the `v2` directory in our plugins were not working.

<img width="872" alt="Screen Shot 2022-01-31 at 9 44 00 AM" src="https://user-images.githubusercontent.com/7523321/151735929-9de6c53b-2993-4c19-a16a-77db3ccf31e8.png">



[ET-1249]: https://theeventscalendar.atlassian.net/browse/ET-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BTRIA-920]: https://theeventscalendar.atlassian.net/browse/BTRIA-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ