### PR TITLE
Fix edge case bug, with multiple actions being cached and not expirin…

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,10 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Fixes a cache bug that showed up in ECP-1475. The underlying issue was cache would carry stale data and not clear with the `save_post` trigger being hit repeatedly.
+
+
 = [5.0.15] 2023-04-10 =
 
 * Fix - Update the Google Maps API setting url on the Troubleshooting page. [TEC-4728]

--- a/src/Tribe/Cache.php
+++ b/src/Tribe/Cache.php
@@ -289,6 +289,7 @@ class Tribe__Cache implements ArrayAccess {
 	 * Returns the time of an action last occurrence.
 	 *
 	 * @since 4.9.14 Changed the return value type from `int` to `float`.
+	 * @since TBD No longer memoizes the first triggered timestamp.
 	 *
 	 * @param string $action The action to return the time for.
 	 *

--- a/src/Tribe/Cache.php
+++ b/src/Tribe/Cache.php
@@ -295,14 +295,6 @@ class Tribe__Cache implements ArrayAccess {
 	 * @return float The time (microtime) an action last occurred, or the current microtime if it never occurred.
 	 */
 	public function get_last_occurrence( $action ) {
-		static $cache_var_name = __METHOD__;
-
-		$cache_last_actions = tribe_get_var( $cache_var_name, [] );
-
-		if ( isset( $cache_last_actions[ $action ] ) ) {
-			return $cache_last_actions[ $action ];
-		}
-
 		$last_action = (float) get_option( 'tribe_last_' . $action, null );
 
 		if ( ! $last_action ) {
@@ -310,11 +302,7 @@ class Tribe__Cache implements ArrayAccess {
 			$this->set_last_occurrence( $action, $last_action );
 		}
 
-		$cache_last_actions[ $action ] = (float) $last_action;
-
-		tribe_set_var( $cache_var_name, $cache_last_actions );
-
-		return $cache_last_actions[ $action ];
+		return $last_action;
 	}
 
 	/**


### PR DESCRIPTION
[ECP-1475](https://theeventscalendar.atlassian.net/browse/ECP-1475)

Fixes a cache bug that was causing the post object to be cached and carry stale data, and any following updates to be made with no longer valid start dates etc. This was due to our memoized action timestamps, which have now been removed in lieu of Wordpress' `get_option` cache.

Artifacts:
First failure in video demonstrates the bug (second failure is existing bug for separate ticket)
https://drive.google.com/file/d/1EP9k51dU1EuVLQ6MCBGWMENiNPQGjUVo/view

[ECP-1475]: https://theeventscalendar.atlassian.net/browse/ECP-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ