### PR TITLE
Only init Telemetry if it has been properly loaded and booted.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 = [5.1.2.1] 2023-06-22 =
 
-
+* Fix - Prevent Telemetry from being initialized and triggering a Fatal when the correct conditionals are not met.
 
 = [5.1.2] 2023-06-22 =
 

--- a/src/Common/Telemetry/Provider.php
+++ b/src/Common/Telemetry/Provider.php
@@ -42,7 +42,12 @@ class Provider extends Service_Provider {
 	 */
 	public function add_actions() {
 		add_action( 'tribe_plugins_loaded', [ $this, 'boot_telemetry' ], 50 );
-		add_action( 'admin_init', [ $this, 'initialize_telemetry' ], 5 );
+
+		/**
+		 * All these actions here need to be hooked from `tec_common_telemetry_preload` action to make sure that we have
+		 * all the telemetry code loaded and ready to go.
+		 */
+		add_action( 'tec_common_telemetry_preload', [ $this, 'hook_telemetry_init' ], 5 );
 
 		add_action( 'tec_telemetry_modal', [ $this, 'show_optin_modal' ] );
 		add_action( 'tec_common_telemetry_preload', [ $this, 'migrate_existing_opt_in' ], 100 );
@@ -57,6 +62,16 @@ class Provider extends Service_Provider {
 	public function add_filters() {
 		add_filter( 'stellarwp/telemetry/optin_args', [ $this, 'filter_optin_args' ] );
 		add_filter( 'stellarwp/telemetry/exit_interview_args', [ $this, 'filter_exit_interview_args' ] );
+	}
+
+	/**
+	 * It's super important to make sure when hooking to WordPress actions that we don't do before we are sure that
+	 * telemetry was properly booted into the system.
+	 *
+	 * @since TBD
+	 */
+	public function hook_telemetry_init(): void {
+		add_action( 'admin_init', [ $this, 'initialize_telemetry' ], 5 );
 	}
 
 	/**

--- a/src/Common/Telemetry/Provider.php
+++ b/src/Common/Telemetry/Provider.php
@@ -102,7 +102,6 @@ class Provider extends Service_Provider {
 	 * Placeholder for eventual Freemius removal hooking in to modify things.
 	 *
 	 * @since 5.1.0
-	 * @todo @bordoni leverage this when ready.
 	 *
 	 * @return void
 	 */

--- a/tests/wpunit/Tribe/functions/templateTags/generalTest.php
+++ b/tests/wpunit/Tribe/functions/templateTags/generalTest.php
@@ -63,7 +63,7 @@ class generalTest extends \Codeception\TestCase\WPTestCase {
 
 		$expected_tmpl = <<< TAG
 <script src='{{ home_url }}/tests/_data/resources/test-script-1.js?ver=1.0.0' id='tribe-test-js-js'></script>
-<link rel='stylesheet' id='tribe-test-css-css'  href='{{ home_url }}/tests/_data/resources/test-style-1.css?ver=1.0.0' media='all' />
+<link rel='stylesheet' id='tribe-test-css-css' href='{{ home_url }}/tests/_data/resources/test-style-1.css?ver=1.0.0' media='all' />
 
 TAG;
 		$expected = str_replace( '{{ home_url }}', home_url(), $expected_tmpl );


### PR DESCRIPTION
Resolving fatals with `6.1.2` and `5.6.1`:
- https://wordpress.org/support/topic/fatal-error-in-tec-6-1-2/
- https://wordpress.org/support/topic/fatal-error-uncaught-teccommonexceptions/
- https://wordpress.org/support/topic/6-1-2-caused-an-error-of-type-e_error-was-caused-in-line-27-of-the-file
