### PR TITLE
[ET-1447] Modify logic of `filter_modify_to_module`.

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -181,7 +181,10 @@ class Tribe__Assets {
 		}
 
 		// Do not add Module to a Script that already has a type.
-		if ( false !== strpos( $tag, ' type=' ) ) {
+		if (
+			false !== strpos( $tag, ' type=' )
+			&& current_theme_supports( 'html5', 'script' ) // These themes already have the `type="text/javascript"` added by WordPress core.
+		) {
 			return $tag;
 		}
 

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -180,12 +180,11 @@ class Tribe__Assets {
 			return $tag;
 		}
 
-		// Do not add Module to a Script that already has a type.
-		if (
-			false !== strpos( $tag, ' type=' )
-			&& current_theme_supports( 'html5', 'script' ) // These themes already have the `type="text/javascript"` added by WordPress core.
-		) {
-			return $tag;
+		// These themes already have the `type='text/javascript'` added by WordPress core.
+		if ( ! current_theme_supports( 'html5', 'script' ) ) {
+			$replacement = 'type="module"';
+
+			return str_replace( "type='text/javascript'", $replacement, $tag );
 		}
 
 		$replacement = '<script type="module" ';


### PR DESCRIPTION
[ET-1447]

Modify logic of `filter_modify_to_module` so that we can safely set as module those assets that are loaded in themes without support for `html5`, `scripts`. (WordPress is adding type in core, and we weren't accounting for that: https://github.com/WordPress/wordpress-develop/blob/8cc9e53847f8a46258d9e42c29f8d524ec0af592/src/wp-includes/script-loader.php#L2013)

https://user-images.githubusercontent.com/252415/157252395-562c6a39-7d22-4b8b-9df7-f3b4b60e5c31.mov




[ET-1447]: https://theeventscalendar.atlassian.net/browse/ET-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ