### PR TITLE
Fix Missing Attendee Collection Component on Ticket Block

### DIFF
--- a/src/Tribe/Editor.php
+++ b/src/Tribe/Editor.php
@@ -35,6 +35,11 @@ class Tribe__Editor {
 	public function should_load_blocks() {
 		$should_load_blocks = (boolean) $this->are_blocks_enabled();
 
+		// Run only on event.
+		if ( function_exists( 'tribe_is_event' ) && ! tribe_is_event() ) {
+			return $should_load_blocks;
+		}
+
 		/**
 		 * Filters whether the Blocks Editor should be activated or not for events.
 		 *


### PR DESCRIPTION
### 🎫 Ticket

[831](https://theeventscalendar.atlassian.net/browse/ETP-831)

### 🗒️ Description

When you try to use a ticket block on a post or page with “Activate Block Editor for Events” unchecked, you are not able to see the “Attendee Collection” and “Attendee Information” options. I have added a conditional to run only for events in the should_load_blocks method in Events Tickets to fix this.

### 🎥 Artifacts <!-- if applicable-->

### ✔️ Checklist
- [] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->
- [] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).
