### PR TITLE
Remove code to show modal - delegate to the plugins themselves.

### DIFF
--- a/src/Common/Telemetry/Telemetry.php
+++ b/src/Common/Telemetry/Telemetry.php
@@ -10,7 +10,6 @@ namespace TEC\Common\Telemetry;
 
 use TEC\Common\StellarWP\Telemetry\Core;
 use TEC\Common\StellarWP\Telemetry\Config;
-use TEC\Common\StellarWP\Telemetry\Opt_In\Opt_In_Subscriber;
 use TEC\Common\StellarWP\Telemetry\Opt_In\Status;
 use Tribe__Container as Container;
 use TEC\Common\StellarWP\Telemetry\Opt_In\Opt_In_Template;

--- a/src/Tribe/Settings_Tab.php
+++ b/src/Tribe/Settings_Tab.php
@@ -153,12 +153,6 @@ if ( ! class_exists( 'Tribe__Settings_Tab' ) ) {
 		 * @return void
 		 */
 		public function doContent() {
-			$telemetry_slug = Telemetry::get_plugin_slug();
-			/**
-			 * Fires when the user is viewing the tab content.
-			 */
-			do_action( "stellarwp/telemetry/{$telemetry_slug}/optin" );
-
 			if ( $this->display_callback && is_callable( $this->display_callback ) ) {
 				call_user_func( $this->display_callback );
 


### PR DESCRIPTION
Just removes some code that now lives in TEC.

Related: https://github.com/the-events-calendar/the-events-calendar/pull/4285