### PR TITLE
Fix/tec 4794 harden common button

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,8 @@
 
 = [TBD] TBD =
 
+* Fix - Elementor and other themes would inadvertently override styles on the tickets button, when the global styles were set. This hardens the common button (rsv/ticket button) styles a bit more. [TEC-4794]
+
 = [5.0.17] 2023-05-08 =
 
 * Feature - Add the `TEC\Provider\Controller` abstract class to kick-start Controllers and the `TEC\Common\Tests\Provider\Controller_Test_Case` class to test them.

--- a/src/resources/postcss/components/full/buttons/_solid.pcss
+++ b/src/resources/postcss/components/full/buttons/_solid.pcss
@@ -18,6 +18,20 @@
 		padding: 11px 20px 11px;
 		width: 100%;
 
+		&,
+		&:hover,
+		&:focus {
+			background-image: none;
+			border: 0;
+			border-radius: var(--tec-border-radius-default);
+			box-shadow: none;
+			color: var(--tec-color-background);
+			font-style: normal;
+			outline: none;
+			text-decoration: none;
+			text-shadow: none;
+		}
+
 		.tribe-common--breakpoint-medium& {
 			width: auto;
 		}


### PR DESCRIPTION
[TEC-4794](https://theeventscalendar.atlassian.net/browse/TEC-4794)

Elementor and other themes would inadvertently override styles on the tickets button, when the global styles were set. This hardens the common button (rsv/ticket button) styles a bit more.

Artifacts:

![image](https://user-images.githubusercontent.com/2826045/236352528-b124b0c0-4dc2-44f9-8376-74792e6d290e.png)


[TEC-4794]: https://theeventscalendar.atlassian.net/browse/TEC-4794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ