### PR TITLE
chore(*) update version to 5.0.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tribe-common",
-  "version": "5.0.11",
+  "version": "5.0.13",
   "repository": "git@github.com:the-events-calendar/tribe-common.git",
   "_resourcepath": "src/resources",
   "_domainPath": "lang",

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -23,7 +23,7 @@ class Tribe__Main {
 	const OPTIONNAME          = 'tribe_events_calendar_options';
 	const OPTIONNAMENETWORK   = 'tribe_events_calendar_network_options';
 
-	const VERSION             = '5.0.11';
+	const VERSION             = '5.0.13';
 
 	const FEED_URL            = 'https://theeventscalendar.com/feed/';
 

--- a/tribe-common.php
+++ b/tribe-common.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Tribe Common
 Description: An event settings framework for managing shared options
-Version: 5.0.11
+Version: 5.0.13
 Author: The Events Calendar
 Author URI: http://evnt.is/1x
 Text Domain: tribe-common


### PR DESCRIPTION
Update the version to 5.0.13 to make sure the version of Common shipped with Event Tickets will not override the one that should be used in TEC.

Context: [ECP-1429](https://theeventscalendar.atlassian.net/browse/ECP-1429)


[ECP-1429]: https://theeventscalendar.atlassian.net/browse/ECP-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ