### PR TITLE
Fix typo: `groups` not `group`

### DIFF
--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -107,7 +107,7 @@ class Tribe__Admin__Notices {
 			[ 'jquery' ],
 			null,
 			[
-				'group' => 'tec-admin-notices',
+				'groups' => 'tec-admin-notices',
 			]
 		);
 	}


### PR DESCRIPTION
There was a small typo found that was preventing the use of dismissible notices.