### PR TITLE
Fix bad pathing creating double-slashes.

### DIFF
--- a/src/Tribe/Template.php
+++ b/src/Tribe/Template.php
@@ -416,7 +416,7 @@ class Tribe__Template {
 		$path = array_merge( (array) $this->template_base_path, $this->folder );
 
 		// Implode to avoid Window Problems
-		$path = implode( DIRECTORY_SEPARATOR, $path );
+		$path = implode( DIRECTORY_SEPARATOR, array_filter( $path ) );
 
 		/**
 		 * Allows filtering of the base path for templates
@@ -505,7 +505,7 @@ class Tribe__Template {
 		}
 
 		// Implode to avoid Window Problems
-		$path = implode( DIRECTORY_SEPARATOR, $path );
+		$path = implode( DIRECTORY_SEPARATOR, array_filter( $path ) );
 
 		/**
 		 * Allows filtering of the base path for templates
@@ -649,7 +649,7 @@ class Tribe__Template {
 				}
 
 				// Build the File Path
-				$file = implode( DIRECTORY_SEPARATOR, array_merge( (array) $folder['path'], $name ) );
+				$file = implode( DIRECTORY_SEPARATOR, array_filter( array_merge( (array) $folder['path'], $name ) ) );
 
 				// Append the Extension to the file path
 				$file .= '.php';
@@ -1149,7 +1149,7 @@ class Tribe__Template {
 		$path            = array_merge( (array) $common_abs_path, $this->folder );
 
 		// Implode to avoid problems on Windows hosts.
-		$path = implode( DIRECTORY_SEPARATOR, $path );
+		$path = implode( DIRECTORY_SEPARATOR, array_filter( $path ) );
 
 		/**
 		 * Allows filtering the path to a template provided by Common.


### PR DESCRIPTION
To do so we run `array_filter()` (without a second param - so it just removes empty items) on $path before we run `implode()`. 

When we implode the $path arrays, ensure we first remove all empty items or we wind up with things like `/site/tec/dev/themes/twentytwenty//tribe/events-pro//custom-tables-v1` instead of
`/site/tec/dev/themes/twentytwenty/tribe/events-pro/custom-tables-v1`

Part of [ECP-1400]

:movie_camera: https://d.pr/v/ihcOLc

Another PR coming on the ECP side as well