### PR TITLE
Don't overwrite the intro, append to it.

### DIFF
--- a/src/Tribe/Admin/Conditional_Content/Black_Friday.php
+++ b/src/Tribe/Admin/Conditional_Content/Black_Friday.php
@@ -77,7 +77,7 @@ class Black_Friday extends Datetime_Conditional_Abstract {
 		$content = $this->get_template()->template( 'conditional_content/black-friday', $template_args, false );
 
 		// Replace starting info box markup.
-		$fields['info-start']['html'] = '<div id="modern-tribe-info">' . $content;
+		$fields['info-start']['html'] .=  $content;
 
 		return $fields;
 	}

--- a/src/Tribe/Admin/Conditional_Content/End_Of_Year_Sale.php
+++ b/src/Tribe/Admin/Conditional_Content/End_Of_Year_Sale.php
@@ -64,7 +64,7 @@ class End_Of_Year_Sale extends Datetime_Conditional_Abstract {
 		$content = $this->get_template()->template( 'conditional_content/end-of-year-sale', $template_args, false );
 
 		// Replace starting info box markup.
-		$fields['info-start']['html'] = '<div id="modern-tribe-info">' . $content;
+		$fields['info-start']['html'] .= $content;
 
 		return $fields;
 	}


### PR DESCRIPTION
Fixes broken styles as the BF banner overwrites the intro section rather than just appending to it.

Same fix for the End of Year Sale banner.

[TEC-4573]

[TEC-4573]: https://theeventscalendar.atlassian.net/browse/TEC-4573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ