### PR TITLE
Strauss handles prefixed file generation, avoid adding headers.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,7 +111,9 @@
       "exclude_from_prefix": {
         "file_patterns": []
       },
-      "delete_vendor_files": true
+      "delete_vendor_files": true,
+      "include_modified_date": false,
+      "include_author": false
     }
   }
 }


### PR DESCRIPTION
The SVN commit process on WP.org will scan the files modified, the more files you include the slower the process will be, so we need to make sure all Strauss Prefixed files do not include the Modified date or the Author.

See how it was on the past release we pushed out:
https://plugins.trac.wordpress.org/changeset/2937978

No changelog or release needed. Just making sure for all next releases we have this in `master`
