### PR TITLE
Don't run the pipeline in the admin

### DIFF
--- a/src/Tribe/Assets_Pipeline.php
+++ b/src/Tribe/Assets_Pipeline.php
@@ -47,6 +47,7 @@ class Tribe__Assets_Pipeline {
 	 * After select2 is loaded to the FE we add one scripts after to prevent select2 from breaking.
 	 *
 	 * @since 4.13.2
+	 * @since TBD ensure we don't run this in the admin.
 	 *
 	 * @param string $tag    The <script> tag for the enqueued script.
 	 * @param string $handle The script's registered handle.
@@ -54,6 +55,10 @@ class Tribe__Assets_Pipeline {
 	 * @return string The <script> tag.
 	 */
 	public function prevent_select2_conflict( $tag, $handle ) {
+		if ( is_admin() ) {
+			return $tag;
+		}
+
 		if ( 'tribe-select2' !== $handle ) {
 			return $tag;
 		}

--- a/src/Tribe/Widget/Widget_Abstract.php
+++ b/src/Tribe/Widget/Widget_Abstract.php
@@ -285,11 +285,11 @@ abstract class Widget_Abstract extends \WP_Widget implements Widget_Interface {
 		// Specifically on the admin we force the admin fields into the arguments.
 		$this->arguments['admin_fields'] = $this->get_admin_fields();
 
-		$this->toggle_hooks( true );
+		$this->toggle_hooks( true, 'form' );
 
 		$html = $this->get_admin_html( $this->get_arguments() );
 
-		$this->toggle_hooks( false );
+		$this->toggle_hooks( false, 'form' );
 		return $html;
 	}
 
@@ -302,11 +302,11 @@ abstract class Widget_Abstract extends \WP_Widget implements Widget_Interface {
 
 		$this->setup( $args, $instance );
 
-		$this->toggle_hooks( true );
+		$this->toggle_hooks( true, 'display' );
 
 		$html = $this->get_html();
 
-		$this->toggle_hooks( false );
+		$this->toggle_hooks( false, 'display' );
 
 		echo $html;
 
@@ -792,15 +792,20 @@ abstract class Widget_Abstract extends \WP_Widget implements Widget_Interface {
 	 *
 	 * @since 4.13.0
 	 *
-	 * @param bool $toggle Whether to turn the hooks on or off.
+	 * @param bool   $toggle Whether to turn the hooks on or off.
+	 * @param string $location If we are doing the form (admin) or the display (front end)
 	 *
 	 * @return void
 	 */
-	public function toggle_hooks( $toggle ) {
+	public function toggle_hooks( $toggle, $location ) {
+		$slug = static::get_widget_slug();
+
 		if ( $toggle ) {
+			do_action( 'tec_start_widget_' . $location, $slug );
 			$this->add_hooks();
 		} else {
 			$this->remove_hooks();
+			do_action( 'tec_end_widget_' . $location, $slug );
 		}
 
 		/**


### PR DESCRIPTION
It causes duplicate dropdowns. See [ECP-1042]

Also, add actions to the widget add/remove_hooks. Used to trigger the asset loading. See [ECP-651]

[TEC_4315]

[ECP-1042]: https://theeventscalendar.atlassian.net/browse/ECP-1042?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ECP-651]: https://theeventscalendar.atlassian.net/browse/ECP-651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ