### PR TITLE
WP Engine System mu plugin + Divi/Avada timezone conflict. [TEC-4387]

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Ensure the TEC timezone settings are applied correctly when using a combination of the WP Engine System MU plugin and Divi or Avada Themes. [TEC-4387]
+
 = [5.0.2] 2022-10-20 =
 
 * Feature - Adds a new `by_not_related_to` repository method for retrieving posts not related to other posts via a meta_value [ET-1567]

--- a/src/Tribe/Timezones.php
+++ b/src/Tribe/Timezones.php
@@ -67,7 +67,7 @@ class Tribe__Timezones {
 	 */
 	public static function wp_timezone_string() {
 		$cache = tribe( 'cache' );
-		if ( ! isset( $cache['option_timezone_string'] ) ) {
+		if ( empty( $cache['option_timezone_string'] ) ) {
 			$cache['option_timezone_string'] = get_option( 'timezone_string' );
 		}
 		if ( ! isset( $cache['option_gmt_offset'] ) ) {


### PR DESCRIPTION
Ensure the TEC timezone settings are applied correctly when using a combination of the WP Engine System MU plugin and Divi or Avada Themes.

https://theeventscalendar.atlassian.net/browse/TEC-4387

https://www.loom.com/share/47416f97696f421a956bcd580faf904a

