### PR TITLE
Prevent Warnings from `Lazy_String` on PHP 8.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 
 = [5.0.3] TBD =
 
+* FiX - Prevent `Lazy_String` from ever returning anything that is not a string, avoiding PHP 8.1 warnings. Props @amiut
 * Fix - Ensure the TEC timezone settings are applied correctly when using a combination of the WP Engine System MU plugin and Divi or Avada Themes. [TEC-4387]
 * Fix - Ensure that when filtering script tags we return the expected string no matter what we're given. [TEC-4556]
 

--- a/src/Tribe/Utils/Lazy_String.php
+++ b/src/Tribe/Utils/Lazy_String.php
@@ -71,11 +71,16 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 	 */
 	public function __toString() {
 		if ( null === $this->string ) {
-			$this->string = (string) call_user_func( $this->value_callback );
+			$value =  call_user_func( $this->value_callback );
+			if ( ! $value instanceof \Generator ) {
+				$value = (string) $value;
+			}
+
+			$this->string = $value;
 			$this->resolved();
 		}
 
-		return $this->string;
+		return (string) $this->string;
 	}
 
 	/**

--- a/src/Tribe/Utils/Lazy_String.php
+++ b/src/Tribe/Utils/Lazy_String.php
@@ -80,7 +80,7 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 			$this->resolved();
 		}
 
-		return (string) $this->string;
+		return $this->string;
 	}
 
 	/**

--- a/src/Tribe/Utils/Lazy_String.php
+++ b/src/Tribe/Utils/Lazy_String.php
@@ -71,7 +71,7 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 	 */
 	public function __toString() {
 		if ( null === $this->string ) {
-			$this->string = call_user_func( $this->value_callback );
+			$this->string = (string) call_user_func( $this->value_callback );
 			$this->resolved();
 		}
 


### PR DESCRIPTION
Resolves #1823 