### PR TITLE
fix(Rewrite) handle rewrite rules mapping to arrays correctly

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [5.0.8] 2023-01-TBD =
 
 * Fix - Correct handling of translated slugs in rewrite context. [TEC-3733]
+* Fix - Handle the case where rewrite rules map to arrays avoiding fatal errors. [TEC-4567]
 
 = [5.0.6] 2022-12-14 =
 

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -641,7 +641,7 @@ class Tribe__Rewrite {
 			// Reverse the rules to try and match the most complex first.
 			$our_rules = array_filter( $all_rules,
 				static function ( $rule_query_string ) use ( $pattern ) {
-					return preg_match( $pattern, $rule_query_string );
+					return is_string( $rule_query_string ) && preg_match( $pattern, $rule_query_string );
 				}
 			);
 
@@ -761,12 +761,13 @@ class Tribe__Rewrite {
 							array_map(
 								static function ( $rule_string ) {
 									wp_parse_str( parse_url( $rule_string, PHP_URL_QUERY ), $vars );
+
 									return array_keys( $vars );
 								},
-								$rules
+								array_filter( $rules, 'is_string' )
 							)
 						)
-					)
+					),
 				)
 			);
 

--- a/tests/wpunit/Tribe/RewriteTest.php
+++ b/tests/wpunit/Tribe/RewriteTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tribe;
+
+class RewriteTest extends \Codeception\TestCase\WPTestCase {
+	private $wp_rewrite_backup;
+
+	/**
+	 * @before
+	 */
+	public function backup_wp_rewrite(): void {
+		global $wp_rewrite;
+
+		$this->wp_rewrite_backup = $wp_rewrite;
+	}
+
+	/**
+	 * @after
+	 */
+	public function restore_wp_rewrite(): void {
+		global $wp_rewrite;
+
+		$wp_rewrite = $this->wp_rewrite_backup;
+	}
+
+	/**
+	 * It should correctly handle rewrite rules whose query string is an array
+	 *
+	 * @test
+	 */
+	public function should_correctly_handle_rewrite_rules_whose_query_string_is_an_array(): void {
+		$rules = [
+			'events/([^/]+)/?$'                  => 'index.php?post_type=tribe_events&eventDisplay=custom&tribe_event_display=custom&tribe_event_category=$matches[1]',
+			'events/([^/]+)/page/([0-9]{1,})/?$' => 'index.php?post_type=tribe_events&eventDisplay=custom&tribe_event_display=custom&tribe_event_category=$matches[1]&paged=$matches[2]',
+			// Some plugins will store callbacks in the form of callable arrays in the rewrite rules.
+			'test/some-path/([^/]+)/?$'          => [ __CLASS__, 'callback' ]
+		];
+		update_option( 'rewrite_rules', $rules );
+		global $wp_rewrite;
+		$wp_rewrite->rules = $rules;
+
+		$rewrite = new \Tribe__Events__Rewrite( $wp_rewrite );
+
+		$canonical = $rewrite->get_canonical_url( home_url( '/test/some-path/123/' ) );
+		$this->assertEquals( home_url( '/test/some-path/123/' ), $canonical );
+	}
+}


### PR DESCRIPTION
Ticket: [TEC-4567](https://theeventscalendar.atlassian.net/browse/TEC-4567) 

Artifacts:
* tests
* [before](https://share.cleanshot.com/Kj87pH6w) and [after](https://share.cleanshot.com/0pMs3DrF) 

This handles the case where some plugins are mapping rewrite rules,
typically `string -> string` to arrays, so that some rules are `string
-> string` while some are `string -> array`; the plugin in question
stores array callables in rewrite rules.


[TEC-4567]: https://theeventscalendar.atlassian.net/browse/TEC-4567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TEC-4567]: https://theeventscalendar.atlassian.net/browse/TEC-4567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ