### PR TITLE
Fix Image Field Dimensions and Chagelog

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,10 @@
 == Changelog ==
 
-= [TBD] TBD =
-
-* Enhancement - Made settings field widths more uniform and mobile-friendly. [ET-1734]
-
 = [5.0.18] TBD =
 
 * Feature - Include a Integrations framework that was ported from The Events Calendar.
+* Enhancement - Made settings field widths more uniform and mobile-friendly. [ET-1734]
+* Fix - Change image field styling for a better look and user experience.
 
 = [5.0.17] 2023-05-08 =
 

--- a/src/resources/postcss/tribe-common-admin/_fields.pcss
+++ b/src/resources/postcss/tribe-common-admin/_fields.pcss
@@ -9,13 +9,12 @@
 	}
 
 	.tec-admin__settings-image-field-image-container {
-		height: 120px;
+		max-height: 120px;
+		max-width: 600px;
 		position: relative;
 
 		img {
 			height: auto;
-			max-height: 100%;
-			max-width: 150px;
 			width: auto;
 		}
 	}


### PR DESCRIPTION
### Description

The dimensions of the image preview in the image field were less than ideal. Also, the changelog for this release got duplicated by accident, so I'm fixing that here, too.

### Artifacts

Before:
![image](https://github.com/the-events-calendar/tribe-common/assets/7432506/e8b7043d-edf0-4761-a279-799c2de47619)

After:
![image](https://github.com/the-events-calendar/tribe-common/assets/7432506/09e0e667-11da-44d2-a44d-dce45dbed293)
