### PR TITLE
Add is_inline_editing_post method to Context

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 * Feature - Add the `is_editing_posts_list` method to the `Tribe__Context` class. [APM-5]
 * Fix - Fix a false positive on checking if a cache value is set after cache expiration passed.
 * Feature - Add the `Tribe__Context::is_inline_editing_post` method.
-* Tweak - Extract `TEC\Common\Context\Post_Request_Type` class from `Tribe__Context` class; proxy post state methods to it.
+* Tweak - Extract `TEC\Common\Context\Post_Request_Type` class from `Tribe__Context` class; proxy post request type methods to it.
 
 = [5.0.11] 2023-02-22 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@
 * Feature - Add the `is_editing_posts_list` method to the `Tribe__Context` class. [APM-5]
 * Fix - Fix a false positive on checking if a cache value is set after cache expiration passed.
 * Feature - Add the `Tribe__Context::is_inline_editing_post` method.
-* Tweak - Extract `TEC\Common\Context\Post_State` class from `Tribe__Context` class; proxy post state methods to it.
+* Tweak - Extract `TEC\Common\Context\Post_Request_Type` class from `Tribe__Context` class; proxy post state methods to it.
 
 = [5.0.11] 2023-02-22 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,8 @@
 
 * Feature - Add the `is_editing_posts_list` method to the `Tribe__Context` class. [APM-5]
 * Fix - Fix a false positive on checking if a cache value is set after cache expiration passed.
+* Feature - Add the `Tribe__Context::is_inline_editing_post` method.
+* Tweak - Extract `TEC\Common\Context\Post_State` class from `Tribe__Context` class; proxy post state methods to it.
 
 = [5.0.11] 2023-02-22 =
 

--- a/src/Common/Context/Post_Request_Type.php
+++ b/src/Common/Context/Post_Request_Type.php
@@ -97,7 +97,7 @@ class Post_Request_Type {
 	 *
 	 * @return bool
 	 */
-	public function is_editing_post( $post_or_type = null ) {
+	public function is_editing_post( $post_or_type = null ): bool {
 		global $pagenow;
 		$is_new     = 'post-new.php' === $pagenow;
 		$is_post    = 'post.php' === $pagenow;

--- a/src/Common/Context/Post_Request_Type.php
+++ b/src/Common/Context/Post_Request_Type.php
@@ -13,13 +13,13 @@ use WP_Post;
 use Tribe__Utils__Array as Arr;
 
 /**
- * Class Post_State.
+ * Class Post_Request_Type.
  *
  * @since   TBD
  *
  * @package TEC\Common\Context;
  */
-class Post_State {
+class Post_Request_Type {
 
 	/**
 	 * Whether the current request is one to quick edit a single post of the specified post type or not.

--- a/src/Common/Context/Post_State.php
+++ b/src/Common/Context/Post_State.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Provides methods to check and get the post state from the current request context.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Common\Context;
+ */
+
+namespace TEC\Common\Context;
+
+use WP_Post;
+use Tribe__Utils__Array as Arr;
+
+/**
+ * Class Post_State.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Common\Context;
+ */
+class Post_State {
+
+	/**
+	 * Whether the current request is one to quick edit a single post of the specified post type or not.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|array<string> $post_type The post type or post types to check.
+	 *
+	 * @return bool Whether the current request is one to quick edit a single post of the specified post type or not.
+	 */
+	public function is_inline_editing_post( $post_type ): bool {
+		if ( ! ( ! empty( $post_type ) && wp_doing_ajax() && tribe_get_request_var( 'action' ) === 'inline-save' ) ) {
+			return false;
+		}
+
+		$post_id = tribe_get_request_var( 'post_ID', null );
+
+		if ( empty( $post_id ) || ! is_numeric( $post_id ) ) {
+			return false;
+		}
+
+		return in_array( get_post_type( $post_id ), (array) $post_type, true );
+	}
+
+	/**
+	 * Whether the current request is one to edit a list of the specified post types or not.
+	 *
+	 * The admin edit screen for a post type is the one that lists all the posts of that typ,
+	 * it has the URL `/wp-admin/edit.php?post_type=<post_type>`.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|array<string> $post_type The post type or post types to check.
+	 *
+	 * @return bool Whether the current request is one to edit a list of the specified post types or not.
+	 */
+	public function is_editing_post_list( $post_type ): bool {
+		// Quick check: are we on the `/wp-admin/edit.php` page?
+		global $pagenow;
+
+		if ( $pagenow !== 'edit.php' ) {
+			return false;
+		}
+
+		// Run some more thorough checks for the post type(s).
+		$post_types = array_filter( (array) $post_type );
+
+		return $this->is_editing_post( $post_types );
+	}
+
+	/**
+	 * Whether we are currently creating a new post, a post of post type(s) or not.
+	 *
+	 * @since 4.7.7
+	 *
+	 * @param null $post_type The optional post type to check.
+	 *
+	 * @return bool Whether we are currently creating a new post, a post of post type(s) or not.
+	 */
+	public function is_new_post( $post_type = null ): bool {
+		global $pagenow;
+		$is_new = 'post-new.php' === $pagenow;
+
+		return $is_new && $this->is_editing_post( $post_type );
+	}
+
+
+	/**
+	 * Whether we are currently editing a post(s), post type(s) or not.
+	 *
+	 * @since 4.7.7
+	 *
+	 * @param null|array|string|int $post_or_type A post ID, post type, an array of post types or post IDs, `null`
+	 *                                            to just make sure we are currently editing a post.
+	 *
+	 * @return bool
+	 */
+	public function is_editing_post( $post_or_type = null ) {
+		global $pagenow;
+		$is_new     = 'post-new.php' === $pagenow;
+		$is_post    = 'post.php' === $pagenow;
+		$is_editing = 'edit.php' === $pagenow;
+
+		if ( ! ( $is_new || $is_post || $is_editing ) ) {
+			return false;
+		}
+
+		if ( ! empty( $post_or_type ) ) {
+			$lookup = [];
+			// Prevent a slew of warnings every time we call this.
+			if ( isset( $_REQUEST ) ) {
+				$lookup[] = (array) $_REQUEST;
+			}
+
+			if ( isset( $_GET ) ) {
+				$lookup[] = (array) $_GET;
+			}
+
+			if ( isset( $_POST ) ) {
+				$lookup[] = (array) $_POST;
+			}
+
+			if ( empty( $lookup ) ) {
+				return false;
+			}
+
+			$current_post = Arr::get_in_any( $lookup, 'post', get_post() );
+
+			if ( is_numeric( $post_or_type ) ) {
+				$post = $is_post ? get_post( $post_or_type ) : null;
+
+				return ! empty( $post ) && $post == $current_post;
+			}
+
+			$post_types = is_array( $post_or_type ) ? $post_or_type : [ $post_or_type ];
+
+			$post = $is_post ? get_post( $current_post ) : null;
+
+			if ( count( array_filter( $post_types, 'is_numeric' ) ) === count( $post_types ) ) {
+				return ! empty( $post ) && in_array( $post->ID, $post_types );
+			}
+
+			if ( $is_post && $post instanceof WP_Post ) {
+				$post_type = $post->post_type;
+			} else {
+				$post_type = Arr::get_in_any( $lookup, 'post_type', 'post' );
+			}
+
+			return (bool) count( array_intersect( $post_types, [ $post_type ] ) );
+		}
+
+		return $is_new || $is_post;
+	}
+}

--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -291,7 +291,7 @@ class Tribe__Context {
 	 *
 	 * @return bool
 	 */
-	public function is_editing_post( $post_or_type = null ) {
+	public function is_editing_post( $post_or_type = null ): bool {
 		return $this->post_state->is_editing_post( $post_or_type );
 	}
 

--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -1,6 +1,6 @@
 <?php
 
-use TEC\Common\Context\Post_State;
+use TEC\Common\Context\Post_Request_Type;
 use Tribe__Utils__Array as Arr;
 
 /**
@@ -251,26 +251,26 @@ class Tribe__Context {
 	 *
 	 * @since TBD
 	 *
-	 * @var Post_State
+	 * @var Post_Request_Type
 	 */
-	protected Post_State $post_state;
+	protected Post_Request_Type $post_state;
 
 	/**
 	 * Tribe__Context constructor.
 	 *
 	 * since TBD
 	 *
-	 * @param Post_State|null $post_state An instance of the post state handler.
+	 * @param Post_Request_Type|null $post_state An instance of the post state handler.
 	 */
-	public function __construct( Post_State $post_state = null ) {
-		$this->post_state = $post_state ?: tribe( Post_State::class );
+	public function __construct( Post_Request_Type $post_state = null ) {
+		$this->post_state = $post_state ?: tribe( Post_Request_Type::class );
 	}
 
 	/**
 	 * Whether we are currently creating a new post, a post of post type(s) or not.
 	 *
 	 * @since 4.7.7
-	 * @since TBD Extracted the logic to the `TEC\Common\Context\Post_State` class.
+	 * @since TBD Extracted the logic to the `TEC\Common\Context\Post_Request_Type` class.
 	 *
 	 * @param null $post_type The optional post type to check.
 	 *
@@ -284,7 +284,7 @@ class Tribe__Context {
 	 * Whether we are currently editing a post(s), post type(s) or not.
 	 *
 	 * @since 4.7.7
-	 * @since TBD Extracted the logic to the `TEC\Common\Context\Post_State` class.
+	 * @since TBD Extracted the logic to the `TEC\Common\Context\Post_Request_Type` class.
 	 *
 	 * @param null|array|string|int $post_or_type A post ID, post type, an array of post types or post IDs, `null`
 	 *                                            to just make sure we are currently editing a post.
@@ -1630,7 +1630,7 @@ class Tribe__Context {
 	 * it has the URL `/wp-admin/edit.php?post_type=<post_type>`.
 	 *
 	 * @since TBD
-	 * @since TBD Extracted the logic to the `TEC\Common\Context\Post_State` class.
+	 * @since TBD Extracted the logic to the `TEC\Common\Context\Post_Request_Type` class.
 	 *
 	 * @param string|array<string> $post_type The post type or post types to check.
 	 *

--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -1,5 +1,6 @@
 <?php
 
+use TEC\Common\Context\Post_State;
 use Tribe__Utils__Array as Arr;
 
 /**
@@ -246,25 +247,44 @@ class Tribe__Context {
 	protected $use_default_locations = true;
 
 	/**
+	 * An instance of the post state handler.
+	 *
+	 * @since TBD
+	 *
+	 * @var Post_State
+	 */
+	protected Post_State $post_state;
+
+	/**
+	 * Tribe__Context constructor.
+	 *
+	 * since TBD
+	 *
+	 * @param Post_State|null $post_state An instance of the post state handler.
+	 */
+	public function __construct( Post_State $post_state = null ) {
+		$this->post_state = $post_state ?: tribe( Post_State::class );
+	}
+
+	/**
 	 * Whether we are currently creating a new post, a post of post type(s) or not.
 	 *
 	 * @since 4.7.7
+	 * @since TBD Extracted the logic to the `TEC\Common\Context\Post_State` class.
 	 *
 	 * @param null $post_type The optional post type to check.
 	 *
 	 * @return bool Whether we are currently creating a new post, a post of post type(s) or not.
 	 */
 	public function is_new_post( $post_type = null ) {
-		global $pagenow;
-		$is_new = 'post-new.php' === $pagenow;
-
-		return $is_new && $this->is_editing_post( $post_type );
+		return $this->post_state->is_new_post( $post_type );
 	}
 
 	/**
 	 * Whether we are currently editing a post(s), post type(s) or not.
 	 *
 	 * @since 4.7.7
+	 * @since TBD Extracted the logic to the `TEC\Common\Context\Post_State` class.
 	 *
 	 * @param null|array|string|int $post_or_type A post ID, post type, an array of post types or post IDs, `null`
 	 *                                            to just make sure we are currently editing a post.
@@ -272,61 +292,7 @@ class Tribe__Context {
 	 * @return bool
 	 */
 	public function is_editing_post( $post_or_type = null ) {
-		global $pagenow;
-		$is_new  = 'post-new.php' === $pagenow;
-		$is_post = 'post.php' === $pagenow;
-		$is_editing = 'edit.php' === $pagenow;
-
-		if ( ! ( $is_new || $is_post || $is_editing ) ) {
-			return false;
-		}
-
-		if ( ! empty( $post_or_type ) ) {
-			$lookup = [];
-			// Prevent a slew of warnings every time we call this.
-			if ( isset( $_REQUEST ) ) {
-				$lookup[] = (array) $_REQUEST;
-			}
-
-			if ( isset( $_GET ) ) {
-				$lookup[] = (array) $_GET;
-			}
-
-			if ( isset( $_POST ) ) {
-				$lookup[] = (array) $_POST;
-			}
-
-			if ( empty( $lookup ) ) {
-				return false;
-			}
-
-			$current_post = Tribe__Utils__Array::get_in_any( $lookup, 'post', get_post() );
-
-			if ( is_numeric( $post_or_type ) ) {
-
-				$post = $is_post ? get_post( $post_or_type ) : null;
-
-				return ! empty( $post ) && $post == $current_post;
-			}
-
-			$post_types = is_array( $post_or_type ) ? $post_or_type : [ $post_or_type ];
-
-			$post = $is_post ? get_post( $current_post ) : null;
-
-			if ( count( array_filter( $post_types, 'is_numeric' ) ) === count( $post_types ) ) {
-				return ! empty( $post ) && in_array( $post->ID, $post_types );
-			}
-
-			if ( $is_post && $post instanceof WP_Post ) {
-				$post_type = $post->post_type;
-			} else {
-				$post_type = Tribe__Utils__Array::get_in_any( $lookup, 'post_type', 'post' );
-			}
-
-			return (bool) count( array_intersect( $post_types, [ $post_type ] ) );
-		}
-
-		return $is_new || $is_post;
+		return $this->post_state->is_editing_post( $post_or_type );
 	}
 
 	/**
@@ -1664,22 +1630,26 @@ class Tribe__Context {
 	 * it has the URL `/wp-admin/edit.php?post_type=<post_type>`.
 	 *
 	 * @since TBD
+	 * @since TBD Extracted the logic to the `TEC\Common\Context\Post_State` class.
 	 *
 	 * @param string|array<string> $post_type The post type or post types to check.
 	 *
 	 * @return bool Whether the current request is one to edit a list of the specified post types or not.
 	 */
 	public function is_editing_posts_list( $post_type ): bool {
-		// Quick check: are we on the `/wp-admin/edit.php` page?
-		global $pagenow;
+		return $this->post_state->is_editing_post_list( $post_type );
+	}
 
-		if ( $pagenow !== 'edit.php' ) {
-			return false;
-		}
-
-		// Run some more thorough checks for the post type(s).
-		$post_types = array_filter( (array) $post_type );
-
-		return $this->is_editing_post( $post_types );
+	/**
+	 * Whether the current request is one to quick edit a single post of the specified post type or not.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|array<string> $post_type The post type or post types to check.
+	 *
+	 * @return bool Whether the current request is one to quick edit a single post of the specified post type or not.
+	 */
+	public function is_inline_editing_post( $post_type ): bool {
+		return $this->post_state->is_inline_editing_post( $post_type );
 	}
 }


### PR DESCRIPTION
[ECP-1261](https://theeventscalendar.atlassian.net/browse/ECP-1261)

Required by [ECP PR](https://github.com/the-events-calendar/events-pro/pull/2223).

Artifacts: tests

Update the `Tribe__Context` class to add the `is_inline_editing_post` method to detect quick-edit of posts.
Refactor the `Tribe__Conext` class to start  breaking it down to a façade that will delegate specialized logic to smaller classes; start by extracting the `TEC\Common\Context\Post_Request_Type` class.


[ECP-1261]: https://theeventscalendar.atlassian.net/browse/ECP-1261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ