### PR TITLE
Fix the pagination styling on the Aggregator import preview data table.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 = [TBD] TBD =
 
-* Fix - Fix the pagination styling on the Aggregator import preview data table. [TCMN-163]
+* Fix - Fix the pagination styling on the Aggregator import preview data table. [TEC-4698]
 
 = [5.0.10] 2023-02-09 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Fix the pagination styling on the Aggregator import preview data table. [TCMN-163]
+
 = [5.0.10] 2023-02-09 =
 
 * Feature - Add new `get_contrast_color` and `get_contrast_ratio` methods to the color utility for determining contrasting colors. [ET-1551]

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -260,7 +260,7 @@ class Tribe__Main {
 			[
 				[ 'tribe-ui', 'tribe-ui.css', [ 'tec-variables-full' ] ],
 				[ 'tribe-buttonset', 'buttonset.js', [ 'jquery', 'underscore' ] ],
-				[ 'tribe-common-admin', 'tribe-common-admin.css', [ 'tec-variables-skeleton', 'tec-variables-full', 'tribe-dependency-style', 'tribe-bumpdown-css', 'tribe-buttonset-style', 'tribe-select2-css' ] ],
+				[ 'tribe-common-admin', 'tribe-common-admin.css', [ 'tec-variables-skeleton', 'tec-variables-full', 'tribe-dependency-style', 'tribe-bumpdown-css', 'tribe-buttonset-style', 'tribe-select2-css', 'datatables-css' ] ],
 				[ 'tribe-validation', 'validation.js', [ 'jquery', 'underscore', 'tribe-common', 'tribe-utils-camelcase', 'tribe-tooltipster' ] ],
 				[ 'tribe-validation-style', 'validation.css', [ 'tec-variables-full', 'tribe-tooltipster-css' ] ],
 				[ 'tribe-dependency', 'dependency.js', [ 'jquery', 'underscore', 'tribe-common' ] ],


### PR DESCRIPTION
Ticket : [TEC-4698](https://theeventscalendar.atlassian.net/browse/TEC-4698)

I'm enqueuing the `datatables-css` stylesheet in order to fix the borked pagination stying on the Aggregator import preview data table. 

For context, the stylesheet was previously registered [here](https://github.com/the-events-calendar/tribe-common/blob/cca67a481cff1f12942cfc1cc64d7e83cbbf8e59/src/Tribe/Main.php#L231) but was never enqueued.

**Artifacts 📸**

Here we can see the pagination UI is borked prior to enqueuing the styles.

![image](https://user-images.githubusercontent.com/22029087/218877712-20c73cd6-c89b-4edb-a109-429b72412aa8.png)

Here the UI is fixed.

![image](https://user-images.githubusercontent.com/22029087/218877498-d710f754-fd67-4048-ba72-8a5e00915ffb.png)


[TCMN-163]: https://theeventscalendar.atlassian.net/browse/TCMN-163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TEC-4698]: https://theeventscalendar.atlassian.net/browse/TEC-4698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ