### PR TITLE
[ET-1541] Load WP Media Assets Earlier

### DIFF
--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -292,7 +292,7 @@ class Tribe__Main {
 			'tec-admin-settings-image-field',
 			'admin-image-field.js',
 			[ 'jquery' ],
-			'admin_footer',
+			'in_admin_footer',
 			[
 				'conditionals' => [ tribe( Settings::class ), 'should_load_image_field_assets' ]
 			]


### PR DESCRIPTION
### Ticket

[ET-1541]

### Description

It was found that the WP Media assets weren't being loaded enough when using the `admin_footer` hook. Changing it to the `in_admin_footer` hook fixes this issue.