### PR TITLE
use the precision getter to make sure filters are run

### DIFF
--- a/src/Tribe/Values/Value_Calculation.php
+++ b/src/Tribe/Values/Value_Calculation.php
@@ -66,6 +66,6 @@ trait Value_Calculation {
 	 * @return int
 	 */
 	public function to_integer( $value ) {
-		return (int) ( round( $value, $this->precision ) * pow( 10, $this->precision ) );
+		return (int) ( round( $value, $this->get_precision() ) * pow( 10, $this->get_precision() ) );
 	}
 }


### PR DESCRIPTION
[GTPLAN-82]

Currencies with zero decimals such as JPY need to filter the `precision` value to fit their standards, and this method was not using the filters.

[GTPLAN-82]: https://theeventscalendar.atlassian.net/browse/GTPLAN-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ