### PR TITLE
Prevent E_ERROR on the context usage of is_main_query() too early

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 
 = [5.0.0.1] 2022-09-07 =
 
+* Fix - Prevent `E_ERROR` from showing up when calling `tribe_context()->is( 'is_main_query' )` too early in execution.
 
 = [5.0.0] 2022-09-06 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 = [5.0.0.1] 2022-09-07 =
 
-* Fix - Prevent `E_ERROR` from showing up when calling `tribe_context()->is( 'is_main_query' )` too early in execution.
+* Fix - Prevent `E_ERROR` from showing up when calling `tribe_context()->is( 'is_main_query' )` too early in execution. [TEC-4464]
 
 = [5.0.0] 2022-09-06 =
 

--- a/src/Tribe/Context/locations.php
+++ b/src/Tribe/Context/locations.php
@@ -51,6 +51,10 @@ return [
 					return false;
 				}
 
+				if ( ! $wp_query instanceof WP_Query ) {
+					return false;
+				}
+
 				return $wp_query->is_main_query();
 			},
 		],

--- a/src/Tribe/Context/locations.php
+++ b/src/Tribe/Context/locations.php
@@ -47,6 +47,10 @@ return [
 			Tribe__Context::FUNC => static function () {
 				global $wp_query;
 
+				if ( empty( $wp_query ) ) {
+					return false;
+				}
+
 				return $wp_query->is_main_query();
 			},
 		],

--- a/tests/wpunit/Tribe/Context_LocationsTest.php
+++ b/tests/wpunit/Tribe/Context_LocationsTest.php
@@ -13,33 +13,49 @@ class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @test
 	 */
-	public function should_not_fail_on_wp_query_null() {
-		global $wp_query;
+	public function is_main_query_should_not_error_on_wp_query_null() {
+		$GLOBALS['wp_query'] = null;
 
-		$wp_query = null;
+		$context = (new \Tribe__Context());
+		$context->dangerously_repopulate_locations();
 
-		$this->assertFalse( tribe_context()->is( 'is_main_query' ), 'When WP_Query is `null` it should be false.' );
+		$this->assertFalse( $context->is( 'is_main_query' ), 'When WP_Query is `null` it should be false.' );
 	}
 
 	/**
 	 * @test
 	 */
-	public function should_not_fail_on_wp_query_is_array() {
-		global $wp_query;
+	public function is_main_query_should_not_error_on_wp_query_is_array() {
+		$GLOBALS['wp_query'] = [ 'test' ];
 
-		$wp_query = [ 'test' ];
+		$context = (new \Tribe__Context());
+		$context->dangerously_repopulate_locations();
 
-		$this->assertFalse( tribe_context()->is( 'is_main_query' ), 'When WP_Query is `array` it should be false.' );
+		$this->assertFalse( $context->get( 'is_main_query' ), 'When WP_Query is `array` it should be false.' );
 	}
 
 	/**
 	 * @test
 	 */
-	public function should_not_fail_on_wp_query_not_WP_Query_instance() {
-		global $wp_query;
+	public function is_main_query_should_not_error_on_wp_query_not_WP_Query_instance() {
+		$GLOBALS['wp_query'] = (object) [];
 
-		$wp_query = (object) [];
+		$context = (new \Tribe__Context());
+		$context->dangerously_repopulate_locations();
 
-		$this->assertFalse( tribe_context()->is( 'is_main_query' ), 'When WP_Query is `stdObj` it should be false.' );
+		$this->assertFalse( $context->get( 'is_main_query' ), 'When WP_Query is `stdObj` it should be false.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function is_main_query_should_return_true_when_both_global_instances_are_the_same() {
+		$GLOBALS['wp_query'] = new \WP_Query();
+		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'];
+
+		$context = (new \Tribe__Context());
+		$context->dangerously_repopulate_locations();
+
+		$this->assertTrue( $context->get( 'is_main_query' ), 'When global $wp_query and $wp_the_query are the same it returns true.' );
 	}
 }

--- a/tests/wpunit/Tribe/Context_LocationsTest.php
+++ b/tests/wpunit/Tribe/Context_LocationsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tribe;
+
+/**
+ * Class Context_LocationsTest
+ *
+ * @since   TBD
+ *
+ * @package Tribe
+ */
+class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * @test
+	 */
+	public function should_not_fail_on_wp_query_null() {
+		global $wp_query;
+
+		$wp_query = null;
+
+		$this->assertFalse( tribe_context()->is( 'is_main_query' ), 'When WP_Query is `null` it should be false.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_not_fail_on_wp_query_is_array() {
+		global $wp_query;
+
+		$wp_query = [ 'test' ];
+
+		$this->assertFalse( tribe_context()->is( 'is_main_query' ), 'When WP_Query is `array` it should be false.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_not_fail_on_wp_query_not_WP_Query_instance() {
+		global $wp_query;
+
+		$wp_query = (object) [];
+
+		$this->assertFalse( tribe_context()->is( 'is_main_query' ), 'When WP_Query is `stdObj` it should be false.' );
+	}
+}

--- a/tests/wpunit/Tribe/Context_LocationsTest.php
+++ b/tests/wpunit/Tribe/Context_LocationsTest.php
@@ -16,7 +16,7 @@ class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
 	public function is_main_query_should_not_error_on_wp_query_null() {
 		$GLOBALS['wp_query'] = null;
 
-		$context = (new \Tribe__Context());
+		$context = new \Tribe__Context();
 		$context->dangerously_repopulate_locations();
 
 		$this->assertFalse( $context->is( 'is_main_query' ), 'When WP_Query is `null` it should be false.' );
@@ -28,7 +28,7 @@ class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
 	public function is_main_query_should_not_error_on_wp_query_is_array() {
 		$GLOBALS['wp_query'] = [ 'test' ];
 
-		$context = (new \Tribe__Context());
+		$context = new \Tribe__Context();
 		$context->dangerously_repopulate_locations();
 
 		$this->assertFalse( $context->get( 'is_main_query' ), 'When WP_Query is `array` it should be false.' );
@@ -40,7 +40,7 @@ class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
 	public function is_main_query_should_not_error_on_wp_query_not_WP_Query_instance() {
 		$GLOBALS['wp_query'] = (object) [];
 
-		$context = (new \Tribe__Context());
+		$context = new \Tribe__Context();
 		$context->dangerously_repopulate_locations();
 
 		$this->assertFalse( $context->get( 'is_main_query' ), 'When WP_Query is `stdObj` it should be false.' );
@@ -53,7 +53,7 @@ class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
 		$GLOBALS['wp_query'] = new \WP_Query();
 		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'];
 
-		$context = (new \Tribe__Context());
+		$context = new \Tribe__Context();
 		$context->dangerously_repopulate_locations();
 
 		$this->assertTrue( $context->get( 'is_main_query' ), 'When global $wp_query and $wp_the_query are the same it returns true.' );

--- a/tests/wpunit/Tribe/Context_LocationsTest.php
+++ b/tests/wpunit/Tribe/Context_LocationsTest.php
@@ -10,6 +10,19 @@ namespace Tribe;
  * @package Tribe
  */
 class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
+
+	public $global_vars = [];
+
+	public function setUp() {
+		$this->global_vars['wp_query'] = $GLOBALS['wp_query'] ?? null;
+		$this->global_vars['wp_the_query'] = $GLOBALS['wp_the_query'] ?? null;
+	}
+
+	public function tearDown() {
+		$GLOBALS['wp_query'] = $this->global_vars['wp_query'];
+		$GLOBALS['wp_the_query'] = $this->global_vars['wp_the_query'];
+	}
+
 	/**
 	 * @test
 	 */

--- a/tests/wpunit/Tribe/Context_LocationsTest.php
+++ b/tests/wpunit/Tribe/Context_LocationsTest.php
@@ -14,7 +14,7 @@ class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
 	public $global_vars = [];
 
 	public function setUp() {
-		parent::setUo();
+		parent::setUp();
 		$this->global_vars['wp_query']     = $GLOBALS['wp_query'] ?? null;
 		$this->global_vars['wp_the_query'] = $GLOBALS['wp_the_query'] ?? null;
 	}

--- a/tests/wpunit/Tribe/Context_LocationsTest.php
+++ b/tests/wpunit/Tribe/Context_LocationsTest.php
@@ -14,12 +14,15 @@ class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
 	public $global_vars = [];
 
 	public function setUp() {
-		$this->global_vars['wp_query'] = $GLOBALS['wp_query'] ?? null;
+		parent::setUo();
+		$this->global_vars['wp_query']     = $GLOBALS['wp_query'] ?? null;
 		$this->global_vars['wp_the_query'] = $GLOBALS['wp_the_query'] ?? null;
 	}
 
 	public function tearDown() {
-		$GLOBALS['wp_query'] = $this->global_vars['wp_query'];
+		parent::tearDown();
+
+		$GLOBALS['wp_query']     = $this->global_vars['wp_query'];
 		$GLOBALS['wp_the_query'] = $this->global_vars['wp_the_query'];
 	}
 
@@ -63,7 +66,7 @@ class Context_LocationsTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function is_main_query_should_return_true_when_both_global_instances_are_the_same() {
-		$GLOBALS['wp_query'] = new \WP_Query();
+		$GLOBALS['wp_query']     = new \WP_Query();
 		$GLOBALS['wp_the_query'] = $GLOBALS['wp_query'];
 
 		$context = new \Tribe__Context();


### PR DESCRIPTION
[WP.org Report](https://wordpress.org/support/topic/site-crash-28)
---

This problem is due to some really early usage of the `tribe_context()->is( 'is_main_query' )`, which leads into having problems with some Third-party plugins that are making use of a WP_Query before the global `WP_Query` is defined.


📷 http://i.bordoni.me/UCzroOEIM0mLrYoWBPpX