### PR TITLE
Support PUE replacement key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,5 +65,10 @@
       "Tribe\\": "src/Tribe/",
       "TEC\\Common\\": "src/Common/"
     }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "TEC\\Common\\Tests\\": "tests/_data/classes"
+    }
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [5.0.2] TBD =
 
 * Fix - Prevents fatal around term cache primer with empty object ID or term name.
+* Tweak - Support replacement license keys in premium products and services.
 
 = [5.0.1] 2022-09-22 =
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1049,16 +1049,22 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				}
 
 				$current_install_key = $this->get_key( $key_type );
+				$replacement_key = $query_args['key'];
 
-				if ( $current_install_key && $current_install_key === $query_args['key'] ) {
+				if ( ! empty( $plugin_info->replacement_key ) ) {
+					// The PUE service might send over a new key upon validation.
+					$replacement_key = $plugin_info->replacement_key;
+				}
+
+				if ( $current_install_key && $current_install_key === $replacement_key ) {
 					$default_success_msg = esc_html( sprintf( __( 'Valid Key! Expires on %s', 'tribe-common' ), $expiration ) );
 				} else {
-					// Set the key
-					$this->update_key( $query_args['key'], $key_type );
+					// Set the key.
+					$this->update_key( $replacement_key, $key_type );
 
 					$default_success_msg = esc_html( sprintf( __( 'Thanks for setting up a valid key. It will expire on %s', 'tribe-common' ), $expiration ) );
 
-					//Set SysInfo Key on Tec.com After Successful Validation of License
+					// Set system info key on TEC.com after successful validation of license.
 					$optin_key = get_option( 'tribe_systeminfo_optin' );
 					if ( $optin_key ) {
 						Tribe__Support::send_sysinfo_key( $optin_key, $query_args['domain'], false, true );

--- a/tests/_data/classes/Http_API/Http_API_Mock.php
+++ b/tests/_data/classes/Http_API/Http_API_Mock.php
@@ -1,0 +1,256 @@
+<?php
+
+namespace TEC\Common\Tests\Http_API;
+
+abstract class Http_API_Mock {
+	/**
+	 * A map from status codes to the HTTP standard status description.
+	 *
+	 * @see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml
+	 */
+	protected static $status_messages = [
+		100 => 'Continue',
+		101 => 'Switching Protocols',
+		102 => 'Processing',
+		103 => 'Early Hints',
+		200 => 'OK',
+		201 => 'Created',
+		202 => 'Accepted',
+		203 => 'Non-Authoritative Information',
+		204 => 'No Content',
+		205 => 'Reset Content',
+		206 => 'Partial Content',
+		207 => 'Multi-Status',
+		208 => 'Already Reported',
+		226 => 'IM Used',
+		300 => 'Multiple Choices',
+		301 => 'Moved Permanently',
+		302 => 'Found',
+		303 => 'See Other',
+		304 => 'Not Modified',
+		305 => 'Use Proxy',
+		307 => 'Temporary Redirect',
+		308 => 'Permanent Redirect',
+		400 => 'Bad Request',
+		401 => 'Unauthorized',
+		402 => 'Payment Required',
+		403 => 'Forbidden',
+		404 => 'Not Found',
+		405 => 'Method Not Allowed',
+		406 => 'Not Acceptable',
+		407 => 'Proxy Authentication Required',
+		408 => 'Request Timeout',
+		409 => 'Conflict',
+		410 => 'Gone',
+		411 => 'Length Required',
+		412 => 'Precondition Failed',
+		413 => 'Content Too Large',
+		414 => 'URI Too Long',
+		415 => 'Unsupported Media Type',
+		416 => 'Range Not Satisfiable',
+		417 => 'Expectation Failed',
+		421 => 'Misdirected Request',
+		422 => 'Unprocessable Content',
+		423 => 'Locked',
+		424 => 'Failed Dependency',
+		425 => 'Too Early',
+		426 => 'Upgrade Required',
+		428 => 'Precondition Required',
+		429 => 'Too Many Requests',
+		431 => 'Request Header Fields Too Large',
+		451 => 'Unavailable For Legal Reasons',
+		500 => 'Internal Server Error',
+		501 => 'Not Implemented',
+		502 => 'Bad Gateway',
+		503 => 'Service Unavailable',
+		504 => 'Gateway Timeout',
+		505 => 'HTTP Version Not Supported',
+		506 => 'Variant Also Negotiates',
+		507 => 'Insufficient Storage',
+		508 => 'Loop Detected',
+		510 => 'Not Extended',
+		511 => 'Network Authentication Required'
+	];
+
+	/**
+	 * A map from method and URI to the response to return.
+	 *
+	 * @var array<string,array<string,array>>
+	 */
+	protected $mock_responses = [];
+
+	/**
+	 * Build and return a mock response.
+	 *
+	 * @param int          $status_code  The response status code.
+	 * @param string|array $body         The response body.
+	 * @param string       $content_type The response Content Type; e.g., 'application/json' or 'text/html'.
+	 *
+	 * @return array<string,mixed> The mock response, in the same format returned by the `wp_remote_request()` function.
+	 *
+	 * @throws \JsonException If the response body cannot be encoded as JSON.
+	 */
+	public function make_response( int $status_code, $body, string $content_type = 'applicaton/json' ): array {
+		if ( $content_type === 'application/json' ) {
+			$body = is_string( $body ) ? $body : json_encode( $body, JSON_THROW_ON_ERROR );
+		} elseif ( $content_type === 'application/x-www-form-urlencoded' ) {
+			$body = is_string( $body ) ? $body : http_build_query( $body );
+		}
+
+		$url = rtrim( $this->get_url(), '/' );
+		$current_date = ( new \DateTime( 'now', new \DateTimezone( 'GMT' ) ) )->format( 'D, d M Y H:i:s GMT' );
+		$request_response = new \Requests_Response();
+		$request_response->headers = new \Requests_Response_Headers( [
+			'date'                          => [ $current_date ],
+			'content-type'                  => [ "$content_type; charset=UTF-8" ],
+			'server'                        => [ 'nginx' ],
+			'vary'                          => [ 'Accept-Encoding' ],
+			'x-robots-tag'                  => [ 'noindex' ],
+			'link'                          => [ '<' . $url . '>; rel="https://api.w.org/"' ],
+			'x-content-type-options'        => [ 'nosniff' ],
+			'access-control-expose-headers' => [ 'X-WP-Total, X-WP-TotalPages, Link' ],
+			'access-control-allow-headers'  => [ 'Authorization, X-WP-Nonce, Content-Disposition, Content-MD5, Content-Type' ],
+			'allow'                         => [ 'GET, POST' ],
+			'strict-transport-security'     => [ 'max-age=31536000; includeSubdomains; preload;' ],
+			'cache-control'                 => [ 'store, must-revalidate, post-check=0, pre-check=0' ],
+			'access-control-allow-origin'   => [ '*' ],
+			'x-frame-options'               => [ 'SAMEORIGIN' ],
+			'x-xss-protection'              => [ '1; mode=block' ],
+			'alternate-protocol'            => [ '443:npn-spdy/3' ],
+			'x-ua-compatible'               => [ 'IE=Edge' ],
+			'content-encoding'              => [ 'gzip' ],
+		] );
+		$request_response->cookies = new \Requests_Cookie_Jar( [] );
+		$status_message = self::$status_messages[ $status_code ] ?? 'Unknown';
+		foreach (
+			[
+				'body'             => $body,
+				'raw'              => "HTTP/1.1 $status_code $status_message
+Date: Wed, 05 Oct 2022 09:30:09 GMT
+Content-Type: $content_type; charset=UTF-8
+Transfer-Encoding: chunked
+Connection: close
+Server: nginx
+Vary: Accept-Encoding
+X-Robots-Tag: noindex
+Link: <$url>; rel=\"https://api.w.org/\"
+X-Content-Type-Options: nosniff
+Access-Control-Expose-Headers: X-WP-Total, X-WP-TotalPages, Link
+Access-Control-Allow-Headers: Authorization, X-WP-Nonce, Content-Disposition, Content-MD5, Content-Type
+Allow: GET, POST
+Strict-Transport-Security: max-age=31536000; includeSubdomains; preload;
+Cache-Control: store, must-revalidate, post-check=0, pre-check=0
+Access-Control-Allow-Origin: *
+X-Frame-Options: SAMEORIGIN
+X-Content-Type-Options: nosniff
+X-XSS-Protection: 1; mode=block
+Alternate-Protocol: 443:npn-spdy/3
+X-UA-Compatible: IE=Edge
+Content-Encoding: gzip
+
+$body",
+				'status_code'      => $status_code,
+				'protocol_version' => 1.1,
+				'success'          => $status_code < 400,
+				'redirects'        => 0,
+				'url'              => 'https://pue.theeventscalendar.com/api/plugins/v2/license/validate',
+				'history'          => [],
+			] as $key => $value
+		) {
+			$request_response->{$key} = $value;
+		}
+		$http_response = new \WP_HTTP_Requests_Response( $request_response );
+
+		return [
+			'headers'       =>
+				new \Requests_Utility_CaseInsensitiveDictionary(
+					[
+						'date'                          => $current_date,
+						'content-type'                  => 'application/json; charset=UTF-8',
+						'server'                        => 'nginx',
+						'vary'                          => 'Accept-Encoding',
+						'x-robots-tag'                  => 'noindex',
+						'link'                          => '<https://pue.theeventscalendar.com/api/>; rel="https://api.w.org/"',
+						'x-content-type-options'        =>
+							[
+								0 => 'nosniff',
+								1 => 'nosniff',
+							],
+						'access-control-expose-headers' => 'X-WP-Total, X-WP-TotalPages, Link',
+						'access-control-allow-headers'  => 'Authorization, X-WP-Nonce, Content-Disposition, Content-MD5, Content-Type',
+						'allow'                         => 'GET, POST',
+						'strict-transport-security'     => 'max-age=31536000; includeSubdomains; preload;',
+						'cache-control'                 => 'store, must-revalidate, post-check=0, pre-check=0',
+						'access-control-allow-origin'   => '*',
+						'x-frame-options'               => 'SAMEORIGIN',
+						'x-xss-protection'              => '1; mode=block',
+						'alternate-protocol'            => '443:npn-spdy/3',
+						'x-ua-compatible'               => 'IE=Edge',
+						'content-encoding'              => 'gzip',
+					]
+				),
+			'body'          => $body,
+			'response'      => [ 'code' => $status_code, 'message' => $status_message, ],
+			'cookies'       => [],
+			'filename'      => null,
+			'http_response' => $http_response,
+		];
+	}
+
+	/**
+	 * Sets up the HPTT API mock to return a response to a specific request.
+	 *
+	 * @param string         $method   The HTTP method to mock, defaults to `GET`.
+	 * @param string         $uri      The URI to mock, relative to the URL specified by the extending class `get_url`
+	 *                                 method.
+	 * @param array|callable $response Either a response in array format, or a callable that will return a
+	 *                                 response and will receive the request parsed arguments and URL as input.
+	 *
+	 * @return void The corresponding mock will be set up.
+	 */
+	public function will_reply_to_request( string $method, string $uri, $response ): void {
+		$method = strtoupper( $method );
+		$uri = '/' . ltrim( $uri, '/' );
+		$key = "$method $uri";
+		$this->mock_responses[ $key ] = $response;
+		if ( ! has_filter( 'pre_http_request', [ $this, 'mock_http_response' ] ) ) {
+			add_filter( 'pre_http_request', [ $this, 'mock_http_response' ], 10, 3 );
+		}
+	}
+
+	/**
+	 * Hooked on the `pre_http_request` filter to prefill the mocked HTTP responses.
+	 *
+	 * @param bool                $preempt     Whether to preempt an HTTP request's return value. Default `false`.
+	 * @param array<string,mixed> $parsed_args The HTTP request arguments.
+	 * @param string              $url         The full request URL.
+	 *
+	 * @return false|mixed Either the mocked response or `false` to let the request go through.
+	 */
+	public function mock_http_response( bool $preempt, array $parsed_args, string $url ) {
+		$uri = '/' . ltrim( str_replace( $this->get_url(), '', $url ), '/' );
+		$method = $parsed_args['method'] ?? 'GET';
+		$key = "$method $uri";
+
+		if ( ! isset( $this->mock_responses[ $key ] ) ) {
+			// We do not have a mock for this, let the HTTP API run its course.
+			return false;
+		}
+
+		$mock_response = $this->mock_responses[ $key ];
+
+		if ( is_callable( $mock_response ) ) {
+			$mock_response = $mock_response( $parsed_args, $url );
+		}
+
+		return $mock_response;
+	}
+
+	/**
+	 * Returns the root URL to use for the mocked HTTP API requests.
+	 *
+	 * @return string The root URL to use for the mocked HTTP API requests.
+	 */
+	abstract protected function get_url(): string;
+
+}

--- a/tests/_data/classes/Licensing/PUE_Service_Mock.php
+++ b/tests/_data/classes/Licensing/PUE_Service_Mock.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace TEC\Common\Tests\Licensing;
+
+use TEC\Common\Tests\Http_API\Http_API_Mock;
+
+class PUE_Service_Mock extends Http_API_Mock {
+	/**
+	 * Returns the body of a success response to the key validation request, in array format.
+	 *
+	 * @return array<string,mixed> The body of a success response to the key validation request.
+	 */
+	public function get_validate_key_success_body(): array {
+		return [
+			'results' => [
+				[
+					'name'           => 'Test Plugin',
+					'slug'           => 'test-plugin',
+					'zip_url'        => '',
+					'file_prefix'    => 'test-plugin.6.0.1',
+					'homepage'       => 'http://evnt.is/test-plugin',
+					'download_url'   => 'https://pue.theeventscalendar.com/api/plugins/v2/download?plugin=test-plugin&version=6.0.1',
+					'icon_svg_url'   => 'https://pue.theeventscalendar.com/product-images/test-plugin.svg',
+					'version'        => '6.0.1',
+					'requires'       => '5.8.4',
+					'tested'         => '6.0.2',
+					'release_date'   => '2022-09-22 00:00:00',
+					'upgrade_notice' => 'Remember to always make a backup of your database and files before updating!',
+					'last_updated'   => '2022-09-22 17:52:39',
+					'sections'       =>
+						[
+							'description'  => 'A test plugin',
+							'installation' => 'Installation instructions.',
+							'changelog'    => '<p>Changelog notes</p>',
+						],
+					'expiration'     => '2028-05-12',
+					'daily_limit'    => null,
+					'custom_update'  =>
+						[
+							'icons' =>
+								[
+									'svg' => 'https://pue.theeventscalendar.com/product-icons/test-plugin.svg',
+								],
+						],
+					'api_upgrade'    => false,
+					'api_expired'    => false,
+					'api_message'    => null,
+				],
+			],
+		];
+	}
+
+
+	/**
+	 * {@inheritdoc }
+	 */
+	protected function get_url(): string {
+		return 'https://pue.theeventscalendar.com/api/';
+	}
+}

--- a/tests/integration/Tribe/PUE/Checker_Test.php
+++ b/tests/integration/Tribe/PUE/Checker_Test.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tribe\PUE;
+
+use TEC\Common\Tests\Licensing\PUE_Service_Mock;
+use Tribe__PUE__Checker as PUE_Checker;
+
+class Checker_Test extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * @var PUE_Service_Mock
+	 */
+	private $pue_service_mock;
+
+	/**
+	 * @before
+	 */
+	public function set_up_pue_service_mock(): void {
+		$this->pue_service_mock = new PUE_Service_Mock();
+	}
+
+	/**
+	 * It should not update license key if replacement key not provided
+	 *
+	 * @test
+	 */
+	public function should_not_update_license_key_if_replacement_key_not_provided(): void {
+		// Ensure there is no key set.
+		delete_option( 'pue_install_key_test_plugin');
+		$validated_key = md5( microtime() );
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $validated_key, false );
+
+		$this->assertEquals( $validated_key, $pue_instance->get_key() );
+	}
+
+	/**
+	 * It should not update license key if replacement key is empty
+	 *
+	 * @test
+	 */
+	public function should_not_update_license_key_if_replacement_key_is_empty(): void {
+		// Ensure there is no key set.
+		delete_option( 'pue_install_key_test_plugin');
+		$validated_key = md5( microtime() );
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		// Add an empty replacement key to the response body.
+		$body['results'][0]['replacement_key'] = '';
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $validated_key, false );
+
+		$this->assertEquals( $validated_key, $pue_instance->get_key() );
+	}
+
+	/**
+	 * It should update license key if replacement key provided and key not previously set
+	 *
+	 * @test
+	 */
+	public function should_update_license_key_if_replacement_key_provided_and_key_not_previously_set(): void {
+		$validated_key = md5( microtime() );
+		// Ensure there is no key set.
+		delete_option( 'pue_install_key_test_plugin');
+		// Set the response mock to provide a replacement key.
+		$replacement_key = '2222222222222222222222222222222222222222';
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		// Add a replacement key to the response body.
+		$body['results'][0]['replacement_key'] = $replacement_key;
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $validated_key, false );
+
+		$this->assertEquals( $replacement_key, $pue_instance->get_key() );
+	}
+
+	/**
+	 * It should update license key if replacement key provided and key previously set
+	 *
+	 * @test
+	 */
+	public function should_update_license_key_if_replacement_key_provided_and_key_previously_set(): void {
+		$original_key = md5( microtime() );
+		// Set the current license key for the plugin.
+		update_option( 'pue_install_key_test_plugin', $original_key );
+		// Set the response mock to provide a replacement key.
+		$replacement_key = '2222222222222222222222222222222222222222';
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		// Add a replacement key to the response body.
+		$body['results'][0]['replacement_key'] = $replacement_key;
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $original_key, false );
+
+		$this->assertEquals( $replacement_key, $pue_instance->get_key() );
+	}
+
+	public function test_replacemnt_key_update_in_multisite_context(): void {
+
+	}
+}

--- a/tests/muwpunit/Tribe/PUE/Replacement_Key_Checker_Test.php
+++ b/tests/muwpunit/Tribe/PUE/Replacement_Key_Checker_Test.php
@@ -121,7 +121,7 @@ class Replacement_Key_Checker_Test extends \Codeception\TestCase\WPTestCase {
 	 *
 	 * @test
 	 */
-	public function should_set_not_previosly_set_network_key_to_validated_key_when_replacement_key_not_provided(): void {
+		public function should_set_network_key_to_validated_key_when_not_previously_set_and_replacement_not_provided(): void {
 		$validated_key = md5( microtime() );
 		// Ensure there is no license key locally or network wide.
 		delete_option( 'pue_install_key_test_plugin' );
@@ -137,11 +137,9 @@ class Replacement_Key_Checker_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * It should set not previously set network key to validated key if replacement key empty
-	 *
 	 * @test
 	 */
-	public function should_set_not_previosly_set_network_key_to_validated_key_if_replacement_key_empty(): void {
+		public function should_set_network_key_to_validated_key_when_not_previously_set_and_replacement_key_empty(): void {
 		$validated_key = md5( microtime() );
 		// Ensure there is no license key locally or network wide.
 		delete_option( 'pue_install_key_test_plugin' );
@@ -159,11 +157,9 @@ class Replacement_Key_Checker_Test extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * It should set not previously set network key to replacement key if provided
-	 *
 	 * @test
 	 */
-	public function should_set_not_previously_set_network_key_to_replacement_key_if_provided(): void {
+	public function should_set_network_key_to_provided_replacement_key_when_not_previously_set(): void {
 		$validated_key = md5( microtime() );
 		// Ensure there is no license key locally or network wide.
 		delete_option( 'pue_install_key_test_plugin' );

--- a/tests/muwpunit/Tribe/PUE/Replacement_Key_Checker_Test.php
+++ b/tests/muwpunit/Tribe/PUE/Replacement_Key_Checker_Test.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Tribe\PUE;
+
+use TEC\Common\Tests\Licensing\PUE_Service_Mock;
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe__PUE__Checker as PUE_Checker;
+
+class Replacement_Key_Checker_Test extends \Codeception\TestCase\WPTestCase {
+	use With_Uopz;
+
+	/**
+	 * @var PUE_Service_Mock
+	 */
+	private $pue_service_mock;
+
+	/**
+	 * @before
+	 */
+	public function set_up_pue_service_mock(): void {
+		$this->pue_service_mock = new PUE_Service_Mock();
+	}
+
+	/**
+	 * @before
+	 */
+	public function set_plugin_active_for_network(): void {
+		$this->set_fn_return( 'is_plugin_active_for_network', function ( string $plugin ): bool {
+			return $plugin === 'test-plugin/test-plugin.php' || is_plugin_active_for_network( $plugin );
+		}, true );
+	}
+
+	/**
+	 * It should not update local license key if replacement key not provided
+	 *
+	 * @test
+	 */
+	public function should_not_update_local_license_key_if_replacement_key_not_provided(): void {
+		// Ensure there is no key set.
+		delete_option( 'pue_install_key_test_plugin' );
+		$original_key = md5( microtime() );
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $original_key, false );
+
+		$this->assertEquals( $original_key, $pue_instance->get_key() );
+	}
+
+	/**
+	 * It should not update local license key if replacement key is empty
+	 *
+	 * @test
+	 */
+	public function should_not_update_local_license_key_if_replacement_key_is_empty(): void {
+		// Ensure there is no key set.
+		delete_option( 'pue_install_key_test_plugin' );
+		$original_key = md5( microtime() );
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		// Add an empty replacement key to the response body.
+		$body['results'][0]['replacement_key'] = '';
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $original_key, false );
+
+		$this->assertEquals( $original_key, $pue_instance->get_key() );
+	}
+
+	/**
+	 * It should update local license key if replacement key provided and key not previously set
+	 *
+	 * @test
+	 */
+	public function should_update_local_license_key_if_replacement_key_provided_and_key_not_previously_set(): void {
+		// Ensure there is no key set.
+		delete_option( 'pue_install_key_test_plugin' );
+		$original_key = md5( microtime() );
+		// Set the response mock to provide a replacement key.
+		$replacement_key = '2222222222222222222222222222222222222222';
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		// Add a replacement key to the response body.
+		$body['results'][0]['replacement_key'] = $replacement_key;
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $original_key, false );
+
+		$this->assertEquals( $replacement_key, $pue_instance->get_key() );
+	}
+
+	/**
+	 * It should update local license key if replacement key provided and key previously set
+	 *
+	 * @test
+	 */
+	public function should_update_local_license_key_if_replacement_key_provided_and_key_previously_set(): void {
+		$original_key = md5( microtime() );
+		// Set the current license key for the plugin.
+		update_option( 'pue_install_key_test_plugin', $original_key );
+		// Set the response mock to provide a replacement key.
+		$replacement_key = '2222222222222222222222222222222222222222';
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		// Add a replacement key to the response body.
+		$body['results'][0]['replacement_key'] = $replacement_key;
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $original_key, false );
+
+		$this->assertEquals( $replacement_key, $pue_instance->get_key() );
+	}
+
+	/**
+	 * It should set not previosly set network key to validated key when replacement key not provided
+	 *
+	 * @test
+	 */
+	public function should_set_not_previosly_set_network_key_to_validated_key_when_replacement_key_not_provided(): void {
+		$validated_key = md5( microtime() );
+		// Ensure there is no license key locally or network wide.
+		delete_option( 'pue_install_key_test_plugin' );
+		delete_network_option( get_current_network_id(), 'pue_install_key_test_plugin' );
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $validated_key, true );
+
+		$this->assertEquals( $validated_key, $pue_instance->get_key() );
+	}
+
+	/**
+	 * It should set not previously set network key to validated key if replacement key empty
+	 *
+	 * @test
+	 */
+	public function should_set_not_previosly_set_network_key_to_validated_key_if_replacement_key_empty(): void {
+		$validated_key = md5( microtime() );
+		// Ensure there is no license key locally or network wide.
+		delete_option( 'pue_install_key_test_plugin' );
+		delete_network_option( get_current_network_id(), 'pue_install_key_test_plugin' );
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		// Add a replacement key to the response body.
+		$body['results'][0]['replacement_key'] = '';
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $validated_key, true );
+
+		$this->assertEquals( $validated_key, $pue_instance->get_key() );
+	}
+
+	/**
+	 * It should set not previously set network key to replacement key if provided
+	 *
+	 * @test
+	 */
+	public function should_set_not_previously_set_network_key_to_replacement_key_if_provided(): void {
+		$validated_key = md5( microtime() );
+		// Ensure there is no license key locally or network wide.
+		delete_option( 'pue_install_key_test_plugin' );
+		delete_network_option( get_current_network_id(), 'pue_install_key_test_plugin' );
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		// Add a replacement key to the response body.
+		$replacement_key = '2222222222222222222222222222222222222222';
+		$body['results'][0]['replacement_key'] = $replacement_key;
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $validated_key, true );
+
+		$this->assertEquals( $replacement_key, $pue_instance->get_key() );
+	}
+
+
+	/**
+	 * It should set previously set network key to replacement key if provided
+	 *
+	 * @test
+	 */
+	public function should_set_previously_set_network_key_to_replacement_key_if_provided() {
+		$validated_key = md5( microtime() );
+		// Ensure there is no license key locally or network wide.
+		delete_option( 'pue_install_key_test_plugin' );
+		update_network_option( get_current_network_id(), 'pue_install_key_test_plugin', 'previous-network-key' );
+		$body = $this->pue_service_mock->get_validate_key_success_body();
+		// Add a replacement key to the response body.
+		$replacement_key = '2222222222222222222222222222222222222222';
+		$body['results'][0]['replacement_key'] = $replacement_key;
+		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
+
+		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
+		$pue_instance->validate_key( $validated_key, true );
+
+		$this->assertEquals( $replacement_key, $pue_instance->get_key() );
+	}
+}


### PR DESCRIPTION
Ticket: [n/a]()

Artifacts: tests

Add support for the `replacement_key` data in the PUE service response
payload; depending on the context of the request either replace the site
or network key, following the behavior already set in the PUE code.

Also: add a acceptably easy to use HTTP API mocking class.
