### PR TITLE
Fallback for JWT classes.

### DIFF
--- a/src/Tribe/Service_Providers/Promoter.php
+++ b/src/Tribe/Service_Providers/Promoter.php
@@ -18,6 +18,9 @@ class Tribe__Service_Providers__Promoter extends tad_DI52_ServiceProvider {
 		if ( ! class_exists( 'Firebase\JWT\JWT' ) ) {
 			class_alias( 'TEC\Common\Firebase\JWT\JWT', 'Firebase\JWT\JWT' );
 		}
+		if ( ! class_exists( 'Firebase\JWT\Key' ) ) {
+			class_alias( 'TEC\Common\Firebase\JWT\Key', 'Firebase\JWT\Key' );
+		}
 		tribe_singleton( 'promoter.auth', 'Tribe__Promoter__Auth' );
 		tribe_singleton( 'promoter.pue', 'Tribe__Promoter__PUE', [ 'load' ] );
 		tribe_singleton( 'promoter.view', 'Tribe__Promoter__View' );

--- a/src/Tribe/Service_Providers/Promoter.php
+++ b/src/Tribe/Service_Providers/Promoter.php
@@ -13,6 +13,11 @@ class Tribe__Service_Providers__Promoter extends tad_DI52_ServiceProvider {
 	 * Binds and sets up implementations.
 	 */
 	public function register() {
+		// Using Strauss namespacing - this is fallback for dependent plugins.
+		// @todo Remove in a few releases, when EVA and ET are tied to this version of common.
+		if ( ! class_exists( 'Firebase\JWT\JWT' ) ) {
+			class_alias( 'TEC\Common\Firebase\JWT\JWT', 'Firebase\JWT\JWT' );
+		}
 		tribe_singleton( 'promoter.auth', 'Tribe__Promoter__Auth' );
 		tribe_singleton( 'promoter.pue', 'Tribe__Promoter__PUE', [ 'load' ] );
 		tribe_singleton( 'promoter.view', 'Tribe__Promoter__View' );


### PR DESCRIPTION
Fallback for Strauss renaming of the JWT.

ET and EVA both depend on JWT from common.