### PR TITLE
[ET-1766] Set Max Width/Height to Image, not Container

### DIFF
--- a/src/resources/postcss/tribe-common-admin/_fields.pcss
+++ b/src/resources/postcss/tribe-common-admin/_fields.pcss
@@ -9,12 +9,12 @@
 	}
 
 	.tec-admin__settings-image-field-image-container {
-		max-height: 120px;
-		max-width: 600px;
 		position: relative;
 
 		img {
 			height: auto;
+			max-height: 120px;
+			max-width: 600px;
 			width: auto;
 		}
 	}


### PR DESCRIPTION
### Ticket
[ET-1766]

### Description
It was found that the image stretched beyond the container's dimensions with the previous CSS. This change sets the max-width and max-height to the preview image itself instead of it's container.

### Artifacts
before:
![image](https://github.com/the-events-calendar/tribe-common/assets/7432506/3156e465-b6c5-4bca-ad19-f737ac801089)

after:
![image](https://github.com/the-events-calendar/tribe-common/assets/7432506/939f03b5-a1db-47b6-a6cc-ad1c0052a11c)


[ET-1766]: https://theeventscalendar.atlassian.net/browse/ET-1766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ