### PR TITLE
Use `tribe_sanitize_deep` instead of `tec_sanitize_string` in situations where we might get an array.

### DIFF
--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -10,6 +10,9 @@
  * @return string $string The sanitized version of the string.
  */
 function tec_sanitize_string( $string ) {
+	// Sanitize the string to remove any potentially malicious characters
+	$string = sanitize_text_field( $string );
+
 	// Replace HTML tags and entities with their plain text equivalents
 	$string = htmlspecialchars_decode( $string, ENT_QUOTES );
 

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -10,9 +10,6 @@
  * @return string $string The sanitized version of the string.
  */
 function tec_sanitize_string( $string ) {
-	// Sanitize the string to remove any potentially malicious characters
-	$string = sanitize_text_field( $string );
-
 	// Replace HTML tags and entities with their plain text equivalents
 	$string = htmlspecialchars_decode( $string, ENT_QUOTES );
 
@@ -1121,7 +1118,7 @@ if ( ! function_exists( 'tribe_get_request_vars' ) ) {
 			array_keys( $_REQUEST ),
 			array_map( static function ( $v )
 			{
-				return tec_sanitize_string( $v );
+				return tribe_sanitize_deep( $v );
 			},
 				$_REQUEST )
 		);

--- a/tests/activation/ActionsCest.php
+++ b/tests/activation/ActionsCest.php
@@ -28,6 +28,7 @@ PHP;
         $I->loginAsAdmin();
         $I->amOnPluginsPage();
         $I->activatePlugin('the-events-calendar');
+        $I->amOnPluginsPage();
         $I->seePluginActivated('the-events-calendar');
 
         $I->seeOptionInDatabase('_tribe_common_loaded_on_request', 'POST /wp-admin/plugins.php');

--- a/tests/wpunit/Tribe/functions/utilsTest.php
+++ b/tests/wpunit/Tribe/functions/utilsTest.php
@@ -514,7 +514,7 @@ class utilsTest extends \Codeception\TestCase\WPTestCase {
 			'Hello, how are you?',
 			'This is an email: john@example.com',
 			'My phone number is 123-456-7890',
-			'<script>alert("This is an attack!")</script>',
+			'<script>alert("This is an attack!)</script>',
 			'My name is <h1>John Doe</h1>',
 			'I like to use the & symbol',
 			'This is <b>bold</b> text',

--- a/tests/wpunit/Tribe/functions/utilsTest.php
+++ b/tests/wpunit/Tribe/functions/utilsTest.php
@@ -514,7 +514,7 @@ class utilsTest extends \Codeception\TestCase\WPTestCase {
 			'Hello, how are you?',
 			'This is an email: john@example.com',
 			'My phone number is 123-456-7890',
-			'<script>alert("This is an attack!)</script>',
+			'<script>alert("This is an attack!")</script>',
 			'My name is <h1>John Doe</h1>',
 			'I like to use the & symbol',
 			'This is <b>bold</b> text',


### PR DESCRIPTION
Ticket : [TEC-4666](https://theeventscalendar.atlassian.net/browse/TEC-4666)

Use `tribe_sanitize_deep` instead of `tec_sanitize_string` in situations where we might get an array.

Also fix a typo I previously missed in the tests.

[TEC-4666]: https://theeventscalendar.atlassian.net/browse/TEC-4666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ