### PR TITLE
fix tribe.ky undefined

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -208,7 +208,7 @@ class Tribe__Main {
 				[ 'tribe-timepicker', 'timepicker.js', [ 'jquery', 'tribe-jquery-timepicker' ] ],
 				[ 'tribe-attrchange', 'vendor/attrchange/js/attrchange.js' ],
 				[ 'tec-ky-module', 'vendor/ky/ky.js', [], null, [ 'module' => true ] ],
-				[ 'tec-ky', 'vendor/ky/tec-ky.js', [ 'tec-ky-module' ], null, [ 'module' => true ] ],
+				[ 'tec-ky', 'vendor/ky/tec-ky.js', [ 'tec-ky-module' ] ],
 			]
 		);
 

--- a/vendor/ky/tec-ky.js
+++ b/vendor/ky/tec-ky.js
@@ -1,2 +1,4 @@
-import ky from './ky.min.js';
-tribe.ky = ky;
+(async () => {
+	const ky = await import('./ky.min.js');
+	window.tribe.ky = ky;
+})

--- a/vendor/ky/tec-ky.js
+++ b/vendor/ky/tec-ky.js
@@ -1,2 +1,2 @@
-import ky from './ky.min';
+import ky from './ky.min.js';
 tribe.ky = ky;

--- a/vendor/ky/tec-ky.js
+++ b/vendor/ky/tec-ky.js
@@ -1,2 +1,3 @@
-import ky from './ky.min.js';
-tribe.ky = ky;
+import( './ky.min.js' ).then( (ky) => {
+	tribe.ky = ky.default;
+});

--- a/vendor/ky/tec-ky.js
+++ b/vendor/ky/tec-ky.js
@@ -1,4 +1,2 @@
-(async () => {
-	const ky = await import('./ky.min.js');
-	window.tribe.ky = ky;
-})
+import ky from './ky.min';
+tribe.ky = ky;


### PR DESCRIPTION
In some cases, even with the scripts loading in the proper order, the `import` statement in `tec-ky.js` is not resolving fast enough so when the checkout script tries to read `tribe.ky` it is still undefined.

~So we'll make it synchronous.~ This actually didn't work properly.

**Updated theory:** 

the issue here seems to stem from the fact that scripts loaded with `type=module` [are deferred by default](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#attr-defer). Modules are loaded when they are requested by other scripts. Given that we never import `tec-ky` directly, it gets executed automatically **but** only after `DOMContentLoaded`. In some cases this is too late, since that's the same event used to hydrate the checkout script.

So the new proposed solution is to not load `tec-ky` as a module. We keep it dependent on `tec-ky-module` so the script tags are placed in order, but have `tec-ky` execute immediately, and populate `tribe.ky` only after the promise is resolved. This may be enough to guarantee that it wil alwaysl be available for `checkout.js`