### PR TITLE
[ET-1692] Fix toggle/checkbox description to be in the same line.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [TBD] TBD =
 
 * Fix - Fixed issue with "Upload Theme" button not working properly when a notification was displayed on the Theme page. [CT-77]
+* Tweak - Fix styles for checkboxes and toggle, to have the description in the same line. [ET-1692]
 
 = [5.0.13] 2023-03-20 =
 

--- a/src/resources/postcss/tribe-common-admin/_fields.pcss
+++ b/src/resources/postcss/tribe-common-admin/_fields.pcss
@@ -46,9 +46,11 @@
 		height: 18px;
 		position: relative;
 		transition: background 0.4s;
-		vertical-align: middle;
+		vertical-align: top;
 		width: 36px;
 		z-index: 10;
+		margin-top: 2px;
+		margin-right: var(--tec-spacer-2);
 
 		&:after,
 		&:before {

--- a/src/resources/postcss/tribe-common-admin/_main.pcss
+++ b/src/resources/postcss/tribe-common-admin/_main.pcss
@@ -244,6 +244,18 @@ table.plugins {
 			.tribe-style-selection {
 				margin-bottom: 18px;
 			}
+
+			.tribe-field-wrap {
+				input[type="checkbox"] ~ .description {
+					display: inline-block;
+					margin-top: 0;
+				}
+
+				input[type="checkbox"] {
+					margin-top: 2px !important;
+					vertical-align: top;
+				}
+			}
 		}
 
 		#tribe-field-stylesheetOption {


### PR DESCRIPTION
[ET-1692]

Porting what Stephen [added for TEC](https://github.com/the-events-calendar/the-events-calendar/pull/4047/files#diff-f1d94ae83aaa6d58df6393ae3b21188a064a64baed17eb963e061b10d7ba6f9dR486-R494) into common.

After changes:
<img width="1043" alt="Screenshot 2023-03-23 at 15 42 46" src="https://user-images.githubusercontent.com/252415/227240810-c216dfab-6e48-426a-9f58-e6f8d9197674.png">
<img width="739" alt="Screenshot 2023-03-23 at 15 42 10" src="https://user-images.githubusercontent.com/252415/227240842-96edd1f0-a890-4657-bbe8-d5127b5b6110.png">
