### PR TITLE
Avoid loops caused by meta update tracker.

### DIFF
--- a/src/Tribe/Tracker.php
+++ b/src/Tribe/Tracker.php
@@ -282,8 +282,12 @@ class Tribe__Tracker {
 		// If we got here we will update the Modified Meta
 		$modified[ $meta_key ] = $now;
 
+		// Avoid loops!
+		remove_filter( 'update_post_metadata', [ $this, 'filter_watch_updated_meta' ], PHP_INT_MAX - 1 );
 		// Actually do the Update
 		update_post_meta( $post->ID, self::$field_key, $modified );
+		// Safe to filter again.
+		add_filter( 'update_post_metadata', [ $this, 'filter_watch_updated_meta' ], PHP_INT_MAX - 1, 5 );
 
 		// We need to return this, because we are still on a filter
 		return $check;


### PR DESCRIPTION
We run `filter_watch_updated_meta` on the `update_post_metadata` hook, and then we run `update_post_meta` inside it.

Let's prevent looping.

[ECP-1203]

[ECP-1203]: https://theeventscalendar.atlassian.net/browse/ECP-1203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ