### PR TITLE
Fix Field Container Width on Medium (and Higher) Screens

### DIFF
--- a/src/resources/postcss/tribe-common-admin/_main.pcss
+++ b/src/resources/postcss/tribe-common-admin/_main.pcss
@@ -280,6 +280,10 @@ table.plugins {
 			*:first-child:not(.wp-switch-editor) {
 				margin-top: 0;
 			}
+			
+			@media (--viewport-medium) {
+				width: auto;
+			}
 		}
 
 		.tribe-sysinfo-optin-msg,


### PR DESCRIPTION
### Ticket

[ET-1734]

### Description

We had previously enhanced the settings fields so that they would be more mobile friendly. When this was implemented, it accidently made the settings stack on top of each other even when not on mobile. One simple CSS tweaks fixes the issue.

Previous PR: #1919 

### Abstract

https://www.loom.com/share/09afb8f944584aca9c7273111a73ea8d

[ET-1734]: https://theeventscalendar.atlassian.net/browse/ET-1734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ