### PR TITLE
[ET-1597] Set Max Width for Image Setting Field

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Set max width to image in image setting field. [ET-1597]
+
 = [5.0.7] 2023-01-16 =
 
 * Tweak - Added a dashboard notice for sites running PHP versions lower than 7.4 to alert them that the minimum version of PHP is changing to 7.4 in February 2023.

--- a/src/resources/postcss/tribe-common-admin/_fields.pcss
+++ b/src/resources/postcss/tribe-common-admin/_fields.pcss
@@ -15,6 +15,7 @@
 		img {
 			height: auto;
 			max-height: 100%;
+			max-width: 150px;
 			width: auto;
 		}
 	}


### PR DESCRIPTION
### Ticket
[ET-1597]

### Description
Add CSS to enforce a maximum width on the image for the image setting field. This will ensure that the image doesn't appear too large on the page.

[ET-1597]: https://theeventscalendar.atlassian.net/browse/ET-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ