### PR TITLE
refactor(src) update code and return types to avoid 8.1 deprecations

### DIFF
--- a/src/Tribe/Admin/Notice/Date_Based.php
+++ b/src/Tribe/Admin/Notice/Date_Based.php
@@ -281,7 +281,9 @@ abstract class Date_Based {
 	 */
 	public function get_start_time() {
 		$date = Dates::build_date_object( $this->start_date, 'UTC' );
-		$date = $date->setTime( $this->start_time, 0 );
+		if ( $this->start_time !== null ) {
+			$date = $date->setTime( $this->start_time, 0 );
+		}
 
 		/**
 		 * Allow filtering of the start date DateTime object,
@@ -305,7 +307,9 @@ abstract class Date_Based {
 	 */
 	public function get_end_time() {
 		$date = Dates::build_date_object( $this->end_date, 'UTC' );
-		$date = $date->setTime( $this->end_time, 0 );
+		if ( $this->end_time !== null ) {
+			$date = $date->setTime( $this->end_time, 0 );
+		}
 
 		/**
 		* Allow filtering of the end date DateTime object,
@@ -331,7 +335,9 @@ abstract class Date_Based {
 	 */
 	public function get_extension_time() {
 		$date = Dates::build_date_object( $this->extension_date, 'UTC' );
-		$date = $date->setTime( $this->extension_time, 0 );
+		if ( $this->extension_time !== null ) {
+			$date = $date->setTime( $this->extension_time, 0 );
+		}
 
 		/**
 		* Allow filtering of the extension date DateTime object,

--- a/src/Tribe/Utils/Collection_Trait.php
+++ b/src/Tribe/Utils/Collection_Trait.php
@@ -67,6 +67,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		$items = $this->all();
 
@@ -76,6 +77,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		$items = $this->all();
 
@@ -87,6 +89,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		$this->items = $this->all();
 
@@ -96,6 +99,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {
 		$this->items = $this->all();
 
@@ -105,6 +109,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function next() {
 		$this->items_index ++;
 	}
@@ -112,6 +117,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function valid() {
 		$items = $this->all();
 
@@ -121,6 +127,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function key() {
 		return $this->items_index;
 	}
@@ -128,6 +135,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function current() {
 		$items = array_values( $this->all() );
 
@@ -137,6 +145,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function rewind() {
 		$this->items_index = 0;
 	}
@@ -144,6 +153,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function count() {
 		return count( $this->all() );
 	}
@@ -169,6 +179,7 @@ trait Collection_Trait {
 
 		if ( method_exists( $this, 'custom_unserialize' ) ) {
 			$this->items = $this->custom_unserialize( $to_unserialize );
+
 			return;
 		}
 
@@ -178,6 +189,7 @@ trait Collection_Trait {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function seek( $position ) {
 		$this->items_index = $position;
 	}
@@ -203,5 +215,39 @@ trait Collection_Trait {
 		$filtered->items = array_filter( $this->all(), $filter_callback );
 
 		return $filtered;
+	}
+
+	/**
+	 * PHP 8.0+ compatible implementation of the serialization logic.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The data to serialize.
+	 */
+	public function __serialize(): array {
+		$to_serialize = $this->all();
+
+		if ( method_exists( $this, 'before_serialize' ) ) {
+			$to_serialize = $this->before_serialize( $this->all() );
+		}
+
+		return $to_serialize;
+	}
+
+	/**
+	 * PHP 8.0+ compatible implementation of the unserialization logic.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $data The data to unserialize.
+	 */
+	public function __unserialize( array $data ): void {
+		if ( method_exists( $this, 'custom_unserialize' ) ) {
+			$this->items = $this->custom_unserialize( serialize( $data ) );
+
+			return;
+		}
+
+		$this->items = $data;
 	}
 }

--- a/src/Tribe/Utils/Lazy_Collection.php
+++ b/src/Tribe/Utils/Lazy_Collection.php
@@ -111,6 +111,7 @@ class Lazy_Collection implements Collection_Interface {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return $this->all();
 	}

--- a/src/Tribe/Utils/Lazy_String.php
+++ b/src/Tribe/Utils/Lazy_String.php
@@ -140,7 +140,34 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return $this->value();
+	}
+
+	/**
+	 * PHP 8.0+ compatible implementation of the serialization logic.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The data to serialize.
+	 */
+	public function __serialize(): array {
+		return [
+			'string'  => $this->string,
+			'escaped' => $this->escaped,
+		];
+	}
+
+	/**
+	 * PHP 8.0+ compatible implementation of the unserialization logic.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $data The data to unserialize.
+	 */
+	public function __unserialize( array $data ): void {
+		$this->string  = $data['string'] ?? null;
+		$this->escaped = $data['escaped'] ?? null;
 	}
 }

--- a/src/Tribe/Utils/Lazy_String.php
+++ b/src/Tribe/Utils/Lazy_String.php
@@ -132,9 +132,8 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 	 * @since 4.9.16
 	 */
 	public function unserialize( $serialized ) {
-		list( $string, $escaped ) = unserialize( $serialized );
-		$this->string  = $string;
-		$this->escaped = $escaped;
+		$data = unserialize( $serialized );
+		$this->__unserialize( $data );
 	}
 
 	/**
@@ -154,8 +153,8 @@ class Lazy_String implements \Serializable, \JsonSerializable {
 	 */
 	public function __serialize(): array {
 		return [
-			'string'  => $this->string,
-			'escaped' => $this->escaped,
+			'string'  => $this->__toString(),
+			'escaped' => $this->escaped(),
 		];
 	}
 

--- a/src/Tribe/Utils/Post_Thumbnail.php
+++ b/src/Tribe/Utils/Post_Thumbnail.php
@@ -230,6 +230,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists( $offset ) {
 		$this->data = $this->fetch_data();
 
@@ -239,6 +240,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet( $offset ) {
 		$this->data = $this->fetch_data();
 
@@ -250,6 +252,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet( $offset, $value ) {
 		$this->data = $this->fetch_data();
 
@@ -259,6 +262,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	/**
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset( $offset ) {
 		$this->data = $this->fetch_data();
 
@@ -283,10 +287,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	 * {@inheritDoc}
 	 */
 	public function serialize() {
-		$data            = $this->fetch_data();
-		$data['post_id'] = $this->post_id;
-
-		return wp_json_encode( $data );
+		return wp_json_encode( $this->__serialize() );
 	}
 
 	/**
@@ -294,14 +295,7 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 	 */
 	public function unserialize( $serialized ) {
 		$data = json_decode( $serialized, true );
-		array_walk( $data, static function ( &$data_entry ) {
-			if ( is_array( $data_entry ) ) {
-				$data_entry = (object) $data_entry;
-			}
-		} );
-		$this->post_id = $data['post_id'];
-		unset( $data['post_id'] );
-		$this->data = ! empty( $data ) ? $data : null;
+		$this->__unserialize( $data );
 	}
 
 	/**
@@ -326,5 +320,37 @@ class Post_Thumbnail implements \ArrayAccess, \Serializable {
 		}
 
 		return $this->exists;
+	}
+
+	/**
+	 * PHP 8.0+ compatible implementation of the serialization logic.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The data to serialize.
+	 */
+	public function __serialize(): array {
+		$data            = $this->fetch_data();
+		$data['post_id'] = $this->post_id;
+
+		return $data;
+	}
+
+	/**
+	 * PHP 8.0+ compatible implementation of the unserialization logic.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $data The data to unserialize.
+	 */
+	public function __unserialize( array $data ): void {
+		array_walk( $data, static function ( &$data_entry ) {
+			if ( is_array( $data_entry ) ) {
+				$data_entry = (object) $data_entry;
+			}
+		} );
+		$this->post_id = $data['post_id'];
+		unset( $data['post_id'] );
+		$this->data = ! empty( $data ) ? $data : null;
 	}
 }

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -1127,7 +1127,7 @@ if ( ! function_exists( 'tribe_sanitize_deep' ) ) {
 			return $value;
 		}
 		if ( is_string( $value ) ) {
-			$value = filter_var( $value, FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_FLAG_NO_ENCODE_QUOTES );
+			$value = htmlspecialchars( stripslashes( strip_tags( $value ) ), ENT_QUOTES );
 			return $value;
 		}
 		if ( is_int( $value ) ) {

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -1127,7 +1127,7 @@ if ( ! function_exists( 'tribe_sanitize_deep' ) ) {
 			return $value;
 		}
 		if ( is_string( $value ) ) {
-			$value = filter_var( $value, FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES );
+			$value = filter_var( $value, FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_FLAG_NO_ENCODE_QUOTES );
 			return $value;
 		}
 		if ( is_int( $value ) ) {

--- a/tests/wpunit/Tribe/Notices/Black_FridayTest.php
+++ b/tests/wpunit/Tribe/Notices/Black_FridayTest.php
@@ -1,23 +1,23 @@
 <?php
 
+use Tribe\Tests\Traits\With_Uopz;
 use Tribe__Date_Utils as Dates;
 
 class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
+	use With_Uopz;
 
 	/**
 	 * Test ! should_display() when constant is set.
 	 *
 	 * Need uopz to test this!
-	 *
-	 * @skip
 	 */
 	public function should_not_display_when_upsells_hidden() {
 		// Set the constant.
-		uopz_redefine( 'TRIBE_HIDE_UPSELL', true );
+		$this->set_const_value( 'TRIBE_HIDE_UPSELL', true );
 		// Ensure we're on a good date.
 		add_filter(
 			'tribe_black-friday_notice_start_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the start date to the past.
 				return Dates::build_date_object( '-7 days', 'UTC' );
 			}
@@ -25,7 +25,7 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 
 		add_filter(
 			'tribe_black-friday_notice_end_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the end date to the future.
 				return Dates::build_date_object( '+7 days', 'UTC' );
 			}
@@ -37,10 +37,6 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 		$notice = tribe( Tribe\Admin\Notice\Marketing\Black_Friday::class );
 
 		$this->assertFalse( $notice->should_display() );
-
-		// So we don't muck up later tests.
-		remove_all_filters( 'tribe_black-friday_notice_start_date' );
-		uopz_undefine( 'TRIBE_HIDE_UPSELL' );
 	}
 
 	/**
@@ -53,7 +49,7 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 		// Ensure we're on a good date.
 		add_filter(
 			'tribe_black-friday_notice_start_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the start date to the past.
 				return Dates::build_date_object( '-7 days', 'UTC' );
 			}
@@ -61,7 +57,7 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 
 		add_filter(
 			'tribe_black-friday_notice_end_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the end date to the future.
 				return Dates::build_date_object( '+7 days', 'UTC' );
 			}
@@ -73,9 +69,6 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 		$notice = tribe( Tribe\Admin\Notice\Marketing\Black_Friday::class );
 
 		$this->assertFalse( $notice->should_display() );
-
-		// So we don't muck up later tests.
-		remove_all_filters( 'tribe_black-friday_notice_start_date' );
 	}
 
 	/**
@@ -87,18 +80,18 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 	public function should_not_display_when_past() {
 		add_filter(
 			'tribe_black-friday_notice_start_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the start date to the past.
 				return Dates::build_date_object( '-7 days', 'UTC' );
-			}
+			}, 200
 		);
 
 		add_filter(
 			'tribe_black-friday_notice_end_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the end date to the past.
 				return Dates::build_date_object( '-5 days', 'UTC' );
-			}
+			}, 200
 		);
 
 		// Ensure we're on a good screen.
@@ -107,10 +100,6 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 		$notice = tribe( Tribe\Admin\Notice\Marketing\Black_Friday::class );
 
 		$this->assertFalse( $notice->should_display() );
-
-		// So we don't muck up later tests.
-		remove_all_filters( 'tribe_black-friday_notice_start_date' );
-		remove_all_filters( 'tribe_black-friday_notice_end_date' );
 	}
 
 	/**
@@ -122,18 +111,18 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 	public function should_not_display_when_in_future() {
 		add_filter(
 			'tribe_black-friday_notice_start_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the start date to the future.
 				return Dates::build_date_object( '+5 days', 'UTC' );
-			}
+			}, 200
 		);
 
 		add_filter(
 			'tribe_black-friday_notice_end_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the end date to the future.
 				return Dates::build_date_object( '+7 days', 'UTC' );
-			}
+			}, 200
 		);
 
 		// Ensure we're on a good screen.
@@ -142,10 +131,6 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 		$notice = tribe( Tribe\Admin\Notice\Marketing\Black_Friday::class );
 
 		$this->assertFalse( $notice->should_display() );
-
-		// So we don't muck up later tests.
-		remove_all_filters( 'tribe_black-friday_notice_start_date' );
-		remove_all_filters( 'tribe_black-friday_notice_end_date' );
 	}
 
 	/**
@@ -157,18 +142,18 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 	public function should_display_when_stars_align() {
 		add_filter(
 			'tribe_black-friday_notice_start_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the start date to the past.
 				return Dates::build_date_object( '-7 days', 'UTC' );
-			}
+			}, 200
 		);
 
 		add_filter(
 			'tribe_black-friday_notice_end_date',
-			function( $date ) {
+			function ( $date ) {
 				// Set the end date to the future.
 				return Dates::build_date_object( '+7 days', 'UTC' );
-			}
+			}, 200
 		);
 
 		// Ensure we're on a good screen.
@@ -176,12 +161,8 @@ class Black_FridayTest extends \Codeception\TestCase\WPTestCase {
 
 		$notice = tribe( Tribe\Admin\Notice\Marketing\Black_Friday::class );
 
-		codecept_debug($notice);
+		codecept_debug( $notice );
 
 		$this->assertTrue( $notice->should_display() );
-
-		// So we don't muck up later tests.
-		remove_all_filters( 'tribe_black-friday_notice_start_date' );
-		remove_all_filters( 'tribe_black-friday_notice_end_date' );
 	}
 }


### PR DESCRIPTION
Ticket: [ECP-1319](https://theeventscalendar.atlassian.net/browse/ECP-1319)

[Screencast](https://share.cleanshot.com/jSiAGj)

This updates some Common code that would throw deprecated issues on PHP 8.1.

Note: when the class is updated to use the `__serialize` and `__unserialize` methods, then those will be used in place of the previously implemented `serialize` and `unserialize` ones; this means existing tests are already covering the changes.