### PR TITLE
Correct AdminBar menu item.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Correct Troubleshooting Menu Item label in Admin Bar. [TBD]
+
 = [4.14.15] 2022-03-01 =
 
 * Tweak - Update version of Freemius to 2.4.3.

--- a/src/Tribe/Admin/Troubleshooting.php
+++ b/src/Tribe/Admin/Troubleshooting.php
@@ -120,7 +120,7 @@ class Troubleshooting {
 
 		$wp_admin_bar->add_menu( [
 			'id'     => 'tec-troubleshooting',
-			'title'  => esc_html__( 'Event Add-Ons', 'tribe-common' ),
+			'title'  => esc_html__( 'Event Troubleshooting', 'tribe-common' ),
 			'href'   => Tribe__Settings::instance()->get_url( [ 'page' => static::MENU_SLUG ] ),
 			'parent' => 'tribe-events-settings-group',
 		] );

--- a/src/Tribe/Admin/Troubleshooting.php
+++ b/src/Tribe/Admin/Troubleshooting.php
@@ -120,7 +120,7 @@ class Troubleshooting {
 
 		$wp_admin_bar->add_menu( [
 			'id'     => 'tec-troubleshooting',
-			'title'  => esc_html__( 'Event Troubleshooting', 'tribe-common' ),
+			'title'  => esc_html__( 'Troubleshooting', 'tribe-common' ),
 			'href'   => Tribe__Settings::instance()->get_url( [ 'page' => static::MENU_SLUG ] ),
 			'parent' => 'tribe-events-settings-group',
 		] );


### PR DESCRIPTION
It currently says "Event Add-Ons" it should say "Troubleshooting"

props @welbinator

[BTRIA-1155]

[BTRIA-1155]: https://theeventscalendar.atlassian.net/browse/BTRIA-1155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ