### PR TITLE
Add lodash as a dependency for the Block Editor Assets.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 = [TBD] TBD =
 
-* Fix - Resolved "Uncaught ReferenceError: lodash is not defined" error by adding `lodash` as a dependency for the Events Gutenberg Assets. [ECP-1575]
+* Fix - Resolved "Uncaught ReferenceError: lodash is not defined" error by adding `lodash` as a dependency for TEC Block Assets. [ECP-1575]
 
 = [5.1.7] TBD =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 = [TBD] TBD =
 
-* Fix - Resolved "Uncaught ReferenceError: lodash is not defined" error by adding `lodash` as a dependency for TEC Block Assets. [ECP-1575]
+* Fix - Resolved "Uncaught ReferenceError: lodash is not defined" error by adding `lodash` as a dependency for the Block Editor Assets. [ECP-1575]
 
 = [5.1.7] TBD =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Resolved "Uncaught ReferenceError: lodash is not defined" error by adding `lodash` as a dependency for the Events Gutenberg Assets. [ECP-1575]
+
 = [5.1.7] TBD =
 
 * Fix - Borked UI on the WYZIWIG field in the Additional Content section of the admin display settings. [TEC-4861]

--- a/src/Tribe/Editor/Assets.php
+++ b/src/Tribe/Editor/Assets.php
@@ -128,6 +128,7 @@ class Tribe__Editor__Assets {
 			'wp-i18n',
 			'wp-element',
 			'wp-editor',
+			'lodash',
 		];
 
 		if ( 'post.php' !== $pagenow && 'post-new.php' !== $pagenow ) {

--- a/src/Tribe/Editor/Assets.php
+++ b/src/Tribe/Editor/Assets.php
@@ -110,6 +110,7 @@ class Tribe__Editor__Assets {
 	 * Filter the dependencies for event blocks
 	 *
 	 * @since 4.14.2
+	 * @since TBD Added lodash to the dependencies.
 	 *
 	 * @param array|object|null $assets Array of asset objects, single asset object, or null.
 	 *


### PR DESCRIPTION
# Ticket
[ECP-1575](https://theeventscalendar.atlassian.net/browse/ECP-1575)

## Overview
This PR addresses the "Uncaught ReferenceError: lodash is not defined" error that was arising when activating the Gutenberg plugin. The root cause of the issue was the missing dependency of `lodash` for our Block Editor Assets. By explicitly defining this dependency, we ensure that `lodash` is loaded before our custom scripts, thus resolving the error.

## Changes
- Updated `Tribe__Editor__Assets` class to include `lodash` as a script dependency.

## Screencast 🎥

https://drive.google.com/file/d/1O9vZyxU6vvkMD3ZyBbdSyX-znnJ7J8dr/view?usp=sharing

[ECP-1575]: https://theeventscalendar.atlassian.net/browse/ECP-1575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ