### PR TITLE
tweak/allow disabling logger

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@
 
 * Fix - Correct handling of translated slugs in rewrite context. [TEC-3733]
 * Fix - Handle the case where rewrite rules map to arrays avoiding fatal errors. [TEC-4567]
-* Tweak - Allow disabling the Logger by setting the `TEC_DISABLE_LOGGING` constant or environment variable to truthy value. [n/a]
+* Tweak - Allow disabling the Logger by setting the `TEC_DISABLE_LOGGING` constant or environment variable to truthy value or by means of the `tec_disable_logging` filter. [n/a]
 
 = [5.0.7] 2023-01-16 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 * Fix - Correct handling of translated slugs in rewrite context. [TEC-3733]
 * Fix - Handle the case where rewrite rules map to arrays avoiding fatal errors. [TEC-4567]
+* Tweak - Allow disabling the Logger by setting the `TEC_DISABLE_LOGGING` constant or environment variable to truthy value. [n/a]
 
 = [5.0.7] 2023-01-16 =
 

--- a/src/Tribe/Log/Service_Provider.php
+++ b/src/Tribe/Log/Service_Provider.php
@@ -11,7 +11,9 @@ namespace Tribe\Log;
 
 
 use Monolog\Handler\ErrorLogHandler;
+use Monolog\Handler\NullHandler;
 use Monolog\Logger;
+use Psr\Log\NullLogger;
 
 class Service_Provider extends \tad_DI52_ServiceProvider {
 
@@ -58,6 +60,23 @@ class Service_Provider extends \tad_DI52_ServiceProvider {
 	 * @return Logger
 	 */
 	public function build_logger() {
+		/*
+		 * Disable logging by either setting the `TEC_DISABLE_LOGGING` constant or by setting the
+		 * `TRIBE_DISABLE_LOGGING` environment variable to a truthy value. Use the environment variable
+		 * in the context of integration tests.
+		 */
+		if (
+			(defined( 'TEC_DISABLE_LOGGING' ) && TEC_DISABLE_LOGGING)
+			|| ! empty( $_ENV['TEC_DISABLE_LOGGING'] )
+			|| getenv( 'TEC_DISABLE_LOGGING' )
+		) {
+			// Logging is disabled, still build a logger to allow fine usage of it and make sure it exists.
+			$logger = new Monolog_Logger( Monolog_Logger::DEFAULT_CHANNEL );
+
+			// Set the handlers to one NullHandler: setting them to an empty array would make it use the STDERR one.
+			return $logger->setHandlers( [ new NullHandler() ] );
+		}
+
 		// Provide more information in debug mode.
 		$level_threshold = defined( 'WP_DEBUG' ) && WP_DEBUG ? Logger::DEBUG : Logger::WARNING;
 

--- a/src/Tribe/Log/Service_Provider.php
+++ b/src/Tribe/Log/Service_Provider.php
@@ -65,11 +65,20 @@ class Service_Provider extends \tad_DI52_ServiceProvider {
 		 * `TRIBE_DISABLE_LOGGING` environment variable to a truthy value. Use the environment variable
 		 * in the context of integration tests.
 		 */
-		if (
-			(defined( 'TEC_DISABLE_LOGGING' ) && TEC_DISABLE_LOGGING)
-			|| ! empty( $_ENV['TEC_DISABLE_LOGGING'] )
-			|| getenv( 'TEC_DISABLE_LOGGING' )
-		) {
+		$logger_disabled = ( defined( 'TEC_DISABLE_LOGGING' ) && TEC_DISABLE_LOGGING )
+		                   || ! empty( $_ENV['TEC_DISABLE_LOGGING'] )
+		                   || getenv( 'TEC_DISABLE_LOGGING' );
+
+		/**
+		 * Allow filtering the logger enabled status.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $logger_disabled Whether the logger should be disabled or not.
+		 */
+		$logger_disabled = apply_filters( 'tec_disable_logging', $logger_disabled );
+
+		if ( $logger_disabled ) {
 			// Logging is disabled, still build a logger to allow fine usage of it and make sure it exists.
 			$logger = new Monolog_Logger( Monolog_Logger::DEFAULT_CHANNEL );
 

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -5,3 +5,5 @@ use Codeception\Util\Autoload;
 
 require_once dirname( __FILE__, 2 ) . '/tribe-autoload.php';
 Autoload::addNamespace( 'Tribe\\Tests', __DIR__ . '/_support' );
+// Silence the logger in the tests.
+$_ENV['TEC_DISABLE_LOGGING'] = 1;

--- a/tests/wpunit/Tribe/Log/ProviderTest.php
+++ b/tests/wpunit/Tribe/Log/ProviderTest.php
@@ -86,4 +86,32 @@ class ProviderTest extends \Codeception\TestCase\WPTestCase {
 		$this->assertCount( 1, $logger->getHandlers() );
 		$this->assertNotInstanceOf( NullHandler::class, $logger->getHandlers()[0] );
 	}
+
+	public function test_filter_works_to_disable_the_logger():void{
+		// Start from a context where the logger is not disabled by either env or const.
+		$this->assertFalse( defined( 'TEC_DISABLE_LOGGING' ) );
+		$this->assertEmpty( getenv( 'TEC_DISABLE_LOGGING' ) );
+		// Filter `tec_disable_logging` to return true and disable the logger.
+		add_filter( 'tec_disable_logging', '__return_true' );
+
+		$logger = tribe(Service_Provider::class)->build_logger();
+
+		$this->assertInstanceOf( Monolog_Logger::class, $logger );
+		$this->assertCount( 1, $logger->getHandlers() );
+		$this->assertInstanceOf( NullHandler::class, $logger->getHandlers()[0] );
+	}
+
+	public function test_filter_overrides_constant_value_to_disable_the_logger(): void {
+		// Start from a context where the logger is disabled by means of the env var.
+		putenv( 'TEC_DISABLE_LOGGING=1' );
+		// Filter the `tec_disable_logging` to return false and enable the logger.
+		add_filter( 'tec_disable_logging', '__return_false' );
+
+		$logger = tribe( Service_Provider::class )->build_logger();
+
+		$this->assertInstanceOf( Monolog_Logger::class, $logger );
+		$this->assertCount( 1, $logger->getHandlers() );
+		$this->assertNotInstanceOf( NullHandler::class, $logger->getHandlers()[0] );
+
+	}
 }

--- a/tests/wpunit/Tribe/Log/ProviderTest.php
+++ b/tests/wpunit/Tribe/Log/ProviderTest.php
@@ -2,15 +2,88 @@
 
 namespace Tribe\Log;
 
+use Monolog\Handler\NullHandler;
+use Tribe\Tests\Traits\With_Uopz;
+
 class ProviderTest extends \Codeception\TestCase\WPTestCase {
+	use With_Uopz;
+
+	/**
+	 * @before
+	 */
+	public function reset_env(): void {
+		putenv( 'TEC_DISABLE_LOGGING=' );
+		unset( $_ENV['TEC_DISABLE_LOGGING'] );
+	}
+
 	/**
 	 * It should register the Action Logger among the available logging engines
 	 *
 	 * @test
 	 */
-	public function should_register_the_action_logger_among_the_available_logging_engines() {
+	public function should_register_the_action_logger_among_the_available_logging_engines(): void {
 		add_filter( 'tribe_log_use_action_logger', '__return_true' );
 		tribe_register_provider( Service_Provider::class );
 		$this->assertArrayHasKey( Action_Logger::class, apply_filters( 'tribe_common_logging_engines', [] ) );
+	}
+
+	public function test_setting_const_will_disable_logger(): void {
+		$this->set_const_value( 'TEC_DISABLE_LOGGING', true );
+
+		$logger = tribe(Service_Provider::class)->build_logger();
+
+		$this->assertInstanceOf( Monolog_Logger::class, $logger );
+		$this->assertCount( 1, $logger->getHandlers() );
+		$this->assertInstanceOf( NullHandler::class, $logger->getHandlers()[0] );
+	}
+
+	public function test_setting_env_value_will_disable_logger(): void {
+		$_ENV['TEC_DISABLE_LOGGING'] = true;
+
+		$logger = tribe(Service_Provider::class)->build_logger();
+
+		$this->assertInstanceOf( Monolog_Logger::class, $logger );
+		$this->assertCount( 1, $logger->getHandlers() );
+		$this->assertInstanceOf( NullHandler::class, $logger->getHandlers()[0] );
+	}
+
+	public function test_setting_putenv_value_will_disable_logger():void{
+		putenv( 'TEC_DISABLE_LOGGING=1' );
+
+		$logger = tribe(Service_Provider::class)->build_logger();
+
+		$this->assertInstanceOf( Monolog_Logger::class, $logger );
+		$this->assertCount( 1, $logger->getHandlers() );
+		$this->assertInstanceOf( NullHandler::class, $logger->getHandlers()[0] );
+	}
+
+	public function test_setting_const_to_falsy_value_will_not_disable_logger():void{
+		$this->set_const_value( 'TEC_DISABLE_LOGGING', false );
+
+		$logger = tribe(Service_Provider::class)->build_logger();
+
+		$this->assertInstanceOf( Monolog_Logger::class, $logger );
+		$this->assertCount( 1, $logger->getHandlers() );
+		$this->assertNotInstanceOf( NullHandler::class, $logger->getHandlers()[0] );
+	}
+
+	public function test_setting_env_to_falsy_value_will_not_disable_logger():void{
+		$_ENV['TEC_DISABLE_LOGGING'] = false;
+
+		$logger = tribe(Service_Provider::class)->build_logger();
+
+		$this->assertInstanceOf( Monolog_Logger::class, $logger );
+		$this->assertCount( 1, $logger->getHandlers() );
+		$this->assertNotInstanceOf( NullHandler::class, $logger->getHandlers()[0] );
+	}
+
+	public function test_setting_putenv_to_falsy_value_will_not_disable_logger():void{
+		putenv( 'TEC_DISABLE_LOGGING=0' );
+
+		$logger = tribe(Service_Provider::class)->build_logger();
+
+		$this->assertInstanceOf( Monolog_Logger::class, $logger );
+		$this->assertCount( 1, $logger->getHandlers() );
+		$this->assertNotInstanceOf( NullHandler::class, $logger->getHandlers()[0] );
 	}
 }


### PR DESCRIPTION
Reproposal of #1857 on the correct base, see the original PR for comments and review.

This adds a filter-based disable feature of the logger using the `tec_disable_logging` filter.
