### PR TITLE
Expose filter for finer post save cache invalidation

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 
 = [5.1.10] TBD =
 
-* Tweak - Add the `tec_cache_listener_save_post_types` filter to allow filtering the post types that should trigger a cache invalidation on post save. [ET-1805]
+* Tweak - Add the `tec_cache_listener_save_post_types` filter to allow filtering the post types that should trigger a cache invalidation on post save. [ET-xxx]
 
 = [5.1.8] 2023-09-13 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [5.1.10] TBD =
+
+* Tweak - Add the `tec_cache_listener_save_post_types` filter to allow filtering the post types that should trigger a cache invalidation on post save. [ET-1805]
+
 = [5.1.8] 2023-09-13 =
 
 * Tweak - Compress the size of all images used by the Common module, to reduce the size of the plugin

--- a/src/Tribe/Cache_Listener.php
+++ b/src/Tribe/Cache_Listener.php
@@ -72,7 +72,7 @@ class Tribe__Cache_Listener {
 	 * @param WP_Post $post    The current post object being saved.w
 	 */
 	public function save_post( $post_id, $post ) {
-		if ( in_array( $post->post_type, Tribe__Main::get_post_types() ) ) {
+		if ( in_array( $post->post_type, $this->get_cache_invalidation_post_types() ) ) {
 			$this->cache->set_last_occurrence( self::TRIGGER_SAVE_POST );
 		}
 	}
@@ -211,5 +211,28 @@ class Tribe__Cache_Listener {
 	 */
 	public function generate_rewrite_rules() {
 		$this->cache->set_last_occurrence( self::TRIGGER_GENERATE_REWRITE_RULES );
+	}
+
+	/**
+	 * Returns the list of post types that should trigger a cache invalidation on `save_post.
+	 *
+	 * @since TBD
+	 *
+	 * @return array<string> The list of post types that should trigger a cache invalidation on `save_post`.
+	 */
+	protected function get_cache_invalidation_post_types(): array {
+		$post_types = Tribe__Main::get_post_types();
+
+		/**
+		 * Filters the list of post types that should trigger a cache invalidation on `save_post`.
+		 *
+		 * @since TBD
+		 *
+		 * @param array<string> $post_types The list of post types that should trigger a cache invalidation on
+		 *                                  `save_post`.
+		 */
+		$post_types = apply_filters( 'tec_cache_listener_save_post_types', $post_types );
+
+		return array_values( array_unique( $post_types ) );
 	}
 }


### PR DESCRIPTION
[ET-1887](https://theeventscalendar.atlassian.net/browse/ET-1887)

This PR updates the Cache Listener to allow a finer control over the list of post types that will trigger a cache invalidation on save.

This allows Event Tickets to add Tickets, Orders and Attendees to the list of post types that should trigger a cache invalidation.


[ET-1887]: https://theeventscalendar.atlassian.net/browse/ET-1887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ