### PR TITLE
Include some extra safeties around the term cache primer

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [5.0.2] TBD =
+
+* Fix - Prevents fatal around term cache primer with empty object ID or term name.
+
 = [5.0.1] 2022-09-22 =
 
 * Fix - Avoid invoking unwanted callables with ORM post creation/updates. [ET-1560]

--- a/src/Tribe/Utils/Taxonomy.php
+++ b/src/Tribe/Utils/Taxonomy.php
@@ -136,10 +136,11 @@ class Taxonomy {
 	 *
 	 * @param array $posts
 	 * @param array $taxonomies
+	 * @param bool  $prime_term_meta
 	 *
 	 * @return array<int, array>
 	 */
-	public static function prime_term_cache( array $posts = [], array $taxonomies = [ 'post_tag', \Tribe__Events__Main::TAXONOMY ], $prime_term_meta = false ) {
+	public static function prime_term_cache( array $posts = [], array $taxonomies = [ 'post_tag', \Tribe__Events__Main::TAXONOMY ], bool $prime_term_meta = false ): array {
 		$first = reset( $posts );
 		$is_numeric = ( ! $first instanceof \WP_Post );
 		if ( $is_numeric ) {
@@ -169,7 +170,18 @@ class Taxonomy {
 		}
 
 		foreach ( $cache as $id => $object_taxonomies ) {
+			// Skip when invalid object id is passed.
+			if ( empty( $id ) ) {
+				continue;
+			}
+
 			foreach ( $object_taxonomies as $taxonomy => $term_ids ) {
+				// Skip when invalid taxonomy is passed.
+				if ( empty( $taxonomy ) ) {
+					continue;
+				}
+
+				// Do not skip when `term_ids` are empty.
 				wp_cache_add( $id, $term_ids, $taxonomy . '_relationships' );
 			}
 		}


### PR DESCRIPTION
Nothing changes here, It just solves a comment a User sent to me: https://github.com/the-events-calendar/tribe-common/commit/d0a22531186726c20653f470ff87d09572b94091

---

![Screen Shot 2022-10-04 at 1 35 30 PM](https://user-images.githubusercontent.com/236579/193887993-aff718e3-866c-4cf6-8834-11415dd1f265.jpg)



