### PR TITLE
fix(Notice) do not build on empty value

### DIFF
--- a/src/Tribe/Admin/Notice/Date_Based.php
+++ b/src/Tribe/Admin/Notice/Date_Based.php
@@ -334,7 +334,12 @@ abstract class Date_Based {
 	 * @return int $end_time The date & time the notice should stop displaying, as a Unix timestamp.
 	 */
 	public function get_extension_time() {
+		if ( $this->extension_date === null ) {
+			return null;
+		}
+
 		$date = Dates::build_date_object( $this->extension_date, 'UTC' );
+
 		if ( $this->extension_time !== null ) {
 			$date = $date->setTime( $this->extension_time, 0 );
 		}


### PR DESCRIPTION
Ticket: [ECP-1319](https://theeventscalendar.atlassian.net/browse/ECP-1319)

Artifacts: existing tests and [screencast](https://share.cleanshot.com/V2rh1R)

This updates the date-based notices to avoid building on empty date values that would default to "now".
