### PR TITLE
Removed enqueing assets to allow upload theme button to function.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tribe-common",
-  "version": "5.0.10",
+  "version": "5.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tribe-common",
-      "version": "5.0.10",
+      "version": "5.0.11",
       "dependencies": {
         "@babel/runtime": "^7.15.3",
         "@moderntribe/common": "file:src/modules",

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Fixed issue with "Upload Theme" button not working properly when a notification was displayed on the Theme page. [CT-77]
+
 = [5.0.11] 2023-02-22 =
 
 * Tweak - PHP version compatibility bumped to PHP 7.4

--- a/src/Tribe/Admin/Notice/Plugin_Download.php
+++ b/src/Tribe/Admin/Notice/Plugin_Download.php
@@ -67,8 +67,6 @@ class Tribe__Admin__Notice__Plugin_Download {
 		}
 
 		// Make sure Thickbox is available and consistent appearance regardless of which admin page we're on
-		wp_enqueue_style( 'plugin-install' );
-		wp_enqueue_script( 'plugin-install' );
 		add_thickbox();
 
 		$has_pue_notices = false;


### PR DESCRIPTION
[CT-77]

When there is an alert on the Dashboard regarding to download a plugin it breaks the "Upload Theme" button.  After debugging, I found that by removing the two enqueues for plugin-install it fixes the button. 

Artifact:

[Video](https://user-images.githubusercontent.com/12241059/226345136-72b45af4-f72b-4b94-80af-a1a12391cdc8.webm)

This video demonstrates how to replicate the issue by enabling ET+, CE, and CT while disabling ET, resulting in the notification appearing. When the download link is clicked, a popup appears with the plugin information, which remains unchanged before and after the changes made.

The video then showcases the theme page, where the "Upload Theme" button is clicked, and the upload area is displayed correctly. Next, ET is enabled, and the process is repeated to demonstrate that the "Upload Theme" button still functions the same way as before.


[CT-77]: https://theeventscalendar.atlassian.net/browse/CT-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ