### PR TITLE
Add the Arr::usearch method

### DIFF
--- a/src/Tribe/Utils/Array.php
+++ b/src/Tribe/Utils/Array.php
@@ -704,5 +704,29 @@ if ( ! class_exists( 'Tribe__Utils__Array' ) ) {
 
 			return $shaped;
 		}
+
+		/**
+		 * Searches an array using a callback and returns the index of the first match.
+		 *
+		 * This method fills the gap left by the non-existence of an `array_usearch` function.
+		 *
+		 * @since TBD
+		 *
+		 * @param mixed    $needle   The element to search in the array.
+		 * @param array    $haystack The array to search.
+		 * @param callable $callback A callback function with signature `fn($needle, $value, $key) :bool`
+		 *                           that will be used to find the first match of needle in haystack.
+		 *
+		 * @return string|int|false Either the index of the first match or `false` if no match was found.
+		 */
+		public static function usearch( $needle, array $haystack, callable $callback ) {
+			foreach ( $haystack as $key => $value ) {
+				if ( $callback( $needle, $value, $key ) ) {
+					return $key;
+				}
+			}
+
+			return false;
+		}
 	}
 }

--- a/tests/unit/Tribe/Utils/ArrayTest.php
+++ b/tests/unit/Tribe/Utils/ArrayTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Tribe__Utils__Array as Arr;
+
 class Tribe__Utils__Array_Test extends \Codeception\Test\Unit {
 	public function shape_filter_data_provider() {
 		$test_shape = [
@@ -299,7 +301,55 @@ class Tribe__Utils__Array_Test extends \Codeception\Test\Unit {
 	 * @dataProvider shape_filter_data_provider
 	 */
 	public function test_shape_filter( array $input, array $shape, array $expected ) {
-		$shaped = Tribe__Utils__Array::shape_filter( $input, $shape );
+		$shaped = Arr::shape_filter( $input, $shape );
 		$this->assertEquals( $expected, $shaped );
+	}
+
+	public function usearch_data_provider() {
+		$value_gt_needle = static function ( $needle, $value ): bool {
+			return $value > $needle;
+		};
+		$matches_needle = static function ( $needle, $value ): bool {
+			return $value === $needle;
+		};
+		$callback_using_value_and_key = static function ( $needle, $value, $key ): bool {
+			return $value === $needle && $key === 'three';
+		};
+
+		return [
+			'empty haysatck'                                    => [ 'foo', [], false, $value_gt_needle ],
+			'haystack not contains needle'                      => [
+				23,
+				[ 'foo', 'bar', 'baz' ],
+				false,
+				$value_gt_needle
+			],
+			'haystack contains 1 needle'                        => [ 23, [ 89, 23, 113, 17 ], 1, $matches_needle ],
+			'haystack contains multiple needles'                => [
+				23,
+				[ 89, 23, 113, 17, 23, 11, 23 ],
+				1,
+				$matches_needle
+			],
+			'haystack contains multiple needles w/ string keys' => [
+				23,
+				[ 'one' => 89, 'two' => 23, 'three' => 23 ],
+				'two',
+				$matches_needle
+			],
+			'callback using value and key'                      => [
+				23,
+				[ 'one' => 89, 'two' => 23, 'three' => 23 ],
+				'three',
+				$callback_using_value_and_key
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider usearch_data_provider
+	 */
+	public function test_usearch( $needle, array $haystack, $expected, callable $callback ) {
+		$this->assertEquals( $expected, Arr::usearch( $needle, $haystack, $callback ) );
 	}
 }


### PR DESCRIPTION
Add the `Array::usearch` method to the class to fill the gap left by the
non existence of an `array_usearch` function that accepts a callback and
will bail on first match. The work-around of either a `foreach` or an
`array_filter` followed by a `reset` are not satisfactory or performant.
