### PR TITLE
Add Validation for Email List

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [TBD] TBD =
 
 * Fix - Fixed issue with "Upload Theme" button not working properly when a notification was displayed on the Theme page. [CT-77]
+* Enhancement - Added an `email_list` validation check for validating a delimited string of valid email addresses. [ET-1621]
 
 = [5.0.13] 2023-03-20 =
 

--- a/src/Tribe/Validate.php
+++ b/src/Tribe/Validate.php
@@ -500,6 +500,38 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 		}
 
 		/**
+		 * Validates and sanitizes a list of email addresses.
+		 *
+		 * @since TBD
+		 */
+		public function email_list() {
+			$candidate = trim( $this->value );
+			$emails = preg_split( '[,|;]', $candidate );
+			$this->result->valid = true;
+			$sanitized_emails = [];
+
+			foreach ( $emails as $email ) {
+				if ( ! filter_var( trim( $email ), FILTER_VALIDATE_EMAIL ) ) {
+					$this->result->valid = false;
+					break;
+				}
+				$sanitized_emails[] = filter_var( trim( $email ), FILTER_SANITIZE_EMAIL );
+			}
+
+			$this->result->valid = true;
+
+			if ( ! $this->result->valid ) {
+				$this->result->error = sprintf( 
+					// Translators: %s - Label of the form input field.
+					esc_html__( '%s must be a list of valid email addresses separated by commas or semicolons.', 'tribe-common' ),
+					$this->label
+				);
+			} else {
+				$this->value = implode( ', ', $sanitized_emails );
+			}
+		}
+
+		/**
 		 * Validates and sanitizes a HTML color codes, including hex, rgb, rgba, hsl and hsla.
 		 *
 		 * @since 5.0.0

--- a/src/Tribe/Validate.php
+++ b/src/Tribe/Validate.php
@@ -505,21 +505,29 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 		 * @since TBD
 		 */
 		public function email_list() {
-			$candidate = trim( $this->value );
-			$emails = preg_split( '[,|;]', $candidate );
+			$value = trim( $this->value );
 			$this->result->valid = true;
 			$sanitized_emails = [];
 
+			// Break emails into an array.
+			$emails = preg_split( '[,|;]', $value );
+			
 			foreach ( $emails as $email ) {
-				if ( ! filter_var( trim( $email ), FILTER_VALIDATE_EMAIL ) ) {
+				// In case there's a blank email or extra comma/semicolon, skip with no error.
+				if ( empty( $email ) ) {
+					continue;
+				}
+
+				// Sanitized email returns blank if invalid.
+				$email = sanitize_email( trim( $email ) );
+				if ( empty( $email ) ) {
 					$this->result->valid = false;
 					break;
 				}
-				$sanitized_emails[] = filter_var( trim( $email ), FILTER_SANITIZE_EMAIL );
+				$sanitized_emails[] = $email;
 			}
 
-			$this->result->valid = true;
-
+			// If any of the emails are invalid, throw an error.
 			if ( ! $this->result->valid ) {
 				$this->result->error = sprintf( 
 					// Translators: %s - Label of the form input field.

--- a/src/Tribe/Validate.php
+++ b/src/Tribe/Validate.php
@@ -510,7 +510,7 @@ if ( ! class_exists( 'Tribe__Validate' ) ) {
 			$sanitized_emails = [];
 
 			// Break emails into an array.
-			$emails = preg_split( '[,|;]', $value );
+			$emails = preg_split( '/[,;]+/', $value );
 			
 			foreach ( $emails as $email ) {
 				// In case there's a blank email or extra comma/semicolon, skip with no error.


### PR DESCRIPTION
### Tickets
[ET-1621]
[ET-1622]

### Description
The new Tickets Emails feature will have settings fields that allow for a comma separated listing of emails. We needed to create a way to validate each email in the field before saving them. We're calling the `validation_type` `email_list`.

[ET-1621]: https://theeventscalendar.atlassian.net/browse/ET-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ET-1622]: https://theeventscalendar.atlassian.net/browse/ET-1622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ