### PR TITLE
Fix/tec 4053 events cat with numbers for slugs

### DIFF
--- a/src/Tribe/Terms.php
+++ b/src/Tribe/Terms.php
@@ -22,13 +22,15 @@ class Tribe__Terms {
 				continue;
 			}
 
+			$is_string = is_string( $term );
+
 			if ( $term instanceof WP_Term ) {
 				// We already have the term object.
 				$term_info = $term->to_array();
-			} elseif ( get_term_by( 'slug', $term, $taxonomy ) ) {
+			} elseif ( $is_string && get_term_by( 'slug', $term, $taxonomy ) ) {
 				// We have a matching term slug.
 				$term_info = get_term_by( 'slug', $term, $taxonomy )->to_array();
-			} elseif ( get_term_by( 'name', $term, $taxonomy ) ) {
+			} elseif ( $is_string && get_term_by( 'name', $term, $taxonomy ) ) {
 				// We have a matching term name.
 				$term_info = get_term_by( 'name', $term, $taxonomy )->to_array();
 			} elseif ( is_numeric( $term ) ) {

--- a/src/Tribe/Terms.php
+++ b/src/Tribe/Terms.php
@@ -23,11 +23,20 @@ class Tribe__Terms {
 			}
 
 			if ( $term instanceof WP_Term ) {
+				// We already have the term object.
 				$term_info = $term->to_array();
+			} elseif ( get_term_by( 'slug', $term, $taxonomy ) ) {
+				// We have a matching term slug.
+				$term_info = get_term_by( 'slug', $term, $taxonomy )->to_array();
+			} elseif ( get_term_by( 'name', $term, $taxonomy ) ) {
+				// We have a matching term name.
+				$term_info = get_term_by( 'name', $term, $taxonomy )->to_array();
 			} elseif ( is_numeric( $term ) ) {
+				// We have a matching term ID.
 				$term = absint( $term );
 				$term_info = get_term( $term, $taxonomy, ARRAY_A );
 			} else {
+				// Fallback
 				$term_info = term_exists( $term, $taxonomy );
 			}
 
@@ -37,6 +46,7 @@ class Tribe__Terms {
 					continue;
 				}
 
+				// Passed a string - (optionally) create a new term.
 				if ( true == $create_missing ) {
 					$term_info = wp_insert_term( $term, $taxonomy );
 				} else {


### PR DESCRIPTION
Test if passed term identifier is a string - and test it for slug/name before we assume the passed numeric string is an ID.

https://d.pr/v/32aNCz

[TEC-4053]

[TEC-4053]: https://theeventscalendar.atlassian.net/browse/TEC-4053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ