### PR TITLE
[ET-1351] tweak padding to ensure everything is centered

### DIFF
--- a/src/resources/postcss/tribe-common-admin/_upsell.pcss
+++ b/src/resources/postcss/tribe-common-admin/_upsell.pcss
@@ -44,7 +44,7 @@
 	.tec-admin__upsell--rounded-corners-text .tec-admin__upsell-text-wrap{
 		background: rgba(51, 74, 255, 0.1);
 		border-radius: 14px;
-		padding: var(--tec-spacer-1) var(--tec-spacer-2) var(--tec-spacer-0);
+		padding: var(--tec-spacer-1) var(--tec-spacer-2);
 	}
 
 	.tec-admin__upsell-link--dark {


### PR DESCRIPTION
This is a quick tweak to the CSS to make sure text is centered vertically.

Original PR was here: https://github.com/the-events-calendar/tribe-common/pull/1727

Ticket: [ET-1351]

[ET-1351]: https://theeventscalendar.atlassian.net/browse/ET-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ