### PR TITLE
[ETP-792] Fix admin links with target and rel attributes

### DIFF
--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -143,7 +143,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 			$label_attributes = $args['label_attributes'];
 			$tooltip    = wp_kses(
 				$args['tooltip'], [
-					'a'      => [  'class' => [], 'href' => [], 'title' => [], 'target' => [] ],
+					'a'      => [  'class' => [], 'href' => [], 'title' => [], 'target' => [], 'rel' => [] ],
 					'br'     => [],
 					'em'     => [ 'class' => [] ],
 					'strong' => [ 'class' => [] ],

--- a/src/admin-views/tribe-options-general.php
+++ b/src/admin-views/tribe-options-general.php
@@ -11,17 +11,17 @@ $generalTabFields = [
 	],
 	'event-tickets-info' => [
 		'type'        => 'html',
-		'html'        => '<p>' . sprintf( esc_html__( 'Thank you for using Event Tickets! All of us at The Events Calendar sincerely appreciate your support and we\'re excited to see you using our plugins. Check out our handy %1$sNew User Primer%2$s to get started.', 'tribe-common' ), '<a href="http://evnt.is/18nd">', '</a>' ) . '</p>',
+		'html'        => '<p>' . sprintf( esc_html__( 'Thank you for using Event Tickets! All of us at The Events Calendar sincerely appreciate your support and we\'re excited to see you using our plugins. Check out our handy %1$sNew User Primer%2$s to get started.', 'tribe-common' ), '<a target="_blank" rel="noopener noreferrer" href="http://evnt.is/18nd">', '</a>' ) . '</p>',
 		'conditional' => ! class_exists( 'Tribe__Events__Main' ),
 	],
 	'event-tickets-upsell-info' => [
 		'type'        => 'html',
-		'html'        => '<p>' . sprintf( esc_html__( 'Optimize your site\'s event listings with %1$sThe Events Calendar%2$s, our free calendar plugin. Looking for additional functionality including recurring events, user-submission, advanced ticket sales and more? Check out our %3$spremium add-ons%4$s.', 'tribe-common' ), '<a href="http://evnt.is/18x6">', '</a>', '<a href="http://evnt.is/18x5">', '</a>' ) . '</p>',
+		'html'        => '<p>' . sprintf( esc_html__( 'Optimize your site\'s event listings with %1$sThe Events Calendar%2$s, our free calendar plugin. Looking for additional functionality including recurring events, user-submission, advanced ticket sales and more? Check out our %3$spremium add-ons%4$s.', 'tribe-common' ), '<a target="_blank" rel="noopener noreferrer" href="http://evnt.is/18x6">', '</a>', '<a target="_blank" rel="noopener noreferrer" href="http://evnt.is/18x5">', '</a>' ) . '</p>',
 		'conditional' => ! class_exists( 'Tribe__Events__Main' ),
 	],
 	'upsell-info'                   => [
 		'type'        => 'html',
-		'html'        => '<p>' . esc_html__( 'Looking for additional functionality including recurring events, custom meta, community events, ticket sales and more?', 'tribe-common' ) . ' <a href="' . Tribe__Main::$tec_url . 'products/?utm_source=generaltab&utm_medium=plugin-tec&utm_campaign=in-app">' . esc_html__( 'Check out the available add-ons', 'tribe-common' ) . '</a>.</p>',
+		'html'        => '<p>' . esc_html__( 'Looking for additional functionality including recurring events, custom meta, community events, ticket sales and more?', 'tribe-common' ) . ' <a target="_blank" rel="noopener noreferrer" href="' . Tribe__Main::$tec_url . 'products/?utm_source=generaltab&utm_medium=plugin-tec&utm_campaign=in-app">' . esc_html__( 'Check out the available add-ons', 'tribe-common' ) . '</a>.</p>',
 		'conditional' => ( ! tec_should_hide_upsell() ) && class_exists( 'Tribe__Events__Main' ),
 	],
 	'donate-link-heading'           => [
@@ -60,7 +60,7 @@ if ( is_super_admin() ) {
 				'Enable this option to log debug information. By default this will log to your server PHP error log. If you\'d like to see the log messages in your browser, then we recommend that you install the %s and look for the "Tribe" tab in the debug output.',
 				'tribe-common'
 			),
-			'<a href="https://wordpress.org/extend/plugins/debug-bar/" target="_blank">' . esc_html__( 'Debug Bar Plugin', 'tribe-common' ) . '</a>'
+			'<a target="_blank" rel="noopener noreferrer" href="https://wordpress.org/extend/plugins/debug-bar/">' . esc_html__( 'Debug Bar Plugin', 'tribe-common' ) . '</a>'
 		),
 		'default'         => false,
 		'validation_type' => 'boolean',


### PR DESCRIPTION
[ETP-792]

* Added support for `rel` attribute on setting field `tooltip` item.
* Added missing target and rel attribute on welcome text for ET settings.

[ETP-792]: https://theeventscalendar.atlassian.net/browse/ETP-792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ