### PR TITLE
Safeguard around rewrite_filter_array hook params.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Added safeguard against the `rewrite_rules_array` filter being passed non-array values, avoids fatal. [TEC-4679]
+
 = [5.0.10] TBD =
 
 * Feature - Add new `get_contrast_color` and `get_contrast_ratio` methods to the color utility for determining contrasting colors. [ET-1551]

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -193,18 +193,35 @@ class Tribe__Rewrite {
 		return $rules;
 	}
 
+	/**
+	 * Filter for the `rewrite_rules_array` hook.
+	 *
+	 * @since TBD
+	 *
+	 * @param array|mixed $rules The rules to be filtered.
+	 *
+	 * @return array|mixed Rules after filtering.
+	 */
+	public function filter_rewrite_rules_array( $rules ) {
+		if ( ! is_array( $rules ) ) {
+			return $rules;
+		}
+
+		return $this->remove_percent_placeholders( $rules );
+	}
+
 	protected function add_hooks() {
 		add_filter( 'generate_rewrite_rules', [ $this, 'filter_generate' ] );
 
 		// Remove percent Placeholders on all items
-		add_filter( 'rewrite_rules_array', [ $this, 'remove_percent_placeholders' ], 25 );
+		add_filter( 'rewrite_rules_array', [ $this, 'filter_rewrite_rules_array' ], 25 );
 
 		add_action( 'shutdown', [ $this, 'dump_cache' ] );
 	}
 
 	protected function remove_hooks() {
 		remove_filter( 'generate_rewrite_rules', [ $this, 'filter_generate' ] );
-		remove_filter( 'rewrite_rules_array', [ $this, 'remove_percent_placeholders' ], 25 );
+		remove_filter( 'rewrite_rules_array', [ $this, 'filter_rewrite_rules_array' ], 25 );
 
 		remove_action( 'shutdown', [ $this, 'dump_cache' ] );
 	}

--- a/tests/wpunit/Tribe/RewriteTest.php
+++ b/tests/wpunit/Tribe/RewriteTest.php
@@ -2,6 +2,8 @@
 
 namespace Tribe;
 
+use Tribe__Rewrite;
+
 class RewriteTest extends \Codeception\TestCase\WPTestCase {
 	private $wp_rewrite_backup;
 
@@ -43,5 +45,31 @@ class RewriteTest extends \Codeception\TestCase\WPTestCase {
 
 		$canonical = $rewrite->get_canonical_url( home_url( '/test/some-path/123/' ) );
 		$this->assertEquals( home_url( '/test/some-path/123/' ), $canonical );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_filter_rewrite_rules_array(): void {
+		$rules = [
+			'events/' . Tribe__Rewrite::PERCENT_PLACEHOLDER . '/?$' => 'index.php?post_type=tribe_events&eventDisplay=custom&tribe_event_display=custom',
+			'events/?$'                                             => 'index.php?post_type=tribe_events&eventDisplay=custom&tribe_event_display=custom',
+			'faux/' . Tribe__Rewrite::PERCENT_PLACEHOLDER           => 'index.php?post_type=tribe_faux&eventDisplay=custom&tribe_event_display=custom',
+		];
+
+		global $wp_rewrite;
+
+		$rewrite        = new Tribe__Rewrite( $wp_rewrite );
+		// Replaces our percent placeholder.
+		$filtered_rules = $rewrite->filter_rewrite_rules_array( $rules );
+		foreach ( $filtered_rules as $rule_match => $url ) {
+			$this->assertNotContains( Tribe__Rewrite::PERCENT_PLACEHOLDER, $rule_match );
+		}
+
+		// Safely returns bad values.
+		$faux_rules = [ 4, false, null, '', [] ];
+		foreach ( $faux_rules as $faux ) {
+			$this->assertEquals( $faux, $rewrite->filter_rewrite_rules_array( $faux ) );
+		}
 	}
 }


### PR DESCRIPTION
[TEC-4679](https://theeventscalendar.atlassian.net/browse/TEC-4679)

Adds a safeguard around the `rewrite_filter_array` hook callback, which expects an array. Now will gracefully return non-array values and avoids fatal errors from improper use of the filter.

Artifacts:
Screenshots in ticket.
```
PHP Fatal error: Uncaught TypeError: Argument 1 passed to Tribe__Rewrite::remove_percent_placeholders() must be of the type array, bool given, called in /home/regeneravida/public_html/wp-includes/class-wp-hook.php on line 308 and defined in /home/regeneravida/public_html/wp-content/plugins/the-events-calendar/common/src/Tribe/Rewrite.php:177
```

[TEC-4679]: https://theeventscalendar.atlassian.net/browse/TEC-4679?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ