### PR TITLE
Ensure the classic "forget" param overrides all else.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 = [TBD] TBD =
 
 * Tweak - Added EA status row showing if it is enabled or disabled in the Event Aggregator system status [TCMN-134]
-* Fix - Ensure the classic "forget" param overrides all else when loading the editor w/Classic Editor active. [TEC-4287]
+* Fix - Ensure the Classic Editor "forget" parameter overrides all else when loading the editor w/Classic Editor active. [TEC-4287]
 * Fix - Do not autoload options used to save batched data. [EA-427]
 * Fix - Update bootstrap logic to make sure Common will correctly load completely in the context of plugin activations requests. [TEC-4338]
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [TBD] TBD =
 
 * Tweak - Added EA status row showing if it is enabled or disabled in the Event Aggregator system status [TCMN-134]
+* Fix - Ensure the classic "forget" param overrides all else when loading the editor w/Classic Editor active. [TEC-4287]
 * Fix - Do not autoload options used to save batched data. [EA-427]
 * Fix - Update bootstrap logic to make sure Common will correctly load completely in the context of plugin activations requests. [TEC-4338]
 

--- a/src/Tribe/Editor/Compatibility/Classic_Editor.php
+++ b/src/Tribe/Editor/Compatibility/Classic_Editor.php
@@ -264,7 +264,7 @@ class Classic_Editor {
 			$should_load_blocks = false;
 		}
 
-		// The "forget" param still overrides all...
+		// The override param inverts whatever else is set via parameter/preference.
 		if ( static::get_classic_override() ) {
 			$should_load_blocks = ! $should_load_blocks;
 		}

--- a/src/Tribe/Editor/Compatibility/Classic_Editor.php
+++ b/src/Tribe/Editor/Compatibility/Classic_Editor.php
@@ -236,7 +236,7 @@ class Classic_Editor {
 		}
 
 		if ( static::get_classic_override() ) {
-			$should_load_blocks = true;
+			$should_load_blocks = ! $should_load_blocks;
 		}
 
 		if ( static::get_classic_param() ) {
@@ -262,6 +262,11 @@ class Classic_Editor {
 			$should_load_blocks = true;
 		} else if ( static::$classic_term === $profile_choice ) {
 			$should_load_blocks = false;
+		}
+
+		// The "forget" param still overrides all...
+		if ( static::get_classic_override() ) {
+			$should_load_blocks = ! $should_load_blocks;
 		}
 
 		return $should_load_blocks;


### PR DESCRIPTION
This allows use of hte link in the editor to switch on the fly.

Bad: https://lw.slack.com/files/U01H2U7LZ0W/F03B1TA7CM6/screen_recording_2022-04-06_at_15.53.41.mov
Good: https://d.pr/v/o8262J


[TEC-4287]

[TEC-4287]: https://theeventscalendar.atlassian.net/browse/TEC-4287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ