### PR TITLE
Don't test current_screen - it's not always available

### DIFF
--- a/src/Tribe/Editor/Compatibility/Classic_Editor.php
+++ b/src/Tribe/Editor/Compatibility/Classic_Editor.php
@@ -158,15 +158,7 @@ class Classic_Editor {
 	public function hooks() {
 		add_action( 'tribe_plugins_loaded', [ $this, 'set_classic_url_params' ], 22 );
 
-		global $current_screen;
-		$good_screens = [
-			'post-new.php',
-			'post.php',
-		];
-
-		if ( ! empty( $current_screen ) && in_array( $current_screen, $good_screens ) ) {
-			add_filter( 'tribe_editor_should_load_blocks', [ $this, 'filter_tribe_editor_should_load_blocks' ], 20 );
-		}
+		add_filter( 'tribe_editor_should_load_blocks', [ $this, 'filter_tribe_editor_should_load_blocks' ], 20 );
 	}
 
 	/**


### PR DESCRIPTION
We call should_load_blocks() too early for current_screen to be set up in some cases - so remove that check to prevent false negatives.

https://d.pr/i/vPNvHJ

[TEC-4016]

[TEC-4016]: https://theeventscalendar.atlassian.net/browse/TEC-4016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ