### PR TITLE
[ET-1820] Use `wp_date` for date formats to avoid translation issues with Month names.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 
 = [5.1.4] TBD =
 
+* Fix  - Make use of `wp_date` to format dates and avoid translation issues with translating month names in other languages. [ET-1820]
 * Feat - Fire an action on Service Provider registration; register Service Providers on action with `Container::register_on_action`.
 
 = [5.1.3] 2023-07-13 =

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -462,6 +462,8 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 * Accepts a string representing a date/time and attempts to convert it to
 		 * the specified format, returning an empty string if this is not possible.
 		 *
+		 * @since TBD Make use of `wp_date` for i18n.
+		 *
 		 * @param $dt_string
 		 * @param $new_format
 		 *

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -469,7 +469,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 */
 		public static function reformat( $dt_string, $new_format ) {
 			$timestamp = self::is_timestamp( $dt_string ) ? $dt_string : strtotime( $dt_string );
-			$revised   = date( $new_format, $timestamp );
+			$revised   = wp_date( $new_format, $timestamp );
 
 			return $revised ? $revised : '';
 		}


### PR DESCRIPTION
[ET-1820]

**Before:**
<img width="942" alt="Screenshot 2023-08-02 at 4 18 28 PM" src="https://github.com/the-events-calendar/tribe-common/assets/7523321/339e6c0b-7b88-4cd9-9879-64cc7f0f00db">

**After:**
<img width="827" alt="Screenshot 2023-08-02 at 4 18 44 PM" src="https://github.com/the-events-calendar/tribe-common/assets/7523321/cef29783-78fb-405a-9fe9-8642d9d176f6">


[ET-1820]: https://theeventscalendar.atlassian.net/browse/ET-1820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ