### PR TITLE
Update utils.php

### DIFF
--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -1127,7 +1127,7 @@ if ( ! function_exists( 'tribe_sanitize_deep' ) ) {
 			return $value;
 		}
 		if ( is_string( $value ) ) {
-			$value = filter_var( $value, FILTER_SANITIZE_STRING );
+			$value = htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );
 			return $value;
 		}
 		if ( is_int( $value ) ) {


### PR DESCRIPTION
In line 1130 the function tribe_sanitize_deep( &$value ) is using the constant FILTER_SANITIZE_STRING.

This constant FILTER_SANITIZE_STRING is deprecated since php 8.1: https://stackoverflow.com/questions/69207368/constant-filter-sanitize-string-is-deprecated

I changed it to this:
$value = htmlspecialchars( $value, ENT_QUOTES, 'UTF-8' );