### PR TITLE
fix(utils) restore pre 8.1 sanitization filter, add test coverage

### DIFF
--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -1127,7 +1127,7 @@ if ( ! function_exists( 'tribe_sanitize_deep' ) ) {
 			return $value;
 		}
 		if ( is_string( $value ) ) {
-			$value = htmlspecialchars( stripslashes( strip_tags( $value ) ), ENT_QUOTES );
+			$value = filter_var( $value, FILTER_SANITIZE_STRING );
 			return $value;
 		}
 		if ( is_int( $value ) ) {

--- a/tests/wpunit/Tribe/functions/utilsTest.php
+++ b/tests/wpunit/Tribe/functions/utilsTest.php
@@ -263,6 +263,10 @@ class utilsTest extends \Codeception\TestCase\WPTestCase {
 						]
 					]
 				],
+			],
+			'URL-encoded string' => [
+				'ticket_name=A%20ticket&ticket_description=Lorem%20ipsum',
+				'ticket_name=A%20ticket&ticket_description=Lorem%20ipsum',
 			]
 		];
 	}


### PR DESCRIPTION
This restores the var filter used in the `tribe_sanitize_deep` function to use the `FILTER_SANITIZE_STRING` filter.  
I had removed its use to work on PHP 8.1 compatibility and had not found it broken in the current test cases.

This adds a test case to cover this issue and make sure any future modification will take that case into account.
