### PR TITLE
Fix `Help` submenu appearing under posts. 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Ensure the `help` submenu only appears under the events post type. [TEC-4443]
+
 = [4.15.4.1] 2022-07-21 =
 
 * Fix - Update Freemius to avoid PHP 8 fatals. [TEC-4330]

--- a/src/Tribe/Settings_Manager.php
+++ b/src/Tribe/Settings_Manager.php
@@ -323,7 +323,7 @@ class Tribe__Settings_Manager {
 			return;
 		}
 
-		$parent = class_exists( 'Tribe__Events__Main' ) ? Tribe__Settings::$parent_page : Tribe__Settings::$parent_slug;
+		$parent = class_exists( 'Tribe__Events__Main' ) && Tribe__Events__Main::POSTTYPE;
 		$title  = esc_html__( 'Help', 'tribe-common' );
 		$slug   = 'tribe-help';
 

--- a/src/Tribe/Terms.php
+++ b/src/Tribe/Terms.php
@@ -22,13 +22,15 @@ class Tribe__Terms {
 				continue;
 			}
 
+			$is_string = is_string( $term );
+
 			if ( $term instanceof WP_Term ) {
 				// We already have the term object.
 				$term_info = $term->to_array();
-			} elseif ( get_term_by( 'slug', $term, $taxonomy ) ) {
+			} elseif ( $is_string && get_term_by( 'slug', $term, $taxonomy ) ) {
 				// We have a matching term slug.
 				$term_info = get_term_by( 'slug', $term, $taxonomy )->to_array();
-			} elseif ( get_term_by( 'name', $term, $taxonomy ) ) {
+			} elseif ( $is_string && get_term_by( 'name', $term, $taxonomy ) ) {
 				// We have a matching term name.
 				$term_info = get_term_by( 'name', $term, $taxonomy )->to_array();
 			} elseif ( is_numeric( $term ) ) {

--- a/src/Tribe/Terms.php
+++ b/src/Tribe/Terms.php
@@ -23,11 +23,20 @@ class Tribe__Terms {
 			}
 
 			if ( $term instanceof WP_Term ) {
+				// We already have the term object.
 				$term_info = $term->to_array();
+			} elseif ( get_term_by( 'slug', $term, $taxonomy ) ) {
+				// We have a matching term slug.
+				$term_info = get_term_by( 'slug', $term, $taxonomy )->to_array();
+			} elseif ( get_term_by( 'name', $term, $taxonomy ) ) {
+				// We have a matching term name.
+				$term_info = get_term_by( 'name', $term, $taxonomy )->to_array();
 			} elseif ( is_numeric( $term ) ) {
+				// We have a matching term ID.
 				$term = absint( $term );
 				$term_info = get_term( $term, $taxonomy, ARRAY_A );
 			} else {
+				// Fallback
 				$term_info = term_exists( $term, $taxonomy );
 			}
 
@@ -37,6 +46,7 @@ class Tribe__Terms {
 					continue;
 				}
 
+				// Passed a string - (optionally) create a new term.
 				if ( true == $create_missing ) {
 					$term_info = wp_insert_term( $term, $taxonomy );
 				} else {

--- a/src/Tribe/Tracker.php
+++ b/src/Tribe/Tracker.php
@@ -282,8 +282,12 @@ class Tribe__Tracker {
 		// If we got here we will update the Modified Meta
 		$modified[ $meta_key ] = $now;
 
+		// Avoid loops!
+		remove_filter( 'update_post_metadata', [ $this, 'filter_watch_updated_meta' ], PHP_INT_MAX - 1 );
 		// Actually do the Update
 		update_post_meta( $post->ID, self::$field_key, $modified );
+		// Safe to filter again.
+		add_filter( 'update_post_metadata', [ $this, 'filter_watch_updated_meta' ], PHP_INT_MAX - 1, 5 );
 
 		// We need to return this, because we are still on a filter
 		return $check;


### PR DESCRIPTION
Ensure the `help` submenu only appears under the events post type.

https://theeventscalendar.atlassian.net/browse/TEC-4443