### PR TITLE
Avoid fatal on invalid terms

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 = [5.0.4] TBD =
 
-
+* Fix - Fixed a bug where the `Tribe\Utils\Taxonomy::prime_term_cache()` method would throw on invalid term results (thanks @shawfactor). [TBD]
 
 = [5.0.3] 2022-11-15 =
 

--- a/src/Tribe/Utils/Taxonomy.php
+++ b/src/Tribe/Utils/Taxonomy.php
@@ -163,9 +163,15 @@ class Taxonomy {
 			'taxonomy'   => $taxonomies,
 		];
 		$terms = get_terms( $args );
-		$term_ids = wp_list_pluck( $terms, 'term_id' );
 
-		foreach ( $terms as $term ) {
+		// Drop invalid results.
+		$valid_terms = array_filter( $terms, static function ( $term ) {
+			return $term instanceof \WP_Term;
+		} );
+
+		$term_ids = wp_list_pluck( $valid_terms, 'term_id' );
+
+		foreach ( $valid_terms as $term ) {
 			$cache[ $term->object_id ][ $term->taxonomy ][] = $term->term_id;
 		}
 

--- a/tests/wpunit/Tribe/Notices/Stellar_SaleTest.php
+++ b/tests/wpunit/Tribe/Notices/Stellar_SaleTest.php
@@ -90,32 +90,20 @@ class Stellar_SaleTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_not_display_when_past() {
-		add_filter(
-			"tribe_stellar-sale_notice_start_date",
-			function( $date ) {
-				// Set the start date to the past.
-				return Dates::build_date_object( '-7 days', 'UTC' );
-			}
-		);
-
-		add_filter(
-			"tribe_stellar-sale_notice_end_date",
-			function( $date ) {
-				// Set the end date to the past.
-				return Dates::build_date_object( '-5 days', 'UTC' );
-			}
-		);
-
 		// Ensure we're on a good screen.
 		set_current_screen( 'tribe_events_page_tribe-common' );
+
+		// Mock the `now` date to be this year, in the past of the notice display date.
+		$year = date( 'Y' );
+		$this->set_class_fn_return( Dates::class, 'build_date_object', static function ( $input ) use ( $year ) {
+			return $input === 'now' ?
+				new DateTime( "$year-02-23 09:23:23" )
+				: new DateTime( $input );
+		}, true );
 
 		$notice = tribe( Tribe\Admin\Notice\Marketing\Black_Friday::class );
 
 		$this->assertFalse( $notice->should_display() );
-
-		// So we don't muck up later tests.
-		remove_all_filters( "tribe_stellar-sale_notice_start_date" );
-		remove_all_filters( "tribe_stellar-sale_notice_end_date" );
 	}
 
 	/**
@@ -125,32 +113,20 @@ class Stellar_SaleTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_not_display_when_in_future() {
-		add_filter(
-			"tribe_stellar-sale_notice_start_date",
-			function( $date ) {
-				// Set the start date to the future.
-				return Dates::build_date_object( '+5 days', 'UTC' );
-			}
-		);
-
-		add_filter(
-			"tribe_stellar-sale_notice_end_date",
-			function( $date ) {
-				// Set the end date to the future.
-				return Dates::build_date_object( '+7 days', 'UTC' );
-			}
-		);
-
 		// Ensure we're on a good screen.
 		set_current_screen( 'tribe_events_page_tribe-common' );
+
+		// Mock the `now` date to be this year, in the future of the notice display date.
+		$year = date( 'Y' );
+		$this->set_class_fn_return( Dates::class, 'build_date_object', static function ( $input ) use ( $year ) {
+			return $input === 'now' ?
+				new DateTime( "$year-12-10 09:23:23" )
+				: new DateTime( $input );
+		}, true );
 
 		$notice = tribe( Tribe\Admin\Notice\Marketing\Black_Friday::class );
 
 		$this->assertFalse( $notice->should_display() );
-
-		// So we don't muck up later tests.
-		remove_all_filters( "tribe_stellar-sale_notice_start_date" );
-		remove_all_filters( "tribe_stellar-sale_notice_end_date" );
 	}
 
 	/**
@@ -160,32 +136,19 @@ class Stellar_SaleTest extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function should_display_when_stars_align() {
-		// Set start and end dates to bracket now.
-		add_filter(
-			"tribe_stellar-sale_notice_start_date",
-			function( $date ) {
-				// Set the start date to today to be sure it's the constant that's stopping us.
-				return Dates::build_date_object( '-7 days', 'UTC' );
-			}
-		);
-
-		add_filter(
-			"tribe_stellar-sale_notice_end_date",
-			function( $date ) {
-				// Set the start date to today to be sure it's the constant that's stopping us.
-				return Dates::build_date_object( '+7 days', 'UTC' );
-			}
-		);
-
 		// Ensure we're on a good screen.
 		set_current_screen( 'tribe_events_page_tribe-common' );
+
+		// Mock the `now` date to be this year on November 21st.
+		$year = date( 'Y' );
+		$this->set_class_fn_return( Dates::class, 'build_date_object', static function ( $input ) use ( $year ) {
+			return $input === 'now' ?
+				new DateTime( "2022-07-27 19:23:23" )
+				: new DateTime( $input );
+		}, true );
 
 		$notice = tribe( Tribe\Admin\Notice\Marketing\Stellar_Sale::class );
 
 		$this->assertTrue( $notice->should_display() );
-
-		// So we don't muck up later tests.
-		remove_all_filters( "tribe_stellar-sale_notice_start_date" );
-		remove_all_filters( "tribe_stellar-sale_notice_end_date" );
 	}
 }


### PR DESCRIPTION
Ticket: n/a

Artifacts: tests

This fixes an issue where the function would assume all the terms
returned from the `get_terms` function would be valid `WP_Term`
instances; due to the filtering that happens in the `get_terms`
filter, that might not be true.
The fix consists in dropping invalid term results from the prime
operation.
