### PR TITLE
Resolve telemetry path issue on Windows

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 = [5.1.2] TBD =
 
-* Fix - Properly handle plugin paths on windows during telemetry booting. [TEC-4842]
+* Fix - Properly handle plugin paths on Windows during telemetry booting. [TEC-4842]
 
 = [5.1.2.2] 2023-06-23 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 = [5.1.2] TBD =
 
-* Release - B23.Goldorak
+* Fix - Properly handle plugin paths on windows during telemetry booting. [TEC-4842]
 
 = [5.1.2.2] 2023-06-23 =
 

--- a/src/Common/Telemetry/Migration.php
+++ b/src/Common/Telemetry/Migration.php
@@ -236,9 +236,9 @@ final class Migration {
 	 * @param Object $fs_active_plugins The stored list of active plugins from Freemius.
 	 */
 	private function remove_inactive_plugins( $fs_active_plugins ): void {
-		$freemius_plugins = $fs_active_plugins->plugins;
+		$freemius_plugins = ! empty( $fs_active_plugins->plugins ) ? (array) $fs_active_plugins->plugins : [];
 
-		foreach( $this->our_plugins as $plugin ) {
+		foreach ( $this->our_plugins as $plugin ) {
 			if ( ! isset( $freemius_plugins[ $plugin ] ) ) {
 				unset( $this->our_plugins[ $plugin ] );
 			}

--- a/src/Common/Telemetry/Telemetry.php
+++ b/src/Common/Telemetry/Telemetry.php
@@ -119,7 +119,6 @@ final class Telemetry {
 		self::$plugin_path  = \Tribe__Main::instance()->get_parent_plugin_file_path();
 		$stellar_slug = self::get_stellar_slug();
 
-
 		if ( empty( $stellar_slug ) ) {
 			return;
 		}

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -789,6 +789,7 @@ class Tribe__Main {
 		$paths = apply_filters( 'tec_common_parent_plugin_file', [] );
 
 		foreach( $paths as $path ) {
+			$path      = wp_normalize_path( $path );
 			$test_path = str_ireplace( '/common', '', $this->parent_plugin_dir );
 
 			if ( stripos( $path, $test_path ) ) {


### PR DESCRIPTION
When we look at paths during the bootstrapping of Telemetry, we need to be sure to normalize paths so that the directory separator matches what WordPress expects.

:ticket: [TEC-4842]

Artifact - saving on Windows fatals every time until this fix is in place, then we get:
![Screenshot 2023-06-28 171300](https://github.com/the-events-calendar/tribe-common/assets/430385/35688cec-42cc-4692-ae6f-f544e5b7117f)

Props to @Camwyn for the debug session.


[TEC-4842]: https://theeventscalendar.atlassian.net/browse/TEC-4842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ