### PR TITLE
Passing null to `strpos()` is deprecated in PHP 8.1

### DIFF
--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -2126,7 +2126,7 @@ abstract class Tribe__Repository
 				$args['meta_query'][ $array_key ]['value'] = $meta_value;
 			}
 
-			if ( 0 === strpos( $type_or_format, '%' ) ) {
+			if ( ! empty( $type_or_format ) && 0 === strpos( $type_or_format, '%' ) ) {
 				throw Tribe__Repository__Usage_Error::because_the_type_is_a_wpdb_prepare_format( $meta_key, $type_or_format, $this );
 			}
 

--- a/src/Tribe/Repository.php
+++ b/src/Tribe/Repository.php
@@ -2126,7 +2126,7 @@ abstract class Tribe__Repository
 				$args['meta_query'][ $array_key ]['value'] = $meta_value;
 			}
 
-			if ( ! empty( $type_or_format ) && 0 === strpos( $type_or_format, '%' ) ) {
+			if ( is_string( $type_or_format ) && 0 === strpos( $type_or_format, '%' ) ) {
 				throw Tribe__Repository__Usage_Error::because_the_type_is_a_wpdb_prepare_format( $meta_key, $type_or_format, $this );
 			}
 


### PR DESCRIPTION
See: https://lw.slack.com/archives/C01STUW82P3/p1682112698672179