### PR TITLE
TEC 6.0 Update page

### DIFF
--- a/src/Tribe/Admin/Activation_Page.php
+++ b/src/Tribe/Admin/Activation_Page.php
@@ -168,6 +168,19 @@ class Tribe__Admin__Activation_Page {
 		if ( $this->is_new_install() ) {
 			$this->redirect_to_welcome_page();
 		}
+
+		/**
+		 * Filters whether we should disable the update page redirect.
+		 *
+		 * @param bool 
+		 */
+		$bypass_update_page = apply_filters( 'tec_admin_update_page_bypass', false );
+		
+		if ( $bypass_update_page ) {
+			return;
+		}
+
+		$this->redirect_to_update_page();
 	}
 
 	/**

--- a/src/Tribe/Plugins_API.php
+++ b/src/Tribe/Plugins_API.php
@@ -71,9 +71,10 @@ class Tribe__Plugins_API {
 				'description-help' => __( 'The #1 calendar for WordPress', 'tribe-common' ),
 				'features'        => [
 					__( 'Premium support', 'tribe-common' ),
-					__( 'Recurring events', 'tribe-common' ),
+					__( 'Recurring events & series', 'tribe-common' ),
 					__( 'Additional views', 'tribe-common' ),
 					__( 'Shortcodes', 'tribe-common' ),
+					__( 'Duplicate events', 'tribe-common' ),
 				],
 				'image'           => 'images/shop/pro.jpg',
 				'logo'            => 'images/logo/events-calendar-pro.svg',


### PR DESCRIPTION
[ECP-1144]

The work in this PR adds a filter for whether to display the updates admin page when users update the events calendar.

When active, users will be taken to the following page after updating:
<img width="958" alt="Screen Shot 2022-06-16 at 9 32 48 AM" src="https://user-images.githubusercontent.com/1430876/174095903-aa69fce6-93eb-4eb4-87ac-657913b5bd20.png">



[ECP-1144]: https://theeventscalendar.atlassian.net/browse/ECP-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ