### PR TITLE
Don't make a singleton of a deprecated class.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 
 * Fix - Update the way we handle Classic Editor compatibility. Specifically around user choice. [TEC-4016]
 * Fix - Remove incorrect reference for moment.min.js.map [TEC-4148]
-* Fix - Remove singleton created from a deprecated class. [TBD]
+* Fix - Remove singleton created from a deprecated class.
 
 = [4.14.12] 2022-01-17 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 * Fix - Update the way we handle Classic Editor compatibility. Specifically around user choice. [TEC-4016]
 * Fix - Remove incorrect reference for moment.min.js.map [TEC-4148]
+* Fix - Remove singleton created from a deprecated class. [TBD]
 
 = [4.14.12] 2022-01-17 =
 

--- a/src/Tribe/Admin/Notice/Service_Provider.php
+++ b/src/Tribe/Admin/Notice/Service_Provider.php
@@ -27,7 +27,6 @@ class Service_Provider extends \tad_DI52_ServiceProvider {
 		tribe_singleton( 'pue.notices', 'Tribe__PUE__Notices' );
 		tribe_singleton( WP_Version::class, WP_Version::class, [ 'hook' ] );
 		tribe_singleton( 'admin.notice.php.version', 'Tribe__Admin__Notice__Php_Version', [ 'hook' ] );
-		tribe_singleton( 'admin.notice.marketing', 'Tribe__Admin__Notice__Marketing', [ 'hook' ] );
 		tribe_singleton( Marketing\Stellar_Sale::class, Marketing\Stellar_Sale::class, [ 'hook' ] );
 
 		$this->hooks();


### PR DESCRIPTION
ref: https://lw.slack.com/archives/C01SYM19N7K/p1643794119030199

@here I’ve just merged latest release/B22.knish into RBE and see a deprecation notice for the src/Tribe/Admin/Notice/Marketing.php file, from Common.
Called here: https://github.com/the-events-calendar/tribe-common/blob/959a9d5cbf80ee88d6e7ed04ea29b08eb128c748/src/Tribe/Admin/Notice/Service_Provider.php#L30
Should this call be removed?
I see the same in master on Common:
call: https://github.com/the-events-calendar/tribe-common/blob/master/src/Tribe/Admin/Notice/Service_Provider.php#L30
deprecation: https://github.com/the-events-calendar/tribe-common/blob/master/src/Tribe/Admin/Notice/Marketing.php#L2