### PR TITLE
Defaulting to Ticketing & RSVP tab when going to Help page from Tickets plugin

### DIFF
--- a/src/Tribe/Admin/Help_Page.php
+++ b/src/Tribe/Admin/Help_Page.php
@@ -67,6 +67,32 @@ class Tribe__Admin__Help_Page {
 	}
 
 	/**
+	 * Checks if the current page is the TEC Help one
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_tec_current_help_page() {
+		global $current_screen;
+
+		return 'tribe_events_page_tec-events-help' === $current_screen->id;
+	}
+
+	/**
+	 * Checks if the current page is the Tickets Help one
+	 *
+	 * @since TBD
+	 *
+	 * @return bool
+	 */
+	public function is_ticketing_current_help_page() {
+		global $current_screen;
+
+		return 'tickets_page_tec-tickets-help' === $current_screen->id;
+	}
+
+	/**
 	 * Register the Admin assets for the help page
 	 *
 	 * @since  4.9.12

--- a/src/admin-views/help-calendar.php
+++ b/src/admin-views/help-calendar.php
@@ -5,9 +5,12 @@ use \Tribe\Admin\Help_Page;
 $faqs              = tribe( Tribe__Admin__Help_Page::class )->get_calendar_faqs();
 $extensions        = tribe( Tribe__Admin__Help_Page::class )->get_calendar_extensions();
 $calendar_products = tribe( Tribe__Admin__Help_Page::class )->get_calendar_products();
+$is_calendar_help_page = tribe( Tribe__Admin__Help_Page::class )->is_tec_current_help_page();
+
+$tribe_calendar_style = $is_calendar_help_page ? 'style="display:block;"' : 'style="display:none;"';
 
 ?>
-<div id="tribe-calendar">
+<div id="tribe-calendar" <?php echo $tribe_calendar_style; ?>>
 	<img
 		class="tribe-events-admin-header__right-image"
 		src="<?php echo esc_url( tribe_resource_url( 'images/help/help-calendar-header.png', false, null, $main ) ); ?>"
@@ -34,7 +37,7 @@ $calendar_products = tribe( Tribe__Admin__Help_Page::class )->get_calendar_produ
 						<?php echo esc_html( $products[ $slug ]['description-help'] ); ?>
 					</div>
 				</div>
-				<?php 
+				<?php
 					$plugin_path_url = WP_PLUGIN_DIR . '/' . $products[ $slug ]['plugin-dir'] . '/' . $products[ $slug ]['main-file'];
 					$plugin_exists = file_exists( $plugin_path_url );
 
@@ -42,7 +45,7 @@ $calendar_products = tribe( Tribe__Admin__Help_Page::class )->get_calendar_produ
 					if ( $products[ $slug ]['is_installed'] ) { ?>
 						<button class="tribe-events-admin-products-card__button tribe-events-admin-products-card__button--active">
 							<?php esc_html_e( 'Active', 'tribe-common' ); ?>
-						</button> 
+						</button>
 						<?php
 					}
 					// displays different message for EA
@@ -75,7 +78,7 @@ $calendar_products = tribe( Tribe__Admin__Help_Page::class )->get_calendar_produ
 		<h3>
 			<?php esc_html_e( 'Start Here', 'tribe-common' ); ?>
 		</h3>
-		
+
 		<a href="https://evnt.is/1aq9" target="_blank" rel="noopener noreferrer">
 			<?php esc_html_e( 'Visit Knowledgebase', 'tribe-common' ); ?>
 		</a>
@@ -187,7 +190,7 @@ $calendar_products = tribe( Tribe__Admin__Help_Page::class )->get_calendar_produ
 		<h3>
 			<?php esc_html_e( 'FAQs', 'tribe-common' ); ?>
 		</h3>
-		
+
 		<a href="https://evnt.is/1av1#faqs" target="_blank" rel="noopener noreferrer">
 			<?php esc_html_e( 'All FAQs', 'tribe-common' ); ?>
 		</a>
@@ -202,10 +205,10 @@ $calendar_products = tribe( Tribe__Admin__Help_Page::class )->get_calendar_produ
 						alt="<?php esc_attr_e( 'lightbulb icon', 'tribe-common' ); ?>"
 					/>
 				</div>
-				<div class="tribe-events-admin-faq-card__content">					
+				<div class="tribe-events-admin-faq-card__content">
 					<div class="tribe-events-admin-faq__question">
 						<a href="<?php echo esc_url( $faq['link'] ); ?>" target="_blank" rel="noopener noreferrer">
-							<?php echo esc_html( $faq['question'] ); ?>	
+							<?php echo esc_html( $faq['question'] ); ?>
 						</a>
 					</div>
 					<div class="tribe-events-admin-faq__answer">
@@ -221,7 +224,7 @@ $calendar_products = tribe( Tribe__Admin__Help_Page::class )->get_calendar_produ
 		<h3>
 			<?php esc_html_e( 'Free extensions', 'tribe-common' ); ?>
 		</h3>
-		
+
 		<a href="https://evnt.is/1aqa" target="_blank" rel="noopener noreferrer">
 			<?php esc_html_e( 'All Extensions', 'tribe-common' ); ?>
 		</a>

--- a/src/admin-views/help-ticketing.php
+++ b/src/admin-views/help-ticketing.php
@@ -5,9 +5,12 @@ use \Tribe\Admin\Help_Page;
 $faqs               = tribe( Tribe__Admin__Help_Page::class )->get_ticketing_faqs();
 $extensions         = tribe( Tribe__Admin__Help_Page::class )->get_ticketing_extensions();
 $ticketing_products = tribe( Tribe__Admin__Help_Page::class )->get_ticketing_products();
+$is_tickets_help_page = tribe( Tribe__Admin__Help_Page::class )->is_ticketing_current_help_page();
+
+$tribe_ticketing_style = $is_tickets_help_page ? 'style="display:block;"' : 'style="display:none;"';
 
 ?>
-<div id="tribe-ticketing">
+<div id="tribe-ticketing" <?php echo $tribe_ticketing_style; ?>>
 	<img
 		class="tribe-events-admin-header__right-image"
 		src="<?php echo esc_url( tribe_resource_url( 'images/help/help-ticketing-header.png', false, null, $main ) ); ?>"
@@ -34,7 +37,7 @@ $ticketing_products = tribe( Tribe__Admin__Help_Page::class )->get_ticketing_pro
 						<?php echo esc_html( $products[ $slug ]['description-help'] ); ?>
 					</div>
 				</div>
-				<?php 
+				<?php
 					$plugin_path_url = WP_PLUGIN_DIR . '/' . $products[ $slug ]['plugin-dir'] . '/' . $products[ $slug ]['main-file'];
 					$plugin_exists = file_exists( $plugin_path_url );
 
@@ -42,7 +45,7 @@ $ticketing_products = tribe( Tribe__Admin__Help_Page::class )->get_ticketing_pro
 					if ( $products[ $slug ]['is_installed'] ) { ?>
 						<button class="tribe-events-admin-products-card__button tribe-events-admin-products-card__button--active">
 							<?php esc_html_e( 'Active', 'tribe-common' ); ?>
-						</button> 
+						</button>
 						<?php
 					}
 					// displays different message for Promoter
@@ -75,7 +78,7 @@ $ticketing_products = tribe( Tribe__Admin__Help_Page::class )->get_ticketing_pro
 		<h3>
 			<?php esc_html_e( 'Start Here', 'tribe-common' ); ?>
 		</h3>
-		
+
 		<a href="https://evnt.is/1aq9" target="_blank" rel="noopener noreferrer">
 			<?php esc_html_e( 'Visit Knowledgebase', 'tribe-common' ); ?>
 		</a>
@@ -183,7 +186,7 @@ $ticketing_products = tribe( Tribe__Admin__Help_Page::class )->get_ticketing_pro
 		<h3>
 			<?php esc_html_e( 'FAQs', 'tribe-common' ); ?>
 		</h3>
-		
+
 		<a href="https://evnt.is/1av3#faqs" target="_blank" rel="noopener noreferrer">
 			<?php esc_html_e( 'All FAQs', 'tribe-common' ); ?>
 		</a>
@@ -201,7 +204,7 @@ $ticketing_products = tribe( Tribe__Admin__Help_Page::class )->get_ticketing_pro
 				<div class="tribe-events-admin-faq-card__content">
 					<div class="tribe-events-admin-faq__question">
 						<a href="<?php echo esc_url( $faq['link'] ); ?>" target="_blank" rel="noopener noreferrer">
-							<?php echo esc_html( $faq['question'] ); ?>	
+							<?php echo esc_html( $faq['question'] ); ?>
 						</a>
 					</div>
 					<div class="tribe-events-admin-faq__answer">
@@ -217,7 +220,7 @@ $ticketing_products = tribe( Tribe__Admin__Help_Page::class )->get_ticketing_pro
 		<h3>
 			<?php esc_html_e( 'Free extensions', 'tribe-common' ); ?>
 		</h3>
-		
+
 		<a href="https://evnt.is/1aqa" target="_blank" rel="noopener noreferrer">
 			<?php esc_html_e( 'All Extensions', 'tribe-common' ); ?>
 		</a>

--- a/src/admin-views/help.php
+++ b/src/admin-views/help.php
@@ -11,6 +11,12 @@ $help = tribe( Tribe__Admin__Help_Page::class );
 // get the products list
 $products = tribe( 'plugins.api' )->get_products();
 
+$is_tec_current_help_page = $help->is_tec_current_help_page();
+$is_tickets_help_page = $help->is_ticketing_current_help_page();
+
+$tribe_calendar_tab_class  = $is_tec_current_help_page ? 'class="selected"' : '';
+$tribe_ticketing_tab_class = $is_tickets_help_page     ? 'class="selected"' : '';
+
 use \Tribe\Admin\Troubleshooting;
 
 ?>
@@ -31,8 +37,8 @@ use \Tribe\Admin\Troubleshooting;
 		<p class="tribe-events-admin-header__description"><?php esc_html_e( 'We\'re committed to helping make your calendar spectacular and have a wealth of resources available.', 'tribe-common' ); ?></p>
 
 		<ul class="tribe-events-admin-tab-nav">
-			<li class="selected" data-tab="tribe-calendar"><?php esc_html_e( 'Calendar', 'tribe-common' ); ?></li>
-			<li data-tab="tribe-ticketing"><?php esc_html_e( 'Ticketing & RSVP', 'tribe-common' ); ?></li>
+			<li <?php echo $tribe_calendar_tab_class; ?> data-tab="tribe-calendar"><?php esc_html_e( 'Calendar', 'tribe-common' ); ?></li>
+			<li <?php echo $tribe_ticketing_tab_class; ?> data-tab="tribe-ticketing"><?php esc_html_e( 'Ticketing & RSVP', 'tribe-common' ); ?></li>
 			<li data-tab="tribe-community"><?php esc_html_e( 'Community', 'tribe-common' ); ?></li>
 		</ul>
 	</div>


### PR DESCRIPTION
🎫 Ticket
[[ET-1837](https://theeventscalendar.atlassian.net/browse/ET-1837)]

🗒️ Description
- Ticketing & RSVP tab selected by default when clicking Help from the Tickets menu

🎥 Artifacts
https://www.loom.com/share/07ef29e97cb3466dbc4901b9f671169a

✔️ Checklist
 
- [ ] I've included a changelog entry in the readme.txt file.
- [ ] My code is tested.
- [ ] My code has [proper inline documentation](https://the-events-calendar.github.io/products-engineering/docs/code-standards/).