### PR TITLE
Tweak/add event now function

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [BTD] TBD =
+
+* Tweak - Add a function to Tribe__Date_Utils to determine if "now" is between two dates. [TBD]
+
 = [5.0.0] 2022-0X-XX =
 
 * Feature - Set the Logger logging threshold do DEBUG when WP_DEBUG is defined.

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -577,20 +577,71 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 *
 		 * @since TBD
 		 *
-		 * @param string|DateTime|int $start_date A `strtotime` parse-able string, a DateTime object or a timestamp.
-		 * @param string|DateTime|int $end_date   A `strtotime` parse-able string, a DateTime object or a timestamp.
+		 * @param string|DateTime|int $start_date A `strtotime` parsable string, a DateTime object or a timestamp.
+		 * @param string|DateTime|int $end_date   A `strtotime` parsable string, a DateTime object or a timestamp.
+		 * @param string|DateTime|int $now        A `strtotime` parsable string, a DateTime object or a timestamp. Defaults to 'now'.
 		 *
 		 * @return boolean
 		 */
-		public static function is_now( $start_date, $end_date ) {
-			$now = self::build_date_object( 'now' );
+		public static function is_now( $start_date, $end_date, $now = 'now' ) {
+			$now        = self::build_date_object( $now );
+			$start_date = self::build_date_object( $start_date );
+			$end_date   = self::build_date_object( $end_date );
 
-			return self::range_coincides(
-				$now->format( 'U' ),
-				$now->add( new DateInterval( 'PT1S' ) )->format( 'U' ),
-				self::build_date_object( $start_date )->format( 'U' ),
-				self::build_date_object( $end_date )->format( 'U' )
+			// If the dates are identical, bail early.
+			if ( $start_date === $end_date ) {
+				return false;
+			}
+
+			// Handle dates passed out of chronological order.
+			list( $start_date, $end_date ) = self::sort( [ $start_date, $end_date ] );
+
+			// If span starts after now, return false.
+			if ( $start_date > $now ) {
+				return false;
+			}
+
+			// If span ends on or before now, return false.
+			if ( $end_date <= $now ) {
+				return false;
+			}
+
+			return true;
+		}
+
+		/**
+		 * Sort an array of dates.
+		 *
+		 * @since TBD
+		 *
+		 * @param mixed  $dates     A single array of dates, or dates passed as individual params.
+		 *                          Individual dates can be a `strtotime` parsable string, a DateTime object or a timestamp.
+		 * @param string $direction 'ASC' or 'DESC' for ascending/descending sorting. Defaults to 'ASC'.
+		 *
+		 * @return array<DateTime> A sorted array of DateTime objects.
+		 */
+		public static function sort( array $dates, $direction = 'ASC' ) {
+			// If we get passed a single array, break it out of the containing array.
+			if ( is_array( $dates[0] ) ) {
+				$dates = $dates[0];
+			}
+
+			// Ensure we're always dealing with date objects here.
+			$dates = array_map(
+				function( $date ) {
+					return self::build_date_object( $date );
+				},
+				$dates
 			);
+
+			// If anything other than 'DESC' gets passed (or nothing) we sort ascending.
+			if ( 'DESC' === $direction ) {
+				rsort( $dates );
+			} else {
+				sort( $dates );
+			}
+
+			return $dates;
 		}
 
 		/**
@@ -1262,7 +1313,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 *
 		 * @since 4.9.5
 		 *
-		 * @param string|DateTime|int      $datetime      A `strtotime` parse-able string, a DateTime object or
+		 * @param string|DateTime|int      $datetime      A `strtotime` parsable string, a DateTime object or
 		 *                                                a timestamp; defaults to `now`.
 		 * @param string|DateTimeZone|null $timezone      A timezone string, UTC offset or DateTimeZone object;
 		 *                                                defaults to the site timezone; this parameter is ignored
@@ -1323,7 +1374,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 *
 		 * @param string $date The date string that should validated.
 		 *
-		 * @return bool Whether the date string can be used to build DateTime objects, and is thus parse-able by functions
+		 * @return bool Whether the date string can be used to build DateTime objects, and is thus parsable by functions
 		 *              like `strtotime`, or not.
 		 */
 		public static function is_valid_date( $date ) {
@@ -1561,7 +1612,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 *
 		 * @since 4.10.2
 		 *
-		 * @param string|DateTime|int      $datetime      A `strtotime` parse-able string, a DateTime object or
+		 * @param string|DateTime|int      $datetime      A `strtotime` parsable string, a DateTime object or
 		 *                                                a timestamp; defaults to `now`.
 		 * @param string|DateTimeZone|null $timezone      A timezone string, UTC offset or DateTimeZone object;
 		 *                                                defaults to the site timezone; this parameter is ignored
@@ -1609,7 +1660,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 *
 		 * @since 4.10.2
 		 *
-		 * @param string|DateTime|int      $datetime      A `strtotime` parse-able string, a DateTime object or
+		 * @param string|DateTime|int      $datetime      A `strtotime` parsable string, a DateTime object or
 		 *                                                a timestamp; defaults to `now`.
 		 * @param string|DateTimeZone|null $timezone      A timezone string, UTC offset or DateTimeZone object;
 		 *                                                defaults to the site timezone; this parameter is ignored

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -573,6 +573,27 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		}
 
 		/**
+		 * Determine if "now" is between two dates.
+		 *
+		 * @since TBD
+		 *
+		 * @param string|DateTime|int $start_date A `strtotime` parse-able string, a DateTime object or a timestamp.
+		 * @param string|DateTime|int $end_date   A `strtotime` parse-able string, a DateTime object or a timestamp.
+		 *
+		 * @return boolean
+		 */
+		public static function is_now( $start_date, $end_date ) {
+			$now = self::build_date_object( 'now' );
+
+			return self::range_coincides(
+				$now->format( 'U' ),
+				$now->add( new DateInterval( 'PT1S' ) )->format( 'U' ),
+				self::build_date_object( $start_date )->format( 'U' ),
+				self::build_date_object( $end_date )->format( 'U' )
+			);
+		}
+
+		/**
 		 * Given 2 datetime ranges, return whether the 2nd one occurs during the 1st one
 		 * Note: all params should be unix timestamps
 		 *

--- a/src/Tribe/Utils/Lazy_Boolean.php
+++ b/src/Tribe/Utils/Lazy_Boolean.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * A boolean value lazily built, suited to any value that might be costly to be built.
+ *
+ * @since   TBD
+ *
+ * @package Tribe\Utils
+ */
+
+
+namespace Tribe\Utils;
+
+
+class Lazy_Boolean {
+	use Lazy_Events;
+
+	/**
+	 * The value produced by the callback, cached.
+	 *
+	 * @since TBD
+	 *
+	 * @var boolean
+	 */
+	protected $value;
+
+	/**
+	 * The callback that will be used to set the value when called the first time.
+	 *
+	 * @since TBD
+	 *
+	 * @var callable
+	 */
+	protected $value_callback;
+
+	/**
+	 * Lazy_Boolean constructor.
+	 *
+	 * @param callable $callback The callback that will be used to populate the value on the first fetch.
+	 */
+	public function __construct( callable $callback ) {
+		$this->value_callback  = $callback;
+	}
+
+	/**
+	 * Inits, and returns, the boolean value.
+	 *
+	 * @since TBD
+	 *
+	 * @return boolean The unescaped value.
+	 */
+	public function __toBool() {
+		if ( null === $this->value ) {
+			$this->value = call_user_func( $this->value_callback );
+			// ensure we have a boolean.
+			$this->value = tribe_is_truthy( $this->value );
+			$this->resolved();
+		}
+
+		return $this->value;
+	}
+
+	/**
+	 * Returns the string value, just a proxy of the `__toBool` method.
+	 *
+	 * @since TBD
+	 *
+	 * @return string The string value.
+	 */
+	public function value() {
+		return $this->__toBool();
+	}
+}

--- a/src/Tribe/Utils/Lazy_Boolean.php
+++ b/src/Tribe/Utils/Lazy_Boolean.php
@@ -46,25 +46,27 @@ class Lazy_Boolean {
 	 *
 	 * @since TBD
 	 *
-	 * @return boolean The unescaped value.
+	 * @return boolean The value.
 	 */
 	public function __toBool() {
-		if ( null === $this->value ) {
-			$this->value = call_user_func( $this->value_callback );
-			// ensure we have a boolean.
-			$this->value = tribe_is_truthy( $this->value );
-			$this->resolved();
+		if ( null !== $this->value ) {
+			return $this->value;
 		}
+
+		$this->value = call_user_func( $this->value_callback );
+		// ensure we have a boolean.
+		$this->value = tribe_is_truthy( $this->value );
+		$this->resolved();
 
 		return $this->value;
 	}
 
 	/**
-	 * Returns the string value, just a proxy of the `__toBool` method.
+	 * Returns the value, just a proxy of the `__toBool` method.
 	 *
 	 * @since TBD
 	 *
-	 * @return string The string value.
+	 * @return string The value.
 	 */
 	public function value() {
 		return $this->__toBool();

--- a/src/Tribe/Utils/Lazy_Events.php
+++ b/src/Tribe/Utils/Lazy_Events.php
@@ -160,7 +160,7 @@ trait Lazy_Events {
 
 		$hooked = has_action( $action, $this->lazy_resolve_callback );
 
-		// Let's play it safe and move the resoloution as late as possible.
+		// Let's play it safe and move the resolution as late as possible.
 		$new_priority = false !== $hooked ? max( $hooked, $priority ) : $priority;
 
 		if ( is_numeric( $hooked ) && $hooked !== $new_priority ) {

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -241,6 +241,7 @@ if ( ! function_exists( 'tribe_is_truthy' ) ) {
 			'yes',
 			'true',
 		] );
+
 		// Makes sure we are dealing with lowercase for testing
 		if ( is_string( $var ) ) {
 			$var = strtolower( $var );

--- a/tests/wpunit/Tribe/Utils/DateTest.php
+++ b/tests/wpunit/Tribe/Utils/DateTest.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Tribe\Utils;
+
+use Tribe__Date_Utils as Dates;
+
+
+class DateTest extends \Codeception\TestCase\WPTestCase {
+
+	/**
+	 * @test
+	 */
+	public function test_date_sort_with_array() {
+		$now          = '47448000';
+		$start_date   = '47448001';
+		$end_date     = '47448002';
+		$sorted_array = [ $now, $start_date, $end_date ];
+		$test_array   = [ $end_date, $now, $start_date ];
+
+		$sorted = Dates::sort( $test_array );
+
+		// Ensure we're comparing apples to apples here, instead of datetime objects to strings.
+		$sorted = array_map(
+			function( $date ) {
+				return $date->format( 'U' );
+			},
+			$sorted
+		);
+
+		$this->assertEquals( $sorted_array, $sorted );
+	}
+	/**
+	 * @test
+	 */
+	public function test_date_sort_desc() {
+		$now        = '47448000';
+		$start_date = '47448001';
+		$end_date   = '47448002';
+		// In descending order!
+		$sorted_array = [ $end_date, $start_date, $now ];
+		$test_array   = [ $end_date, $now, $start_date ];
+
+		$sorted = Dates::sort( $test_array, 'DESC' );
+
+		// Ensure we're comparing apples to apples here, instead of datetime objects to strings.
+		$sorted = array_map(
+			function( $date ) {
+				return $date->format( 'U' );
+			},
+			$sorted
+		);
+
+		$this->assertEquals( $sorted_array, $sorted );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_two_identical_timestamps() {
+		$now        = '47448000';
+		$start_date = '47448000';
+		$end_date   = '47448000';
+
+		$this->assertFalse( Dates::is_now( $start_date, $end_date, $now ), 'If the start and end date are identical, the function should fail (return false).' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_starts_after_now() {
+		$now        = '47448000';
+		$start_date = '47448001';
+		$end_date   = '47448002';
+
+		$this->assertFalse( Dates::is_now( $start_date, $end_date, $now ), 'If the start is in the future, the function should fail (return false).' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_starts_after_now_out_of_order() {
+		$now        = '47448000';
+		$start_date = '47448002';
+		$end_date   = '47448001';
+
+		$this->assertFalse( Dates::is_now( $start_date, $end_date, $now ), 'If the start is in the future, the function should fail (return false).' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_ends_before_now() {
+		$now        = '47448000';
+		$start_date = '47447888';
+		$end_date   = '47447999';
+
+		$this->assertFalse( Dates::is_now( $start_date, $end_date, $now ), 'If the end is in the past, the function should fail (return false).' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_ends_before_now_out_of_order() {
+		$now        = '47448000';
+		$start_date = '47447999';
+		$end_date   = '47447888';
+
+		$this->assertFalse( Dates::is_now( $start_date, $end_date, $now ), 'If the end is in the past, the function should fail (return false).' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_ends_now() {
+		$now        = '47448000';
+		$start_date = '47447888';
+		$end_date   = '47448000';
+
+		$this->assertFalse( Dates::is_now( $start_date, $end_date, $now ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_ends_now_out_of_order() {
+		$now        = '47448000';
+		$start_date = '47448000';
+		$end_date   = '47447888';
+
+		$this->assertFalse( Dates::is_now( $start_date, $end_date, $now ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_starts_now() {
+		$now        = '47448000';
+		$start_date = '47448000';
+		$end_date   = '47448001';
+
+		$this->assertTrue( Dates::is_now( $start_date, $end_date, $now ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_starts_now_out_of_order() {
+		$now        = '47448000';
+		$start_date = '47448001';
+		$end_date   = '47448000';
+
+		$this->assertTrue( Dates::is_now( $start_date, $end_date, $now ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_started_in_past() {
+		$now        = '47448000';
+		$start_date = '47447999';
+		$end_date   = '47448001';
+
+		$this->assertTrue( Dates::is_now( $start_date, $end_date, $now ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function test_span_started_in_past_out_of_order() {
+		$now        = '47448000';
+		$start_date = '47448001';
+		$end_date   = '47447999';
+
+		$this->assertTrue( Dates::is_now( $start_date, $end_date, $now ) );
+	}
+}


### PR DESCRIPTION
Required for https://github.com/the-events-calendar/the-events-calendar/pull/3946

Adds a is_now function to Date Utils, as well as a sort function.