### PR TITLE
Fix parameters order in `implode()`

### DIFF
--- a/src/Tribe/Utils/Array.php
+++ b/src/Tribe/Utils/Array.php
@@ -35,7 +35,7 @@ if ( ! class_exists( 'Tribe__Utils__Array' ) ) {
 					// would likely lead to unexpected problems for whatever first set it.
 					$error = sprintf(
 						'Attempted to set $array[%1$s] but %2$s is already set and is not an array.',
-						implode( $key, '][' ),
+						implode( '][', $key ),
 						$i
 					);
 


### PR DESCRIPTION
Hello, passing the `$glue` and `$pieces` parameters in reverse order to `implode()` has been deprecated since PHP 7.4 ([see docs](https://www.php.net/manual/en/function.implode.php#refsect1-function.implode-changelog)) so this will throw a Fatal Error on PHP8+

This PR fixes the order so that it will continue to work correctly on PHP8.