### PR TITLE
Updating monolog namespaces to use strauss namespacing.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,8 @@
       "packages": [
         "stellarwp/container-contract",
         "stellarwp/db",
-        "stellarwp/installer"
+        "stellarwp/installer",
+        "monolog/monolog"
       ],
       "delete_vendor_files": true
     }

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,7 @@
 
 * Feature - Add the `is_editing_posts_list` method to the `Tribe__Context` class. [APM-5]
 * Fix - Fix a false positive on checking if a cache value is set after cache expiration passed.
+* Fix - Updates the Monolog repository to use TEC namespacing via Strauss, to provide more compatibility with other plugins. [TEC-4730]
 
 = [5.0.11] 2023-02-22 =
 

--- a/src/Tribe/Log/Action_Logger.php
+++ b/src/Tribe/Log/Action_Logger.php
@@ -9,7 +9,7 @@
 
 namespace Tribe\Log;
 
-use Monolog\Logger;
+use TEC\Common\Monolog\Logger;
 use Tribe__Log;
 
 /**

--- a/src/Tribe/Log/Canonical_Formatter.php
+++ b/src/Tribe/Log/Canonical_Formatter.php
@@ -11,8 +11,8 @@
 namespace Tribe\Log;
 
 
-use Monolog\Formatter\FormatterInterface;
-use Monolog\Formatter\LineFormatter;
+use TEC\Common\Monolog\Formatter\FormatterInterface;
+use TEC\Common\Monolog\Formatter\LineFormatter;
 
 class Canonical_Formatter implements FormatterInterface {
 	/**

--- a/src/Tribe/Log/Monolog_Logger.php
+++ b/src/Tribe/Log/Monolog_Logger.php
@@ -9,7 +9,7 @@
 
 namespace Tribe\Log;
 
-use Monolog\Logger;
+use TEC\Common\Monolog\Logger;
 
 /**
  * Class Monolog_Logger

--- a/src/Tribe/Log/Service_Provider.php
+++ b/src/Tribe/Log/Service_Provider.php
@@ -10,9 +10,9 @@
 namespace Tribe\Log;
 
 
-use Monolog\Handler\ErrorLogHandler;
-use Monolog\Handler\NullHandler;
-use Monolog\Logger;
+use TEC\Common\Monolog\Handler\ErrorLogHandler;
+use TEC\Common\Monolog\Handler\NullHandler;
+use TEC\Common\Monolog\Logger;
 use Psr\Log\NullLogger;
 
 class Service_Provider extends \tad_DI52_ServiceProvider {

--- a/tests/_support/Traits/With_Log_Recording.php
+++ b/tests/_support/Traits/With_Log_Recording.php
@@ -10,9 +10,9 @@
 
 namespace Tribe\Tests\Traits;
 
-use Monolog\Formatter\FormatterInterface;
-use Monolog\Handler\HandlerInterface;
-use Monolog\Logger;
+use TEC\Common\Monolog\Formatter\FormatterInterface;
+use TEC\Common\Monolog\Handler\HandlerInterface;
+use TEC\Common\Monolog\Logger;
 use PHPUnit\Framework\Assert;
 
 trait With_Log_Recording {

--- a/tests/wpunit/Tribe/Log/Canonical_FormatterTest.php
+++ b/tests/wpunit/Tribe/Log/Canonical_FormatterTest.php
@@ -2,7 +2,7 @@
 
 namespace Tribe\Log;
 
-use Monolog\Logger;
+use TEC\Common\Monolog\Logger;
 
 class Canonical_FormatterTest extends \Codeception\TestCase\WPTestCase {
 	/**

--- a/tests/wpunit/Tribe/Log/ProviderTest.php
+++ b/tests/wpunit/Tribe/Log/ProviderTest.php
@@ -2,7 +2,7 @@
 
 namespace Tribe\Log;
 
-use Monolog\Handler\NullHandler;
+use TEC\Common\Monolog\Handler\NullHandler;
 use Tribe\Tests\Traits\With_Uopz;
 
 class ProviderTest extends \Codeception\TestCase\WPTestCase {


### PR DESCRIPTION
[TEC-4730](https://theeventscalendar.atlassian.net/browse/TEC-4730)

This will resolve conflicts with other libraries using various versions of Monolog. This is using the Strauss namespace rewrite to consolidate to our TEC namespace. 

Several other repos will need updates, mostly for tests.

Artifacts:
<img width="831" alt="Captura de Tela 2023-03-03 às 13 04 40" src="https://user-images.githubusercontent.com/2826045/223804835-be0d9acc-793f-4949-adb4-043356c00f29.png">


[TEC-4730]: https://theeventscalendar.atlassian.net/browse/TEC-4730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ