### PR TITLE
[Fix] Ensure string resolution of Lazy_String

### DIFF
--- a/src/Tribe/Utils/Lazy_String.php
+++ b/src/Tribe/Utils/Lazy_String.php
@@ -71,7 +71,7 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 	 */
 	public function __toString() {
 		if ( null === $this->string ) {
-			$this->string = call_user_func( $this->value_callback );
+			$this->string = (string) call_user_func( $this->value_callback );
 			$this->resolved();
 		}
 


### PR DESCRIPTION
`Lazy_String::__toString()` does not resolve to string in some cases which causes fatal error where string is expected.
In our case problem occurs in **community add event** page where `Event` object's properties like `title`, `permalink`, `excerpt`, etc. are empty and the problem happens on `wp_set_cache` level.
For example look at [this line](https://github.com/the-events-calendar/the-events-calendar/blob/master/src/Tribe/Models/Post_Types/Event.php#L210), the result of [tribe_events_get_the_excerpt](https://github.com/the-events-calendar/the-events-calendar/blob/74a292df5169b185a7a202b2277a82d138846f70/src/functions/template-tags/general.php#L1528) function is possible to be null which makes `Lazy_String::__toString()` return null as well.