### PR TITLE
[ET-1565] Common > Create Customizable WYSIWYG Editor

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Enhancement - Added a way to customize the WYSIWYG editor field by passing in a `settings` parameter. [ET-1565]
+
 = [5.0.11] 2023-02-22 =
 
 * Tweak - PHP version compatibility bumped to PHP 7.4

--- a/src/Tribe/Admin/Wysiwyg.php
+++ b/src/Tribe/Admin/Wysiwyg.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Tribe\Admin;
+
+/**
+ * Admin Wysiwyg class.
+ * 
+ * @since TBD
+ */
+
+class Wysiwyg {
+
+	/**
+	 * Unique name given to editor in case more than one is being used on the same page.
+	 * 
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected $name = '';
+
+	/**
+	 * Initial HTML of the editor.
+	 *
+	 * @since TBD
+	 * 
+	 * @var string
+	 */
+	protected $value = '';
+
+	/**
+	 * Settings to pass into the editor.
+	 *
+	 * @since TBD
+	 * 
+	 * @var array
+	 */
+	protected $args = [];
+
+	/**
+	 * Create a new Wywiwyg object.
+	 *
+	 * @since TBD
+	 * 
+	 * @param string $name  Unique name given to editor.
+	 * @param string $value Initial value/HTML.
+	 * @param array  $args  Array of settings.
+	 * 
+	 * @return void
+	 */
+	function __construct( $name, $value = '', $args = [] ) {
+		$this->name = $name;
+		$this->value = $value;
+		$default_args = [
+			'teeny'   => true,
+			'wpautop' => true,
+		];
+		$this->args = wp_parse_args( $args, $default_args );
+	}
+
+	/**
+	 * Filters editor buttons.
+	 * 
+	 * @since TBD
+	 * 
+	 * @param  array $buttons Array of buttons to include.
+	 * 
+	 * @return array Filtered array of buttons.
+	 */
+	public function filter_buttons( $buttons ) {
+		if (
+			empty( $this->args )
+			|| ! isset( $this->args['buttons'] )
+			|| empty( $this->args['buttons'] )
+		) {
+			return $buttons;
+		}
+
+		return $this->args['buttons'];
+	}
+
+	/**
+	 * Filter 2nd row of buttons.
+	 * 
+	 * @since TBD
+	 *
+	 * @param  array $buttons Array of buttons to include.
+	 * 
+	 * @return array Filtered array of buttons.
+	 */
+	public function maybe_filter_buttons_2( $buttons ) {
+		if (
+			empty( $this->args ) ||
+			! isset( $this->args['buttons_2'] ) ||
+			empty( $this->args['buttons_2'] )
+		) {
+			return $buttons;
+		}
+
+		return $this->args['buttons_2'];
+	}
+
+	/**
+	 * Get HTML of editor.
+	 * 
+	 * @since TBD
+	 *
+	 * @return string HTML of editor
+	 */
+	public function get_html() {
+		// Add button filters.
+		add_filter( 'teeny_mce_buttons', [ $this, 'filter_buttons' ] );
+		add_filter( 'tiny_mce_buttons', [ $this, 'filter_buttons' ] );
+		add_filter( 'mce_buttons', [ $this, 'filter_buttons' ] );
+		add_filter( 'mce_buttons_2', [ $this, 'maybe_filter_buttons_2' ] );
+
+		// Get HTML of editor.
+		ob_start();
+		wp_editor( html_entity_decode( ( $this->value ) ), $this->name, $this->args );
+		$html = ob_get_clean();
+
+		// Remove button filters.
+		remove_filter( 'teeny_mce_buttons', [ $this, 'filter_buttons' ] );
+		remove_filter( 'tiny_mce_buttons', [ $this, 'filter_buttons' ] );
+		remove_filter( 'mce_buttons', [ $this, 'filter_buttons' ] );
+		remove_filter( 'mce_buttons_2', [ $this, 'maybe_filter_buttons_2' ] );
+
+		return $html;
+	}
+
+	/**
+	 * Renders editor HTML.
+	 * 
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function render_html() {
+		echo $this->get_html();
+	}
+	
+}

--- a/src/Tribe/Admin/Wysiwyg.php
+++ b/src/Tribe/Admin/Wysiwyg.php
@@ -38,7 +38,7 @@ class Wysiwyg {
 	protected $args = [];
 
 	/**
-	 * Create a new Wywiwyg object.
+	 * Create a new Wysiwyg object.
 	 *
 	 * @since TBD
 	 * 

--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -3,6 +3,7 @@
 // Don't load directly
 
 use Tribe\Admin\Settings;
+use Tribe\Admin\Wysiwyg;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
@@ -58,6 +59,15 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 		 */
 		public $valid_field_types;
 
+		/**
+		 * Settings array.
+		 * 
+		 * @since TBD
+		 * 
+		 * @var array
+		 */
+		public $settings;
+
 
 		/**
 		 * Class constructor
@@ -93,6 +103,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 				'clear_after'         => true,
 				'tooltip_first'       => false,
 				'allow_clear'         => false,
+				'settings'            => [],
 			];
 
 			// a list of valid field types, to prevent screwy behavior
@@ -196,6 +207,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 			$clear_after      = (bool) $args['clear_after'];
 			$tooltip_first    = (bool) $args['tooltip_first'];
 			$allow_clear      = (bool) $args['allow_clear'];
+			$settings         = $args['settings'];
 
 			// set the ID
 			$this->id = apply_filters( 'tribe_field_id', $id );
@@ -503,17 +515,11 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 		 * @return string the field
 		 */
 		public function wysiwyg() {
-			$settings = [
-				'teeny'   => true,
-				'wpautop' => true,
-			];
-			ob_start();
-			wp_editor( html_entity_decode( ( $this->value ) ), $this->name, $settings );
-			$editor = ob_get_clean();
+			$mce = new Wysiwyg( $this->name, $this->value, $this->settings );
 			$field  = $this->do_field_start();
 			$field .= $this->do_field_label();
 			$field .= $this->do_field_div_start();
-			$field .= $editor;
+			$field .= $mce->get_html();
 			$field .= $this->do_screen_reader_label();
 			$field .= $this->do_field_div_end();
 			$field .= $this->do_field_end();


### PR DESCRIPTION
Note: This PR is a copy of https://github.com/the-events-calendar/tribe-common/pull/1797 which was merged into the `G22.parksosaurus` release awhile ago. The `G22.parksosaurus` branch was never pulled into common when it was released to production, so we're re-introducing it now.

# Ticket
[ET-1565]

# Description
This enhances the current WYSIWYG field to accept settings so that you can customize the features that WP Editor uses.

The settings can be found here: https://developer.wordpress.org/reference/classes/_WP_Editors/parse_settings/

It also adds the ability to pass in what buttons you'd like to show within the editor.

Example usage:
```
$wysiwyg_field = [
	'type'                => 'wysiwyg',
	'label'               => esc_html__( 'Field Label', 'event-tickets' ),
	'tooltip'             => esc_html__( 'This is the description of the field.', 'tribe-common' ),
	'default'             => '',
	'validation_type'     => 'html',
	'settings'            => [
		'media_buttons' => false,
		'quicktags'     => false,
		'editor_height' => 200,
		'buttons'       => [
			'bold',
			'italic',
			'underline',
			'strikethrough',
		],
	]
];
```

[ET-1565]: https://theeventscalendar.atlassian.net/browse/ET-1565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ