### PR TITLE
feat(Context) add the is_editing_posts_list method

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Feature - Add the `is_editing_posts_list` method to the `Tribe__Context` class. [APM-5]
+
 = [5.0.10] 2023-02-09 =
 
 * Feature - Add new `get_contrast_color` and `get_contrast_ratio` methods to the color utility for determining contrasting colors. [ET-1551]

--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -1656,4 +1656,30 @@ class Tribe__Context {
 			$this->request_cache[ $key ] = $val;
 		}
 	}
+
+	/**
+	 * Whether the current request is one to edit a list of the specified post types or not.
+	 *
+	 * The admin edit screen for a post type is the one that lists all the posts of that typ,
+	 * it has the URL `/wp-admin/edit.php?post_type=<post_type>`.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|array<string> $post_type The post type or post types to check.
+	 *
+	 * @return bool Whether the current request is one to edit a list of the specified post types or not.
+	 */
+	public function is_editing_posts_list( $post_type ): bool {
+		// Quick check: are we on the `/wp-admin/edit.php` page?
+		global $pagenow;
+
+		if ( $pagenow !== 'edit.php' ) {
+			return false;
+		}
+
+		// Run some more thorough checks for the post type(s).
+		$post_types = array_filter( (array) $post_type );
+
+		return $this->is_editing_post( $post_types );
+	}
 }

--- a/tests/_support/Traits/With_Uopz.php
+++ b/tests/_support/Traits/With_Uopz.php
@@ -5,6 +5,10 @@ namespace Tribe\Tests\Traits;
 use PHPUnit\Framework\Assert;
 
 trait With_Uopz {
+	/*
+	 * The following properties are static to cover data providers where 2 diff. instances of the test case are used:
+	 * one to build the data sets, the other to run the tests.
+	 */
 	private static array $uopz_set_returns = [];
 	private static array $uopz_redefines = [];
 	private static array $uopz_set_properties = [];

--- a/tests/_support/Traits/With_Uopz.php
+++ b/tests/_support/Traits/With_Uopz.php
@@ -5,17 +5,17 @@ namespace Tribe\Tests\Traits;
 use PHPUnit\Framework\Assert;
 
 trait With_Uopz {
-	private $uopz_set_returns = [];
-	private $uopz_redefines = [];
-	private $uopz_set_properties = [];
-	private $uopz_add_class_fns = [];
+	private static array $uopz_set_returns = [];
+	private static array $uopz_redefines = [];
+	private static array $uopz_set_properties = [];
+	private static array $uopz_add_class_fns = [];
 
 	/**
 	 * @after
 	 */
 	public function unset_uopz_returns() {
 		if ( function_exists( 'uopz_set_return' ) ) {
-			foreach ( $this->uopz_set_returns as $f ) {
+			foreach ( self::$uopz_set_returns as $f ) {
 				if ( is_array( $f ) ) {
 					list( $class, $method ) = $f;
 					uopz_unset_return( $class, $method );
@@ -26,7 +26,7 @@ trait With_Uopz {
 		}
 
 		if ( function_exists( 'uopz_redefine' ) ) {
-			foreach ( $this->uopz_redefines as $restore_callback ) {
+			foreach ( self::$uopz_redefines as $restore_callback ) {
 				$restore_callback();
 			}
 		}
@@ -37,13 +37,13 @@ trait With_Uopz {
 	 */
 	public function unset_uopz_properties() {
 		if ( function_exists( 'uopz_set_property' ) ) {
-			foreach ( $this->uopz_set_properties as $definition ) {
+			foreach ( self::$uopz_set_properties as $definition ) {
 				list( $object, $field, $original_value ) = $definition;
 				// Overwrite value with what we stored as the original value.
 				uopz_set_property( $object, $field, $original_value );
 			}
 		}
-		$this->uopz_set_properties = [];
+		self::$uopz_set_properties = [];
 	}
 
 	/**
@@ -65,7 +65,7 @@ trait With_Uopz {
 			$this->markTestSkipped( 'uopz extension is not installed' );
 		}
 		uopz_set_return( $fn, $value, $execute );
-		$this->uopz_set_returns[] = $fn;
+		self::$uopz_set_returns[] = $fn;
 	}
 
 	private function set_const_value( $const, ...$args ) {
@@ -88,7 +88,7 @@ trait With_Uopz {
 				};
 			}
 			uopz_redefine( $const, $args[0] );
-			$this->uopz_redefines[] = $restore_callback;
+			self::$uopz_redefines[] = $restore_callback;
 
 			return;
 		}
@@ -112,7 +112,7 @@ trait With_Uopz {
 			};
 		}
 		uopz_redefine( $const, ...$args );
-		$this->uopz_redefines[] = $restore_callback;
+		self::$uopz_redefines[] = $restore_callback;
 	}
 
 	private function set_class_fn_return( $class, $method, $value, $execute = false ) {
@@ -120,7 +120,7 @@ trait With_Uopz {
 			$this->markTestSkipped( 'uopz extension is not installed' );
 		}
 		uopz_set_return( $class, $method, $value, $execute );
-		$this->uopz_set_returns[] = [ $class, $method ];
+		self::$uopz_set_returns[] = [ $class, $method ];
 	}
 
 	/**
@@ -135,7 +135,7 @@ trait With_Uopz {
 		$original_value = uopz_get_property( $object, $field );
 		uopz_set_property( $object, $field, $value );
 		// Store here to override, i.e. unset, later.
-		$this->uopz_set_properties[] = [ $object, $field, $original_value ];
+		self::$uopz_set_properties[] = [ $object, $field, $original_value ];
 	}
 
 	private function add_class_fn( $class, $function, $handler ) {
@@ -147,7 +147,7 @@ trait With_Uopz {
 			$function,
 			$handler
 		);
-		$this->uopz_add_class_fns[] = [ $class, $function ];
+		self::$uopz_add_class_fns[] = [ $class, $function ];
 	}
 
 	/**
@@ -158,10 +158,10 @@ trait With_Uopz {
 			$this->markTestSkipped( 'uopz extension is not installed' );
 		}
 
-		foreach ( $this->uopz_add_class_fns as $definition ) {
+		foreach ( self::$uopz_add_class_fns as $definition ) {
 			list( $class, $function ) = $definition;
 			uopz_del_function( $class, $function );
 		}
-		$this->uopz_add_class_fns = [];
+		self::$uopz_add_class_fns = [];
 	}
 }


### PR DESCRIPTION
Ticket: [TEC-4542](https://theeventscalendar.atlassian.net/browse/TEC-4542)

Add the `Tribe__Context::is_editing_posts_list( $post_type): bool`
method to the context to allow unified detection of an admin posts list
edit screen for specified post types.

Artifacts: tests


[TEC-4542]: https://theeventscalendar.atlassian.net/browse/TEC-4542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ