### PR TITLE
Handle model caching correctly

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Refactor the Post model code to avoid serialization/unserialization issues in object caching context. [TEC-4379]
+
 = [5.0.2] 2022-10-20 =
 
 * Feature - Adds a new `by_not_related_to` repository method for retrieving posts not related to other posts via a meta_value [ET-1567]

--- a/src/Tribe/Cache_Listener.php
+++ b/src/Tribe/Cache_Listener.php
@@ -62,6 +62,7 @@ class Tribe__Cache_Listener {
 		add_action( 'updated_option', [ $this, 'update_last_updated_option' ], 10, 3 );
 		add_action( 'updated_option', [ $this, 'update_last_save_post' ], 10, 3 );
 		add_action( 'generate_rewrite_rules', [ $this, 'generate_rewrite_rules' ] );
+		add_action( 'clean_post_cache', [ $this, 'save_post' ], 0, 2 );
 	}
 
 	/**

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -21,7 +21,7 @@ class Tribe__Main {
 	const OPTIONNAME          = 'tribe_events_calendar_options';
 	const OPTIONNAMENETWORK   = 'tribe_events_calendar_network_options';
 
-	const VERSION             = '5.0.2';
+	const VERSION             = '5.0.3';
 
 	const FEED_URL            = 'https://theeventscalendar.com/feed/';
 

--- a/src/Tribe/Models/Post_Types/Base.php
+++ b/src/Tribe/Models/Post_Types/Base.php
@@ -227,7 +227,7 @@ abstract class Base {
 		$callback = null;
 
 		if ( wp_using_ext_object_cache() ) {
-			$callback = $this->get_object_cache_callback( $cache_slug, $filter );
+			$callback = $this->get_object_cache_callback( $filter );
 		}
 
 		return $callback;

--- a/src/Tribe/Models/Post_Types/Base.php
+++ b/src/Tribe/Models/Post_Types/Base.php
@@ -179,12 +179,13 @@ abstract class Base {
 	 * Returns the WP_Post version of this model.
 	 *
 	 * @since 4.9.18
+	 * @since TBD Added the `$force` parameter.
 	 *
 	 * @param string $output The required return type. One of OBJECT, ARRAY_A, or ARRAY_N, which correspond to a WP_Post
 	 *                       object,an associative array, or a numeric array, respectively.
 	 * @param string $filter Type of filter to apply. Accepts 'raw', 'edit', 'db', or 'display' and other formats
 	 *                       supported by the specific type implementation.
-	 * @param bool $force Whether to force the post to be reloaded from the database or not.
+	 * @param bool   $force  Whether to force the post to be reloaded from the database or not.
 	 *
 	 * @return \WP_Post|array|null The post object version of this post type model or `null` if the post is not valid.
 	 */

--- a/src/Tribe/Models/Post_Types/Base.php
+++ b/src/Tribe/Models/Post_Types/Base.php
@@ -21,6 +21,7 @@ use Tribe__Cache_Listener as Cache_Listener;
  * @package Tribe\Models\Post_Types
  */
 abstract class Base {
+	const PRE_SERIALIZED_PROPERTY = '_tec_pre_serialized';
 	/**
 	 * The post object base for this post type instance.
 	 *
@@ -102,14 +103,52 @@ abstract class Base {
 	 * @since 4.9.18
 	 *
 	 * @param string $filter The type of filter to get the properties for.
+	 * @param bool $force Whether to force a rebuild of the properties or not.
 	 *
 	 * @return array The model properties. This value might be cached.
 	 */
-	protected function get_properties( $filter ) {
-		$cached = $this->get_cached_properties( $filter);
+	protected function get_properties( $filter, bool $force = false ) {
+		$cached = ! $force ? $this->get_cached_properties( $filter ) : false;
 
 		if ( false !== $cached ) {
-			return $cached;
+			// Un-serialize the pre-serialized properties now, when classes will be most likely defined.
+			$pre_serialized_properties = $cached[ self::PRE_SERIALIZED_PROPERTY ] ?? [];
+
+			foreach ( $pre_serialized_properties as $key => $value ) {
+				try {
+					$cached[ $key ] = unserialize( $value, [ 'allowed_classes' => true ] );
+				} catch ( \Throwable $t ) {
+					/*
+					 * Deal with the case where plugin A, B, C were active when the cache was built,
+					 * but B and C are now inactive. In this case the un-serialization will fail for
+					 * any pre-serialized value using classes from B and C: here we gracefully ignore
+					 * each one of those.
+					 */
+				}
+			}
+
+			try {
+				// Allow models to apply further unserialization operations.
+				$cached = $this->scalar_unserialize_properties( $cached );
+
+				/**
+				 * Allows filtering the properties of the post type model after they have been unserialized from the
+				 * cache..
+				 *
+				 * @since TBD
+				 *
+				 * @param array<string,mixed> $cached The key-value map of the properties of the post type model.
+				 * @param \WP_Post            $post   The post object of the post type model.
+				 */
+				$cached = apply_filters( "tec_model_{$this->get_cache_slug()}_read_cache_properties", $cached, $this->post );
+
+				// Remove the pre-serialized properties from the cached properties.
+				unset( $cached[ self::PRE_SERIALIZED_PROPERTY ] );
+
+				return $cached;
+			} catch ( \Throwable $t ) {
+				// Rebuid the properties from cache failed, move on.
+			}
 		}
 
 		$props = $this->build_properties( $filter );
@@ -139,28 +178,28 @@ abstract class Base {
 	 *                       object,an associative array, or a numeric array, respectively.
 	 * @param string $filter Type of filter to apply. Accepts 'raw', 'edit', 'db', or 'display' and other formats
 	 *                       supported by the specific type implementation.
+	 * @param bool $force Whether to force the post to be reloaded from the database or not.
 	 *
 	 * @return \WP_Post|array|null The post object version of this post type model or `null` if the post is not valid.
 	 */
-	public function to_post( $output = OBJECT, $filter = 'raw' ) {
-		$properties = $this->get_properties( $filter );
-
-		// Clone the post to avoid side effects.
-		$post = clone $this->post;
-
-		// And decorate the clone with the properties.
-		foreach ( $properties as $key => $value ) {
-			$post->{$key} = $value;
-		}
+	public function to_post( $output = OBJECT, $filter = 'raw', bool $force = false ) {
+		$properties = $this->get_properties( $filter, $force );
 
 		switch ( $output ) {
 			case ARRAY_A:
-				return (array) $post;
+				return array_merge( (array) $this->post, $properties );
 			case ARRAY_N:
-				return array_values( (array) $post );
+				return array_values( array_merge( (array) $this->post, $properties ) );
 			case OBJECT:
-			default;
-				return $post;
+			default:
+				// Clone the post to avoid side effects.
+				$clone = clone $this->post;
+				// And decorate the clone with the properties.
+				foreach ( $properties as $key => $value ) {
+					$clone->{$key} = $value;
+				}
+
+				return $clone;
 		}
 	}
 
@@ -183,24 +222,107 @@ abstract class Base {
 		$callback = null;
 
 		if ( wp_using_ext_object_cache() ) {
-			/*
-			 * If any real caching is in place , then define a function to cache this event when, and if, one of the
-			 * lazy properties is loaded.
-			 * Cache by post ID and filter.
-			 */
-			$cache_key = $cache_slug . '_' . $this->post->ID . '_' . $filter;
-			$cache     = new Cache();
-			$callback  = function () use ( $cache, $cache_key, $filter ) {
-				$properties = $this->get_properties( $filter );
-
-				/*
-				 * Cache without expiration, but only until a post of the types managed by The Events Calendar is
-				 * updated or created.
-				 */
-				$cache->set( $cache_key, $properties, 0, Cache_Listener::TRIGGER_SAVE_POST );
-			};
+			$callback = $this->get_object_cache_callback( $cache_slug, $filter );
 		}
 
 		return $callback;
+	}
+
+	/**
+	 * Further scalarizes the properties of the post type model.
+	 *
+	 * Extending classes should implement this method to handle
+	 * specific scalarization of the model properties.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $properties A key-value map of the
+	 *                                        properties of the post type model.
+	 *
+	 * @return array<string,mixed> The scalarized properties key-value map.
+	 */
+	protected function scalar_serialize_properties( array $properties ): array {
+		return $properties;
+	}
+
+	/**
+	 * Further un-scalarizes the properties of the post type model.
+	 *
+	 * Extending classes should implement this method to handle
+	 * specific un-scalarization of the model properties.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<string,mixed> $properties A key-value map of the
+	 *                                        properties of the post type model.
+	 *
+	 * @return array<string,mixed> The un-scalarized properties key-value map.
+	 */
+	protected function scalar_unserialize_properties( array $properties ): array {
+		return $properties;
+	}
+
+	/**
+	 * Returns the callback function that should be used to cache the model using object caching.
+	 *
+	 * If any real caching is in place , then define a function to cache this event when, and if, one of the
+	 * lazy properties is loaded.
+	 * Cache by post ID and filter.
+	 * Cache could be pre-fetched: in that case only built-in PHP classes will be supported: for this reason
+	 * object properties will be "scalarized".
+	 *
+	 * @since TBD
+	 *
+	 * @param string $cache_slug The cache slug of the post type model.
+	 * @param string $filter     The filter to cache the model for.
+	 *
+	 * @return \Closure The callback function that should be used to cache the model using object caching.
+	 */
+	protected function get_object_cache_callback( string $cache_slug, string $filter ): \Closure {
+		$cache_key = $cache_slug . '_' . $this->post->ID . '_' . $filter;
+		$cache = new Cache();
+
+		return function () use ( $cache, $cache_key, $filter ) {
+			$properties = $this->get_properties( $filter );
+			$pre_serialized_properties = [];
+
+			try {
+				// Pre-serialize each Serializable property and store it in a separate cache entry.
+				foreach ( $properties as $key => &$value ) {
+					if ( $value instanceof \Serializable ) {
+						$pre_serialized_properties[ $key ] = serialize( $value );
+					}
+				}
+				unset( $value );
+
+				// Remove the pre-serialized properties from the main cache entry.
+				$properties = array_diff_key( $properties, $pre_serialized_properties );
+
+				// Allow models to customize the pre-serialization further.
+				$properties = $this->scalar_serialize_properties( $properties );
+
+				// Add the pre-serialized properties to the main cache entry.
+				$properties[ self::PRE_SERIALIZED_PROPERTY ] = $pre_serialized_properties;
+
+				/**
+				 * Allows filtering the properties of the post type model before they are cached.
+				 *
+				 * @since TBD
+				 *
+				 * @param array<string,mixed> $properties The key-value map of the properties of the post type model.
+				 * @param \WP_Post            $post       The post object of the post type model.
+				 */
+				$properties = apply_filters( "tec_model_{$this->get_cache_slug()}_put_cache_properties", $properties, $this->post );
+			} catch ( \Throwable $t ) {
+				// If we can't serialize the properties, bail.
+				return;
+			}
+
+			/*
+			 * Cache without expiration, but only until a post of the types managed by The Events Calendar is
+			 * updated or created.
+			 */
+			$cache->set( $cache_key, $properties, 0, Cache_Listener::TRIGGER_SAVE_POST );
+		};
 	}
 }

--- a/src/Tribe/Models/Post_Types/Nothing.php
+++ b/src/Tribe/Models/Post_Types/Nothing.php
@@ -38,7 +38,7 @@ class Nothing extends Base {
 	/**
 	 * {@inheritDoc}
 	 */
-	public function to_post( $output = OBJECT, $filter = 'raw' ) {
+	public function to_post( $output = OBJECT, $filter = 'raw', bool $force = false ) {
 		return null;
 	}
 }

--- a/tests/wpunit/Tribe/Models/Post_Types/BaseTest.php
+++ b/tests/wpunit/Tribe/Models/Post_Types/BaseTest.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Tribe\Models\Post_Types;
+
+use Tribe\Events\Collections\Lazy_Post_Collection;
+use Tribe\Utils\Lazy_Collection;
+use Tribe\Utils\Lazy_String;
+use Tribe__Cache_Listener as Cache_Listener;
+
+class Plain_Test_Object_d41d8cd98f00b204e9800998ecf8427e {
+	public $one = 1;
+	public $two = 2;
+	public $three = 3;
+}
+
+class BaseTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * It should not cache properties when post is not decorated by any
+	 *
+	 * @test
+	 */
+	public function should_not_cache_properties_when_post_is_not_decorated_by_any() {
+		$post = $this->factory()->post->create_and_get();
+		$model_class = new class extends Base {
+			protected function get_cache_slug() {
+				return 'boxes';
+			}
+
+			protected function build_properties( $filter ) {
+				// No property decoration happening here.
+				return [];
+			}
+		};
+
+		$model = $model_class::from_post( $post );
+		$model->commit_to_cache();
+
+		$cached = tribe_cache()->get( $model->get_properties_cache_key( 'raw' ), Cache_Listener::TRIGGER_SAVE_POST );
+		$this->assertEquals( [], $cached );
+	}
+
+	/**
+	 * It should cache scalar properties when post is decorated by only scalar properties
+	 *
+	 * @test
+	 */
+	public function should_cache_scalar_properties_when_post_is_decorated_by_only_scalar_properties() {
+		$post = $this->factory()->post->create_and_get();
+		$model_class = new class extends Base {
+			protected function get_cache_slug() {
+				return 'boxes';
+			}
+
+			protected function build_properties( $filter ) {
+				return [
+					'prop_1' => 'string value',
+					'prop_2' => 23,
+					'prop_3' => '2389',
+				];
+			}
+		};
+
+		$model = $model_class::from_post( $post );
+		$model->commit_to_cache();
+
+		$cached = tribe_cache()->get( $model->get_properties_cache_key( 'raw' ), Cache_Listener::TRIGGER_SAVE_POST );
+		$this->assertEquals( [
+			'prop_1' => 'string value',
+			'prop_2' => 23,
+			'prop_3' => '2389',
+		], $cached );
+	}
+
+	/**
+	 * It should cache serializable properties correctly when post is decorated with serializable properties
+	 *
+	 * @test
+	 */
+	public function should_cache_serializable_properties_correctly_when_post_is_decorated_with_serializable_properties() {
+		$other_posts = static::factory()->post->create_many( 3 );
+		$post = $this->factory()->post->create_and_get();
+		$lazy_string = new Lazy_String( static function (): string {
+			return 'string value';
+		} );
+
+		$lazy_collection = new Lazy_Collection( static function (): array {
+			return [ 'hello', 'from', 'the', 'other', 'side' ];
+		} );
+		$lazy_post_collection = new Lazy_Post_Collection( static function () use ( $other_posts ): array {
+			return array_map( 'get_post', $other_posts );
+		} );
+		$custom_object = new Plain_Test_Object_d41d8cd98f00b204e9800998ecf8427e();
+		$model_class = new class() extends Base {
+			public $lazy_string;
+			public $lazy_collection;
+			public $lazy_post_collection;
+			public $custom_object;
+
+			protected function get_cache_slug() {
+				return 'boxes';
+			}
+
+			protected function build_properties( $filter ) {
+				return [
+					'prop_1' => 'string value',
+					'prop_2' => 23,
+					'prop_3' => '2389',
+					'prop_4' => $this->lazy_string,
+					'prop_5' => $this->lazy_collection,
+					'prop_6' => $this->lazy_post_collection,
+					'prop_7' => $this->custom_object,
+				];
+			}
+		};
+
+		$model = $model_class::from_post( $post );
+		$model->lazy_string = $lazy_string;
+		$model->lazy_collection = $lazy_collection;
+		$model->lazy_post_collection = $lazy_post_collection;
+		$model->custom_object = $custom_object;
+		$model->commit_to_cache();
+
+		$cached = tribe_cache()->get( $model->get_properties_cache_key( 'raw' ), Cache_Listener::TRIGGER_SAVE_POST );
+		$this->assertEquals( [
+			'prop_1'                      => 'string value',
+			'prop_2'                      => 23,
+			'prop_3'                      => '2389',
+			Base::PRE_SERIALIZED_PROPERTY => [
+				'prop_4' => serialize( $lazy_string ),
+				'prop_5' => serialize( $lazy_collection ),
+				'prop_6' => serialize( $lazy_post_collection ),
+				'prop_7' => serialize( $custom_object ),
+			]
+		], $cached );
+	}
+
+	/**
+	 * It should cache built-in object properties correctly
+	 *
+	 * @test
+	 */
+	public function should_cache_built_in_object_properties_correctly() {
+		$post = $this->factory()->post->create_and_get();
+		$model_class = new class() extends Base {
+			public $object;
+
+			protected function get_cache_slug() {
+				return 'boxes';
+			}
+
+			protected function build_properties( $filter ) {
+				return [
+					'prop_1' => $this->object,
+					'prop_2' => 23,
+					'prop_3' => '2389',
+				];
+			}
+		};
+
+		$model = $model_class::from_post( $post );
+		$object = (object) [ 'one' => 1, 'two' => 2, 'three' => 3 ];
+		$model->object = $object;
+		$model->commit_to_cache();
+
+		$cached = tribe_cache()->get( $model->get_properties_cache_key( 'raw' ), Cache_Listener::TRIGGER_SAVE_POST );
+		$this->assertEquals( [
+			'prop_1' => $object,
+			'prop_2' => 23,
+			'prop_3' => '2389',
+		], $cached );
+	}
+
+	/**
+	 * It should drop object properties that are not built-in or serializable
+	 *
+	 * @test
+	 */
+	public function should_drop_object_properties_that_are_not_built_in_or_serializable() {
+		$post = $this->factory()->post->create_and_get();
+		$model_class = new class() extends Base {
+			public $custom_object;
+
+			protected function get_cache_slug() {
+				return 'boxes';
+			}
+
+			protected function build_properties( $filter ) {
+				return [
+					'prop_1' => $this->custom_object,
+					'prop_2' => 23,
+					'prop_3' => '2389',
+				];
+			}
+		};
+
+		$model = $model_class::from_post( $post );
+		$model->commit_to_cache();
+		$bad_serializaion_object = new class implements \Serializable {
+			public function serialize() {
+				throw new \RuntimeException( 'Bad serialization' );
+			}
+
+			public function unserialize( $data ) {
+				throw new \RuntimeException( 'Bad unserialization' );
+			}
+		};
+		$model->custom_object = $bad_serializaion_object;
+
+		$cached = tribe_cache()->get( $model->get_properties_cache_key( 'raw' ), Cache_Listener::TRIGGER_SAVE_POST );
+		$this->assertEquals( [
+			'prop_1' => null,
+			'prop_2' => 23,
+			'prop_3' => '2389',
+		], $cached );
+	}
+}

--- a/tests/wpunit/Tribe/Process/HandlerTest.php
+++ b/tests/wpunit/Tribe/Process/HandlerTest.php
@@ -11,6 +11,29 @@ use Tribe__Feature_Detection as Feature_Detection;
 class HandlerTest extends \Codeception\TestCase\WPTestCase {
 	use Cron_Assertions;
 
+	private static $no_async_backup_value;
+
+	/**
+	 * @beforeClass
+	 */
+	public static function backup_no_async_value():void{
+		self::$no_async_backup_value = getenv( 'TRIBE_NO_ASYNC' )	;
+	}
+
+	/**
+	 * @afterClass
+	 */
+	public function restore_no_aync_value(): void {
+		putenv( 'TRIBE_NO_ASYNC=' . self::$no_async_backup_value );
+	}
+
+	/**
+	 * @before
+	 */
+	public function support_async(): void {
+		putenv( 'TRIBE_NO_ASYNC=0' );
+	}
+
 	/**
 	 * A prophecy of the feature detection class.
 	 *

--- a/tribe-common.php
+++ b/tribe-common.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Tribe Common
 Description: An event settings framework for managing shared options
-Version: 5.0.2
+Version: 5.0.3
 Author: The Events Calendar
 Author URI: http://evnt.is/1x
 Text Domain: tribe-common


### PR DESCRIPTION
Ticket: [TEC-4379](https://theeventscalendar.atlassian.net/browse/TEC-4379) 

Artifacts: tests and [screencast](https://share.cleanshot.com/2ktUfb)  

This commit updates the logic used in the Post decoration process to
make sure it plays nice with different caching solutions.

Depending on the specific caching solution or plugin, the failure will
come down to PHP trying to build, during an `unserialize` call, objects
of not yet defined classes.
This might happen for 2 main reasons:
1. When the object was cached plugins A, B and C were active; if only A
   is active when the object is unserialized, then this will lead to a
   cascading failure when PHP tries to build objects of classes defined
   by the plugins B and C.
2. The object is unserialized **before** the plugins defininig the
   classes are loaded, the result will be, as is the case for 1, a
   cascading failure during unserialization.

Unserialization failures will trigger, by default, a warning
(`E_WARNING`) that **will not** stop the code execution and will
propagate incoherent of partially built values down the execution line.

The main cause of this kind of issues would be posts cached in the
`posts` group. Functions like `tribe_get_event` will decorate these post
objects adding dynamic properties to them (e.g., `is_now` or
`start_date` or `venues`). Any one of these properties that is not a
scalar or an instance of an object defined by Core PHP (e.g. `stdClass`
or `DateTime`) will likely cause this failure.

The `posts` cache group, in particular, is consistenly pre-fetched by
many caching solutions when trying to push performance, it's beyond TEC
control.

Given TEC code, and other developer codes, depends on the dynamic
properties mentioned above, we cannot remove them.
Also, we cannot control the serialization of a `WP_Post` instance as
it is unfiltered internal code.
With these premises the solution is two-fold:
1. Make sure no property dynamically added to `WP_Post` instances is an
   object of a class not defined by PHP Core.
2. Alleviate the cost of re-decorating each `WP_Post` instance by
   caching the proerties in a way under our control (a
   `_tec_pre_serialized` property is added to the `WP_Post`)
3. Memoize the decorated `WP_Post` instance, do not cache it.

PHP 8.2 will deprecate dynamic properties, i.e., all the ones we
decorate the `WP_Post` instance with. The `WP_Post` class will look for
undefined properties in the meta (see `WP_Post::__get`), but meta lookup
is really inefficient since the value will be filtered each time it's
fetched. I've thought about using this refactoring to mitigate that
problem too, but the Core team is steering toward the wide-spread use of
the `AllowDynamicProperties` attribute; I've hence decided not to move
dynamic properties to meta.
