### PR TITLE
Fix PHP 8.1 deprecation notices

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [5.0.1] TBD =
 
 * Fix - Avoid invoking unwanted callables with ORM post creation/updates. [ET-1560]
+* Tweak - Deprecated the `Tribe__Settings_Manager::add_help_admin_menu_item()` method in favour of `Settings::add_admin_pages()`. [TEC-4443]
 * Tweak - patch some PHP8 compatibility and ensure we don't try to test globals that might not be set. (props to @theskinnyghost for the implode fix!)  [TEC-4453]
 
 = [5.0.0.1] 2022-09-07 =

--- a/src/Tribe/Admin/Notice/Date_Based.php
+++ b/src/Tribe/Admin/Notice/Date_Based.php
@@ -35,7 +35,7 @@ abstract class Date_Based {
 	 *
 	 * @var int
 	 */
-	public $start_time;
+	public $start_time = 0;
 
 	/**
 	 * Placeholder for end date string.
@@ -53,7 +53,7 @@ abstract class Date_Based {
 	 *
 	 * @var int
 	 */
-	public $end_time;
+	public $end_time = 0;
 
 	/**
 	 * Placeholder for extension date string.
@@ -71,7 +71,7 @@ abstract class Date_Based {
 	 *
 	 * @var int
 	 */
-	public $extension_time;
+	public $extension_time = 0;
 
 	/**
 	 * Whether or not The Events Calendar is active.

--- a/src/Tribe/App_Shop.php
+++ b/src/Tribe/App_Shop.php
@@ -343,7 +343,7 @@ if ( ! class_exists( 'Tribe__App_Shop' ) ) {
 					'image' => 'images/shop/stellar-iconic-cta.jpg',
 					'logo' => 'images/shop/stellar-iconic-logo.png',
 					'title' => __( 'Sales-boosting WooCommerce plugins.', 'tribe-common' ),
-					'link' => 'https://iconicwp.com/?utm_source=theeventscalendar&utm_medium=in-app&utm_campaign=cross-brand-add-on-shop',
+					'link' => 'https://evnt.is/iconic',
 					'linktext' => __( 'Add Commerce Tools', 'tribe-common' ),
 					'description' => __( 'Easy-to-use WooCommerce plugins work perfectly together, with any theme. Create a fast and profitable eCommerce store without any technical knowledge.
 					', 'tribe-common' ),

--- a/src/Tribe/Editor/Meta.php
+++ b/src/Tribe/Editor/Meta.php
@@ -9,11 +9,11 @@ abstract class Tribe__Editor__Meta
 	implements Tribe__Editor__Meta_Interface {
 
 	/**
-	 * Default definition for an attribute of type text
+	 * Default definition for an attribute of type text.
 	 *
 	 * @since 4.8
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	protected function text() {
 		return [
@@ -26,11 +26,11 @@ abstract class Tribe__Editor__Meta
 	}
 
 	/**
-	 * Add arguments to escape a text area field
+	 * Add arguments to escape a text area field.
 	 *
 	 * @since 4.8
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	protected function textarea() {
 		return [
@@ -43,11 +43,11 @@ abstract class Tribe__Editor__Meta
 	}
 
 	/**
-	 * Add arguments to escape a field of URL type
+	 * Add arguments to escape a field of URL type.
 	 *
 	 * @since 4.8
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	protected function url() {
 		return [
@@ -60,11 +60,11 @@ abstract class Tribe__Editor__Meta
 	}
 
 	/**
-	 * Default definition for an attribute of type text
+	 * Default definition for an attribute of type text.
 	 *
 	 * @since 4.8
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	protected function numeric() {
 		return [
@@ -77,11 +77,11 @@ abstract class Tribe__Editor__Meta
 	}
 
 	/***
-	 * Default definition for an attribute of type boolean
+	 * Default definition for an attribute of type boolean.
 	 *
 	 * @since 4.8
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	protected function boolean() {
 		return [
@@ -94,11 +94,11 @@ abstract class Tribe__Editor__Meta
 	}
 
 	/**
-	 * Register a numeric type of array
+	 * Register a numeric type of array.
 	 *
 	 * @since 4.8
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	protected function numeric_array() {
 		return [
@@ -112,11 +112,11 @@ abstract class Tribe__Editor__Meta
 	}
 
 	/**
-	 * Register a text type of array
+	 * Register a text type of array.
 	 *
 	 * @since 4.8
 	 *
-	 * @return array
+	 * @return array<string,mixed>
 	 */
 	protected function text_array() {
 		return [
@@ -130,13 +130,13 @@ abstract class Tribe__Editor__Meta
 	}
 
 	/**
-	 * Sanitize an array of text
+	 * Sanitize a string or array of strings.
 	 *
 	 * @since 4.8
 	 *
-	 * @param $value
+	 * @param array<string>|string $value The string or array to sanitize.
 	 *
-	 * @return array
+	 * @return array<string>|string The sanitized value or array of values.
 	 */
 	public function sanitize_text_array( $value ) {
 		if ( is_array( $value ) ) {
@@ -147,13 +147,14 @@ abstract class Tribe__Editor__Meta
 	}
 
 	/**
-	 * Checks and sanitize a given value to a numeric array or a numeric string
+	 * Checks and sanitize a given value to a numeric array or a numeric string.
 	 *
 	 * @since 4.8
 	 *
-	 * @param  mixed $value Check agains this value
+	 * @param array<string|int>|string $value The string or array to sanitize.
 	 *
-	 * @return array|bool|int
+	 * @return array<int>|int|bool The sanitized value or array of values.
+	 *                             Boolean false if not supplied an array or numeric value.
 	 */
 	public function sanitize_numeric_array( $value ) {
 		if ( is_array( $value ) ) {
@@ -166,35 +167,35 @@ abstract class Tribe__Editor__Meta
 	}
 
 	/**
-	 * Make sure sanitization on boolean does not triggered warnings when multiple values are passed
-	 * to the function
+	 * Make sure sanitization on boolean does not trigger warnings
+	 * when multiple values are passed to the function.
 	 *
 	 * @since 4.8
 	 *
-	 * @param $value
+	 * @param bool $value The value to sanitize.
 	 *
-	 * @return bool
+	 * @return bool The sanitized value.
 	 */
 	public function sanitize_boolean( $value ) {
 		return filter_var( $value, FILTER_VALIDATE_BOOLEAN );
 	}
 
 	/**
-	 * Sanitize strings allowing the usage of white spaces before or after the separators, as
-	 * - sanitize_text_field removes any whitespace
+	 * Sanitize strings allowing the usage of white spaces before or after
+	 * the separators, as sanitize_text_field removes any whitespace.
 	 *
 	 * @since 4.8
 	 *
-	 * @param $value
+	 * @param string $value The string to sanitize.
 	 *
-	 * @return mixed
+	 * @return string The sanitized string.
 	 */
 	public function sanitize_separator( $value ) {
-		return filter_var( $value, FILTER_SANITIZE_STRING );
+		return htmlspecialchars( $value );
 	}
 
 	/**
-	 * Verify if the current user can edit or not this Post
+	 * Verify if the current user can (or cannot) edit this Post.
 	 *
 	 * @since 4.8
 	 *

--- a/src/Tribe/Process/Post_Thumbnail_Setter.php
+++ b/src/Tribe/Process/Post_Thumbnail_Setter.php
@@ -110,7 +110,7 @@ class Tribe__Process__Post_Thumbnail_Setter extends Tribe__Process__Handler {
 		}
 
 		$id             = filter_var( $data_source['post_id'], FILTER_SANITIZE_NUMBER_INT );
-		$post_thumbnail = filter_var( $data_source['post_thumbnail'], FILTER_SANITIZE_STRING );
+		$post_thumbnail = htmlspecialchars( $data_source['post_thumbnail'] );
 
 		do_action( 'tribe_log', 'debug', $this->identifier, [
 			'status'         => 'fetching thumbnail',

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -2126,7 +2126,7 @@ abstract class Tribe__Repository
 				$args['meta_query'][ $array_key ]['value'] = $meta_value;
 			}
 
-			if ( 0 === strpos( $type_or_format, '%' ) ) {
+			if ( ! empty( $type_or_format ) && 0 === strpos( $type_or_format, '%' ) ) {
 				throw Tribe__Repository__Usage_Error::because_the_type_is_a_wpdb_prepare_format( $meta_key, $type_or_format, $this );
 			}
 

--- a/src/Tribe/Settings_Manager.php
+++ b/src/Tribe/Settings_Manager.php
@@ -26,7 +26,6 @@ class Tribe__Settings_Manager {
 		add_action( '_network_admin_menu', [ $this, 'init_options' ] );
 		add_action( '_admin_menu', [ $this, 'init_options' ] );
 
-		add_action( 'admin_menu', [ $this, 'add_help_admin_menu_item' ], 50 );
 		add_action( 'tribe_settings_do_tabs', [ $this, 'do_setting_tabs' ] );
 		add_action( 'tribe_settings_validate_tab_network', [ $this, 'save_all_tabs_hidden' ] );
 		add_action( 'updated_option', [ $this, 'update_options_cache' ], 10, 3 );
@@ -315,19 +314,10 @@ class Tribe__Settings_Manager {
 	/**
 	 * Add help menu item to the admin (unless blocked via network admin settings).
 	 *
-	 * @todo move to an admin class
+	 * @deprecated TBD
 	 */
 	public function add_help_admin_menu_item() {
-		$hidden_settings_tabs = self::get_network_option( 'hideSettingsTabs', [] );
-		if ( in_array( 'help', $hidden_settings_tabs ) ) {
-			return;
-		}
-
-		$parent = class_exists( 'Tribe__Events__Main' ) ? Tribe__Settings::$parent_page : Tribe__Settings::$parent_slug;
-		$title  = esc_html__( 'Help', 'tribe-common' );
-		$slug   = 'tribe-help';
-
-		add_submenu_page( $parent, $title, $title, 'manage_options', $slug, [ $this, 'do_help_tab' ] );
+		_deprecated_function( __METHOD__, 'TBD', 'Now handled by Tribe\Events\Admin\Settings::add_admin_pages()' );
 	}
 
 	/**

--- a/src/Tribe/Template.php
+++ b/src/Tribe/Template.php
@@ -135,9 +135,12 @@ class Tribe__Template {
 		}
 
 		if (
-			empty( $origin->plugin_path )
-			&& empty( $origin->pluginPath )
-			&& ! is_dir( $origin )
+			empty( $origin )
+			|| (
+				empty( $origin->plugin_path )
+				&& empty( $origin->pluginPath )
+				&& ! is_dir( $origin )
+			)
 		) {
 			throw new InvalidArgumentException( 'Invalid Origin Class for Template Instance' );
 		}

--- a/src/Tribe/Utils/Collection_Trait.php
+++ b/src/Tribe/Utils/Collection_Trait.php
@@ -144,7 +144,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function count() {
+	public function count() : int {
 		return count( $this->all() );
 	}
 

--- a/src/Tribe/Utils/Collection_Trait.php
+++ b/src/Tribe/Utils/Collection_Trait.php
@@ -12,6 +12,7 @@ namespace Tribe\Utils;
 
 /**
  * Trait Collection_Trait
+ *
  * @since   4.9.14
  * @package Tribe\Utils
  */
@@ -67,7 +68,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function offsetExists( $offset ) {
+	public function offsetExists( $offset ): bool {
 		$items = $this->all();
 
 		return isset( $items[ $offset ] );
@@ -76,6 +77,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		$items = $this->all();
 
@@ -87,7 +89,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function offsetSet( $offset, $value ) {
+	public function offsetSet( $offset, $value ): void {
 		$this->items = $this->all();
 
 		$this->items[ $offset ] = $value;
@@ -96,7 +98,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( $offset ): void {
 		$this->items = $this->all();
 
 		unset( $this->items[ $offset ] );
@@ -105,14 +107,14 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function next() {
+	public function next(): void {
 		$this->items_index ++;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function valid() {
+	public function valid(): bool {
 		$items = $this->all();
 
 		return ( isset( $items[ $this->items_index ] ) );
@@ -121,13 +123,14 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function key() {
+	public function key(): string {
 		return $this->items_index;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function current() {
 		$items = array_values( $this->all() );
 
@@ -137,14 +140,14 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function rewind() {
+	public function rewind(): void {
 		$this->items_index = 0;
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	public function count() : int {
+	public function count(): int {
 		return count( $this->all() );
 	}
 
@@ -162,6 +165,24 @@ trait Collection_Trait {
 	}
 
 	/**
+	 * PHP Compatibility for 8.1 requires us to have a separate magic method to avoid notices.
+	 * static::serialize() will return a string and the magic method needs to return an array.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function __serialize(): array {
+		$to_serialize = $this->all();
+
+		if ( method_exists( $this, 'before_serialize' ) ) {
+			$to_serialize = $this->before_serialize( $this->all() );
+		}
+
+		return $to_serialize;
+	}
+
+	/**
 	 * {@inheritDoc}
 	 */
 	public function unserialize( $serialized ) {
@@ -169,16 +190,21 @@ trait Collection_Trait {
 
 		if ( method_exists( $this, 'custom_unserialize' ) ) {
 			$this->items = $this->custom_unserialize( $to_unserialize );
+
 			return;
 		}
 
 		$this->items = unserialize( $to_unserialize );
 	}
 
+	public function __unserialize( array $data ): void {
+		$this->unserialize( $data );
+	}
+
 	/**
 	 * {@inheritDoc}
 	 */
-	public function seek( $position ) {
+	public function seek( $position ): void {
 		$this->items_index = $position;
 	}
 

--- a/src/Tribe/Utils/Lazy_Collection.php
+++ b/src/Tribe/Utils/Lazy_Collection.php
@@ -111,6 +111,7 @@ class Lazy_Collection implements Collection_Interface {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return $this->all();
 	}

--- a/src/Tribe/Utils/Lazy_String.php
+++ b/src/Tribe/Utils/Lazy_String.php
@@ -69,7 +69,7 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 	 *
 	 * @return string The unescaped string value.
 	 */
-	public function __toString() {
+	public function __toString(): string {
 		if ( null === $this->string ) {
 			$this->string = call_user_func( $this->value_callback );
 			$this->resolved();
@@ -124,17 +124,37 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 	/**
 	 * {@inheritDoc}
 	 *
+	 * @since TBD
+	 */
+	#[\ReturnTypeWillChange]
+	public function __serialize() {
+		return (array) unserialize( $this->serialize( $serialized ) );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @since 4.9.16
 	 */
 	public function unserialize( $serialized ) {
-		list( $string, $escaped ) = unserialize( $serialized );
+		[ $string, $escaped ] = unserialize( $serialized );
 		$this->string  = $string;
 		$this->escaped = $escaped;
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @since TBD
 	 */
+	public function __unserialize( $serialized ): void {
+		$this->unserialize( $serialized );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return $this->value();
 	}

--- a/src/Tribe/Utils/Post_Thumbnail.php
+++ b/src/Tribe/Utils/Post_Thumbnail.php
@@ -160,16 +160,16 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 		$image_sizes  = $this->get_image_sizes();
 		$thumbnail_id = $this->thumbnail_id;
 
-		$cache_key = empty( $thumbnail_id ) ? -1 : $thumbnail_id;
+		$cache_key = empty( $thumbnail_id ) ? - 1 : $thumbnail_id;
 
 		if ( empty( $cache_thumbnail[ $cache_key ] ) ) {
 			$thumbnail_data = array_combine(
 				$image_sizes,
 				array_map(
-					static function( $size ) use ( $thumbnail_id ) {
+					static function ( $size ) use ( $thumbnail_id ) {
 						static $cache_size_data = [];
 
-						$size_data_cache_key = empty( $thumbnail_id ) ? -1 : $thumbnail_id;
+						$size_data_cache_key = empty( $thumbnail_id ) ? - 1 : $thumbnail_id;
 						$size_data_cache_key = "{$size_data_cache_key}:{$size}";
 
 						if ( ! isset( $cache_size_data[ $size_data_cache_key ] ) ) {
@@ -230,7 +230,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function offsetExists( $offset ) {
+	public function offsetExists( $offset ): bool {
 		$this->data = $this->fetch_data();
 
 		return isset( $this->data[ $offset ] );
@@ -239,6 +239,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		$this->data = $this->fetch_data();
 
@@ -250,7 +251,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function offsetSet( $offset, $value ) {
+	public function offsetSet( $offset, $value ): void {
 		$this->data = $this->fetch_data();
 
 		$this->data[ $offset ] = $value;
@@ -259,7 +260,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function offsetUnset( $offset ) {
+	public function offsetUnset( $offset ): void {
 		$this->data = $this->fetch_data();
 
 		unset( $this->data[ $offset ] );
@@ -311,7 +312,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	 *
 	 * @return bool Whether a post thumbnail is set for the post or not.
 	 */
-	public function exists() {
+	public function exists(): bool {
 		if ( null !== $this->exists ) {
 			return $this->exists;
 		}

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -1098,7 +1098,7 @@ if ( ! function_exists( 'tribe_get_request_vars' ) ) {
 			array_keys( $_REQUEST ),
 			array_map( static function ( $v )
 			{
-				return filter_var( $v, FILTER_SANITIZE_STRING );
+				return htmlspecialchars( $v );
 			},
 				$_REQUEST )
 		);
@@ -1126,7 +1126,7 @@ if ( ! function_exists( 'tribe_sanitize_deep' ) ) {
 			return $value;
 		}
 		if ( is_string( $value ) ) {
-			$value = filter_var( $value, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES );
+			$value = htmlspecialchars( $value, ENT_NOQUOTES );
 			return $value;
 		}
 		if ( is_int( $value ) ) {

--- a/tests/_support/ea-server-mocker/src/Cleaner.php
+++ b/tests/_support/ea-server-mocker/src/Cleaner.php
@@ -30,7 +30,7 @@ class Tribe__Events__Aggregator_Mocker__Cleaner
 			}
 
 			if ( $trigger !== 'ea_mocker-clean-all' ) {
-				$post_types = (array) filter_var( $_POST[ $trigger ], FILTER_SANITIZE_STRING );
+				$post_types = array_map( 'htmlspecialchars', (array) $_POST[ $trigger ] );
 			} else {
 				$post_types = array( 'tribe_events', 'tribe-ea-record', 'tribe_venue', 'tribe_organizer' );
 			}


### PR DESCRIPTION
Fixes:
- Deprecated: DateTime::setTime(): Passing null to parameter https://github.com/the-events-calendar/tribe-common/pull/1 ($hour) of type int is deprecated
- Deprecated: Constant FILTER_SANITIZE_STRING is deprecated
- Deprecated: strpos(): Passing null to parameter https://github.com/the-events-calendar/tribe-common/pull/1 ($haystack) of type string is deprecated

Thanks @bordoni !
- Return type of `Tribe\Utils\Lazy_Collection::count()` should be compatible with `Countable::count()`
- The `serialize()`/`__serialize()` mess