### PR TITLE
fix duplicate 'Event Add-Ons' item in admin menu

### DIFF
--- a/src/Tribe/Admin/Troubleshooting.php
+++ b/src/Tribe/Admin/Troubleshooting.php
@@ -120,7 +120,7 @@ class Troubleshooting {
 
 		$wp_admin_bar->add_menu( [
 			'id'     => 'tec-troubleshooting',
-			'title'  => esc_html__( 'Event Add-Ons', 'tribe-common' ),
+			'title'  => esc_html__( 'Event Troubleshooting', 'tribe-common' ),
 			'href'   => Tribe__Settings::instance()->get_url( [ 'page' => static::MENU_SLUG ] ),
 			'parent' => 'tribe-events-settings-group',
 		] );


### PR DESCRIPTION
The Events menu in the admin bar lists Event Add-Ons twice. The second one links to the troubleshooting page. This changes the text to Event Troubleshooting.