### PR TITLE
Fix select2 `clear selection` functionality. [TEC-4393]

### DIFF
--- a/vendor/tribe-selectWoo/dist/js/selectWoo.full.js
+++ b/vendor/tribe-selectWoo/dist/js/selectWoo.full.js
@@ -1875,7 +1875,12 @@ S2.define('select2/selection/allowClear',[
       }
     }
 
-    this.$element.val(this.placeholder.id).trigger('change');
+    // Allow clearing when the data-placeholder attribute isn't set. 
+    if ( typeof this.placeholder !== 'undefined' ) {
+      this.$element.val( this.placeholder.id ).trigger( 'change' );
+    } else {
+      this.$element.val( '' ).trigger( 'change' );
+    }
 
     this.trigger('toggle', {});
   };


### PR DESCRIPTION
Ticket: [TEC-4393](https://theeventscalendar.atlassian.net/browse/TEC-4393)

This PR fixes the issue with select2 where `clear selection` functionality doesn't work when the `data-placeholder` attribute doesn't contain a value. 

Artifact:
https://www.loom.com/share/852beb40d4664a11a978afa30cc01f7a