### PR TITLE
[ET-1815] Set button background image

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Tweak - Set background image to none on the button element to prevent general button styling overrides. [ET-1815]
+
 = [5.1.6] 2023-08-15 =
 
 * Feature - Add the 'Tribe__Repository__Query_Filters::meta_not' method to work around costly meta queries.

--- a/src/resources/postcss/base/full/_buttons.pcss
+++ b/src/resources/postcss/base/full/_buttons.pcss
@@ -5,11 +5,13 @@
 
 	button {
 		background-color: transparent;
+		background-image: none;
 		border: none;
 
 		&:hover,
 		&:focus {
 			background-color: transparent;
+			background-image: none;
 		}
 	}
 
@@ -30,6 +32,7 @@
 			&:hover,
 			&:focus {
 				background-color: transparent;
+				background-image: none;
 			}
 		}
 	}
@@ -38,6 +41,7 @@
 
 		button {
 			background-color: transparent;
+			background-image: none;
 			text-transform: inherit;
 
 			&:hover,
@@ -55,6 +59,7 @@
 
 		button:not(:hover):not(:active) {
 			background-color: inherit;
+			background-image: inherit;
 			color: inherit;
 		}
 	}


### PR DESCRIPTION
### Ticket
[ET-1815]

### Description
It was found that some site customizers (Elementor Pro in particular) set the background image of all buttons when using a gradient background. We do not set any background image for buttons in TEC. By setting it to none, it prevents TEC button backgrounds from getting overridden.

### Abstract
![image](https://github.com/the-events-calendar/tribe-common/assets/7432506/a6f35572-9392-4116-8030-9fa785ad9f99)


[ET-1815]: https://theeventscalendar.atlassian.net/browse/ET-1815?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ