### PR TITLE
Add the Query_Filters::meta_not method

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [5.1.4] TBD =
 
 * Feat - Fire an action on Service Provider registration; register Service Providers on action with `Container::register_on_action`.
+* Feat - Add the 'Tribe__Repository__Query_Filters::meta_not' method to work around costly meta queries.
 
 = [5.1.3] 2023-07-13 =
 

--- a/src/Tribe/Repository/Query_Filters.php
+++ b/src/Tribe/Repository/Query_Filters.php
@@ -1,5 +1,7 @@
 <?php
 
+use Tribe__Utils__Array as Arr;
+
 /**
  * Class Tribe__Repository__Query_Filters
  *
@@ -12,7 +14,7 @@ class Tribe__Repository__Query_Filters {
 	 *
 	 * @since 4.9.21
 	 */
-	CONST AFTER = 'after:';
+	const AFTER = 'after:';
 
 	/**
 	 * @var array
@@ -95,8 +97,8 @@ class Tribe__Repository__Query_Filters {
 	 * @return array
 	 */
 	public static function meta_not_in( $meta_keys, $values, $query_slug ) {
-		$meta_keys = Tribe__Utils__Array::list_to_array( $meta_keys );
-		$values    = Tribe__Utils__Array::list_to_array( $values );
+		$meta_keys = Arr::list_to_array( $meta_keys );
+		$values    = Arr::list_to_array( $values );
 
 		if ( empty( $meta_keys ) || count( $values ) === 0 ) {
 			return [];
@@ -149,8 +151,8 @@ class Tribe__Repository__Query_Filters {
 	 * @return array
 	 */
 	public static function meta_in( $meta_keys, $values, $query_slug ) {
-		$meta_keys = Tribe__Utils__Array::list_to_array( $meta_keys );
-		$values    = Tribe__Utils__Array::list_to_array( $values );
+		$meta_keys = Arr::list_to_array( $meta_keys );
+		$values    = Arr::list_to_array( $values );
 
 		if ( empty( $meta_keys ) || count( $values ) === 0 ) {
 			return [];
@@ -194,7 +196,7 @@ class Tribe__Repository__Query_Filters {
 	 * @return array
 	 */
 	public static function meta_exists( $meta_keys, $query_slug ) {
-		$meta_keys = Tribe__Utils__Array::list_to_array( $meta_keys );
+		$meta_keys = Arr::list_to_array( $meta_keys );
 
 		if ( empty( $meta_keys ) ) {
 			return [];
@@ -231,8 +233,8 @@ class Tribe__Repository__Query_Filters {
 	 * @return array
 	 */
 	public static function meta_in_or_not_exists( $meta_keys, $values, $query_slug ) {
-		$meta_keys = Tribe__Utils__Array::list_to_array( $meta_keys );
-		$values    = Tribe__Utils__Array::list_to_array( $values );
+		$meta_keys = Arr::list_to_array( $meta_keys );
+		$values    = Arr::list_to_array( $values );
 
 		if ( empty( $meta_keys ) || count( $values ) === 0 ) {
 			return [];
@@ -283,8 +285,8 @@ class Tribe__Repository__Query_Filters {
 	 * @return array
 	 */
 	public static function meta_not_in_or_not_exists( $meta_keys, $values, $query_slug ) {
-		$meta_keys = Tribe__Utils__Array::list_to_array( $meta_keys );
-		$values    = Tribe__Utils__Array::list_to_array( $values );
+		$meta_keys = Arr::list_to_array( $meta_keys );
+		$values    = Arr::list_to_array( $values );
 
 		if ( empty( $meta_keys ) || count( $values ) === 0 ) {
 			return [];
@@ -634,11 +636,11 @@ class Tribe__Repository__Query_Filters {
 	 * @since 4.7.19
 	 * @since 4.9.14 Added the `$id` and `$override` parameters.
 	 *
-	 * @param string $where_clause
-	 * @param null|string $id          Optional WHERE ID to prevent duplicating clauses.
-	 * @param boolean     $override    Whether to override the clause if a WHERE by the same ID exists or not.
+	 * @param string      $where_clause
+	 * @param null|string $id       Optional WHERE ID to prevent duplicating clauses.
+	 * @param boolean     $override Whether to override the clause if a WHERE by the same ID exists or not.
 	 */
-	public function where( $where_clause, $id = null, $override =false  ) {
+	public function where( $where_clause, $id = null, $override = false ) {
 		if ( $this->buffer_where_clauses ) {
 			if ( $id ) {
 				if ( $override || ! isset( $this->buffered_where_clauses[ $id ] ) ) {
@@ -704,7 +706,7 @@ class Tribe__Repository__Query_Filters {
 	 */
 	public function orderby( $orderby, $id = null, $override = false, $after = false ) {
 		$orderby_key = $after ? static::AFTER . 'orderby' : 'orderby';
-		$entries = [];
+		$entries     = [];
 
 		foreach ( (array) $orderby as $key => $value ) {
 			/*
@@ -739,7 +741,7 @@ class Tribe__Repository__Query_Filters {
 	 * @since 4.9.5
 	 * @since 4.9.14 Added the `$id` and `$override` parameters.
 	 *
-	 * @param string $field The field to add to the result.
+	 * @param string      $field    The field to add to the result.
 	 * @param null|string $id       Optional ORDER ID to prevent duplicating order-by clauses..
 	 * @param boolean     $override Whether to override the clause if another by the same ID exists.
 	 */
@@ -984,7 +986,7 @@ class Tribe__Repository__Query_Filters {
 		 * format.
 		 */
 		$build_entry = static function ( $entries ) {
-			$buffer  = [];
+			$buffer = [];
 
 			foreach ( $entries as list( $orderby, $order ) ) {
 				$buffer[] = sprintf( '%s %s', $orderby, $order );
@@ -1093,7 +1095,7 @@ class Tribe__Repository__Query_Filters {
 	 *
 	 * @return array An associative array of identifiable filters and their values, if any.
 	 *
-	 * @see Tribe__Repository__Query_Filters::$identifiable_filters
+	 * @see   Tribe__Repository__Query_Filters::$identifiable_filters
 	 */
 	public function get_filters_by_id( $id ) {
 		$entries = [];
@@ -1125,5 +1127,62 @@ class Tribe__Repository__Query_Filters {
 				unset( $filters[ $id ] );
 			}
 		);
+	}
+
+	/**
+	 * Filters the query JOIN and WHERE clauses to filter out posts that either do not have a meta key
+	 * or whose meta value is not in the provided list.
+	 *
+	 * This method is an alternative approach to the static `meta_not_in_or_not_exists` method that avoids
+	 * the excessive use of JOINs the use of `meta_query` implies.
+	 *
+	 * @since TBD
+	 *
+	 * @param string|array<string>    $meta_keys  The meta keys to filter by.
+	 * @param mixed|array<mixed>|null $values     The values to filter by or `null` to filter by existence only.
+	 * @param string|null             $query_slug The prefix that will be used to distinguish the query from other
+	 *                                            queries.
+	 *
+	 * @return void The method will filter the query JOIN and WHERE clauses.
+	 */
+	public function meta_not( $meta_keys, $values = null, string $query_slug = null ): void {
+		$keys = Arr::list_to_array( $meta_keys );
+
+		if ( ! count( $keys ) ) {
+			return;
+		}
+
+		global $wpdb;
+		$keys_sql_list = $wpdb->prepare(
+			implode( ',', array_fill( 0, count( $keys ), '%s' ) ),
+			$keys
+		);
+
+		$values = Arr::list_to_array( $values );
+
+		// Sanitize the query_slug to make sure it will make for a valid MYSQL table alias.
+		$safe_query_slug = $query_slug ?
+			preg_replace( '/[^a-z0-9_]/i', '_', $query_slug )
+			: substr( md5( microtime() ), 0, 8 );
+		$meta_table      = "meta_not_$safe_query_slug";
+		$this->join( "LEFT JOIN $wpdb->postmeta AS $meta_table ON " .
+		             "($wpdb->posts.ID = $meta_table.post_id AND $meta_table.meta_key IN ($keys_sql_list))" );
+
+		if ( ! count( $values ) ) {
+			// Just check the meta_keys are not set.
+			$this->where( "$meta_table.meta_value IS NULL" );
+
+			return;
+		}
+
+		/*
+		 * There are values: either the meta values should be NULL (LEFT JOIN), or the values should not be in the list.
+		 * Prepare all values as strings: meta values are always strings.
+		 */
+		$values_sql_list = $wpdb->prepare(
+			implode( ',', array_fill( 0, count( $values ), '%s' ) ),
+			$values
+		);
+		$this->where( "$meta_table.meta_value IS NULL OR $meta_table.meta_value NOT IN ($values_sql_list)" );
 	}
 }

--- a/tests/wpunit/Tribe/Repository/Meta_Filter_Test.php
+++ b/tests/wpunit/Tribe/Repository/Meta_Filter_Test.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace TEC\Tribe\Repository;
+
+require_once __DIR__ . '/ReadTestBase.php';
+
+use Tribe\Repository\ReadTestBase;
+
+class Meta_Filter_Test extends ReadTestBase {
+	/**
+	 * It should allow filtering by meta key not by NULL
+	 *
+	 * @test
+	 */
+	public function should_allow_filtering_by_meta_key_not_by_null(): void {
+		$book_1 = static::factory()->post->create( [
+			'post_type'  => 'book',
+			'meta_input' => [
+				'_has_review' => '1'
+			]
+		] );
+		// Books with no reviews.
+		$book_2 = static::factory()->post->create( [ 'post_type' => 'book' ] );
+		$book_3 = static::factory()->post->create( [
+			'post_type'  => 'book',
+			'meta_input' => [
+				'_has_review' => '0'
+			]
+		] );
+
+		/** @var \Tribe__Repository $repository */
+		$repository = $this->repository();
+		$repository->add_schema_entry( 'has_no_review', static function () use ( $repository ): void {
+			$repository->filter_query->meta_not( '_has_review' );
+		} );
+		$found = $repository->where( 'has_no_review' )->get_ids();
+
+		$this->assertEqualSets( [ $book_2 ], $found );
+	}
+
+	/**
+	 * It should allow filtering by meta key not in value set
+	 *
+	 * @test
+	 */
+	public function should_allow_filtering_by_meta_key_not_in_value_set(): void {
+		$book_1 = static::factory()->post->create( [
+			'post_type'  => 'book',
+			'meta_input' => [
+				'_has_review' => '1'
+			]
+		] );
+		// Books with no reviews.
+		$book_2 = static::factory()->post->create( [ 'post_type' => 'book' ] );
+		$book_3 = static::factory()->post->create( [
+			'post_type'  => 'book',
+			'meta_input' => [
+				'_has_review' => '0'
+			]
+		] );
+
+		/** @var \Tribe__Repository $repository */
+		$repository = $this->repository();
+		$repository->add_schema_entry( 'has_no_review', static function () use ( $repository ): void {
+			$repository->filter_query->meta_not( '_has_review', 1 );
+		} );
+		$found = $repository->where( 'has_no_review' )->get_ids();
+
+		$this->assertEqualSets( [ $book_2, $book_3 ], $found );
+	}
+
+	/**
+	 * It should allow filtering by meta key not with key and value sets
+	 *
+	 * @test
+	 */
+	public function should_allow_filtering_by_meta_key_not_with_key_and_value_sets(): void {
+		$book_1 = static::factory()->post->create( [
+			'post_type'  => 'book',
+			'meta_input' => [
+				'_has_reader_review' => '1',
+				'_has_writer_review' => '1'
+			]
+		] );
+		$book_2 = static::factory()->post->create( [ 'post_type' => 'book' ] );
+		$book_3 = static::factory()->post->create( [
+			'post_type'  => 'book',
+			'meta_input' => [
+				'_has_review' => '0'
+			]
+		] );
+
+		/** @var \Tribe__Repository $repository */
+		$repository = $this->repository();
+		$repository->add_schema_entry( 'has_no_review', static function () use ( $repository ): void {
+			$repository->filter_query->meta_not( [ '_has_reader_review', '_has_writer_review' ], 1 );
+		} );
+		$found = $repository->where( 'has_no_review' )->get_ids();
+
+		$this->assertEqualSets( [ $book_2, $book_3 ], $found );
+	}
+
+	/**
+	 * It should allow filtering by meta key not with key set and NULL values
+	 *
+	 * @test
+	 */
+	public function should_allow_filtering_by_meta_key_not_with_key_set_and_null_values(): void {
+		$book_1 = static::factory()->post->create( [
+			'post_type'  => 'book',
+			'meta_input' => [
+				'_has_reader_review' => '1',
+				'_has_writer_review' => '1'
+			]
+		] );
+		$book_2 = static::factory()->post->create( [ 'post_type' => 'book' ] );
+		$book_3 = static::factory()->post->create( [
+			'post_type'  => 'book',
+			'meta_input' => [
+				'_has_review' => '0'
+			]
+		] );
+
+		/** @var \Tribe__Repository $repository */
+		$repository = $this->repository();
+		$repository->add_schema_entry( 'has_no_review', static function () use ( $repository ): void {
+			$repository->filter_query->meta_not( [ '_has_reader_review', '_has_writer_review' ] );
+		} );
+		$found = $repository->where( 'has_no_review' )->get_ids();
+
+		$this->assertEqualSets( [ $book_2, $book_3 ], $found );
+	}
+}


### PR DESCRIPTION
Add the `Tribe__Repository__Query_Filters::meta_not` method to provide an alternative way to run queries to fetch posts that either do not have a meta key set, or whose meta value is not in a set.

The original method used, `Tribe__Repository__Query_Filters::meta_not_in_or_not_exists` relies on default `WP_Query` argument building that will get costly adding a `JOIN` clause for each `meta_key` looked up.
The original method is left in place for back-compatibility reasons, and teh `meta_not` method is provided, with the same signature, as an alternative.
