### PR TITLE
Implements Black Friday banner updates for 2023

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tribe-common",
-  "version": "5.1.8",
+  "version": "5.1.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tribe-common",
-      "version": "5.1.8",
+      "version": "5.1.10",
       "dependencies": {
         "@babel/runtime": "^7.15.3",
         "@moderntribe/common": "file:src/modules",
@@ -5496,7 +5496,9 @@
       "license": "CC-BY-4.0"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001457",
+      "version": "1.0.30001543",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001543.tgz",
+      "integrity": "sha512-qxdO8KPWPQ+Zk6bvNpPeQIOH47qZSYdFZd6dXQzb2KzhnSXju4Kd7H1PkSJx6NICSMgo/IhRZRhhfPTHYpJUCA==",
       "dev": true,
       "funding": [
         {
@@ -5506,9 +5508,12 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -29290,7 +29295,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001457",
+      "version": "1.0.30001543",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001543.tgz",
+      "integrity": "sha512-qxdO8KPWPQ+Zk6bvNpPeQIOH47qZSYdFZd6dXQzb2KzhnSXju4Kd7H1PkSJx6NICSMgo/IhRZRhhfPTHYpJUCA==",
       "dev": true
     },
     "cardinal": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   "_glotPressUrl": "https://translations.theeventscalendar.com",
   "_glotPressSlug": "tribe-common",
   "_glotPressFileFormat": "%textdomain%-%wp_locale%.%format%",
-  "_glotPressFormats": ["po", "mo"],
+  "_glotPressFormats": [
+    "po",
+    "mo"
+  ],
   "_glotPressFilter": {
     "translation_sets": false,
     "minimum_percentage": 30,
@@ -31,9 +34,14 @@
       "!src/resources/postcss/datepicker.pcss",
       "!src/resources/postcss/tribe-ui.pcss"
     ],
-    "jest": ["src/modules/**/__tests__/**/*.js"]
+    "jest": [
+      "src/modules/**/__tests__/**/*.js"
+    ]
   },
-  "engines": { "node": "18.13.0", "npm": "8.19.3" },
+  "engines": {
+    "node": "18.13.0",
+    "npm": "8.19.3"
+  },
   "scripts": {
     "analyze": "webpack-bundle-analyzer -m static stats.json",
     "bootstrap": "./scripts/linkDependencies",
@@ -106,7 +114,11 @@
     "webpack-cli": "^3.1.2",
     "webpack-merge": "^4.1.4"
   },
-  "overrides": { "babel-plugin-lodash": { "@babel/types": "~7.20.0" } },
+  "overrides": {
+    "babel-plugin-lodash": {
+      "@babel/types": "~7.20.0"
+    }
+  },
   "browserslist": [
     "last 2 Chrome versions",
     "last 2 Firefox versions",

--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [5.1.10] TBD =
 
 * Tweak - Add the `tec_cache_listener_save_post_types` filter to allow filtering the post types that should trigger a cache invalidation on post save. [ET-1887]
+* Tweak - Updates to the Date_Based banner functionality. [ET-1890]
 
 = [5.1.9] 2023-10-03 =
 

--- a/src/Common/Telemetry/Telemetry.php
+++ b/src/Common/Telemetry/Telemetry.php
@@ -609,7 +609,6 @@ final class Telemetry {
 
 		// No entries - show modal.
 		if ( count( $shows ) < 1 ) {
-			error_log('no entries');
 			return true;
 		}
 

--- a/src/Tribe/Admin/Notice/Date_Based.php
+++ b/src/Tribe/Admin/Notice/Date_Based.php
@@ -324,8 +324,6 @@ abstract class Date_Based {
 		return $date;
 	}
 
-
-
 	/**
 	 * Unix time for notice extension end.
 	 *

--- a/src/Tribe/Admin/Notice/Marketing.php
+++ b/src/Tribe/Admin/Notice/Marketing.php
@@ -38,10 +38,10 @@ class Tribe__Admin__Notice__Marketing {
 	 * Register the various Marketing notices.
 	 *
 	 * @since 4.7.23
-	 * @deprecated TBD
+	 * @deprecated 5.1.10
 	 */
 	public function hook() {
-		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Date_Based.' );
+		_deprecated_function( __METHOD__, '5.1.10', 'See Tribe\Admin\Notice\Date_Based.' );
 		$this->black_friday_hook_notice();
 	}
 
@@ -49,10 +49,10 @@ class Tribe__Admin__Notice__Marketing {
 	 * Register the Black Friday notice.
 	 *
 	 * @since 4.12.14
-	 * @deprecated TBD
+	 * @deprecated 5.1.10
 	 */
 	public function black_friday_hook_notice() {
-		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
+		_deprecated_function( __METHOD__, '5.1.10', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
 
 		tribe_notice(
 			'black-friday',
@@ -71,12 +71,12 @@ class Tribe__Admin__Notice__Marketing {
 	 * Unix time for Monday of Thanksgiving week @ 11am UTC. (11am UTC is 6am EST).
 	 *
 	 * @since 4.12.14
-	 * @deprecated TBD
+	 * @deprecated 5.1.10
 	 *
 	 * @return int
 	 */
 	public function get_black_friday_start_time() {
-		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
+		_deprecated_function( __METHOD__, '5.1.10', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
 
 		$date = Dates::build_date_object( 'fourth Thursday of November ' . date( 'Y' ), 'UTC' );
 		$date = $date->modify( '-3 days' );
@@ -98,12 +98,12 @@ class Tribe__Admin__Notice__Marketing {
 	 * Unix time for Dec 1 @ 5am UTC. (5am UTC is 12am EST).
 	 *
 	 * @since 4.12.14
-	 * @deprecated TBD
+	 * @deprecated 5.1.10
 	 *
 	 * @return int
 	 */
 	public function get_black_friday_end_time() {
-		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
+		_deprecated_function( __METHOD__, '5.1.10', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
 
 		$date = Dates::build_date_object( 'December 1st', 'UTC' );
 		$date = $date->setTime( 5, 0 );
@@ -127,12 +127,12 @@ class Tribe__Admin__Notice__Marketing {
 	 * 6am UTC is midnight for TheEventsCalendar.com, which uses the America/Los_Angeles time zone.
 	 *
 	 * @since 4.12.14
-	 * @deprecated TBD
+	 * @deprecated 5.1.10
 	 *
 	 * @return boolean
 	 */
 	public function black_friday_should_display() {
-		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
+		_deprecated_function( __METHOD__, '5.1.10', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
 
 		// If upsells have been manually hidden, respect that.
 		if ( tec_should_hide_upsell() ) {
@@ -166,12 +166,12 @@ class Tribe__Admin__Notice__Marketing {
 	 * HTML for the Black Friday notice.
 	 *
 	 * @since 4.12.14
-	 * @deprecated TBD
+	 * @deprecated 5.1.10
 	 *
 	 * @return string
 	 */
 	public function black_friday_display_notice() {
-		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
+		_deprecated_function( __METHOD__, '5.1.10', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
 
 		Tribe__Assets::instance()->enqueue( [ 'tribe-common-admin' ] );
 

--- a/src/Tribe/Admin/Notice/Marketing.php
+++ b/src/Tribe/Admin/Notice/Marketing.php
@@ -29,7 +29,7 @@ class Tribe__Admin__Notice__Marketing {
 	public $et_is_active;
 
 	public function __construct() {
-		$tribe_dependency    = Tribe__Dependency::instance();
+		$tribe_dependency    = tribe( Tribe__Dependency::class );
 		$this->tec_is_active = $tribe_dependency->is_plugin_active( 'Tribe__Events__Main' );
 		$this->et_is_active  = $tribe_dependency->is_plugin_active( 'Tribe__Tickets__Main' );
 	}
@@ -38,8 +38,10 @@ class Tribe__Admin__Notice__Marketing {
 	 * Register the various Marketing notices.
 	 *
 	 * @since 4.7.23
+	 * @deprecated TBD
 	 */
 	public function hook() {
+		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Date_Based.' );
 		$this->black_friday_hook_notice();
 	}
 
@@ -47,8 +49,10 @@ class Tribe__Admin__Notice__Marketing {
 	 * Register the Black Friday notice.
 	 *
 	 * @since 4.12.14
+	 * @deprecated TBD
 	 */
 	public function black_friday_hook_notice() {
+		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
 
 		tribe_notice(
 			'black-friday',
@@ -67,10 +71,13 @@ class Tribe__Admin__Notice__Marketing {
 	 * Unix time for Monday of Thanksgiving week @ 11am UTC. (11am UTC is 6am EST).
 	 *
 	 * @since 4.12.14
+	 * @deprecated TBD
 	 *
 	 * @return int
 	 */
 	public function get_black_friday_start_time() {
+		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
+
 		$date = Dates::build_date_object( 'fourth Thursday of November ' . date( 'Y' ), 'UTC' );
 		$date = $date->modify( '-3 days' );
 		$date = $date->setTime( 11, 0 );
@@ -91,10 +98,13 @@ class Tribe__Admin__Notice__Marketing {
 	 * Unix time for Dec 1 @ 5am UTC. (5am UTC is 12am EST).
 	 *
 	 * @since 4.12.14
+	 * @deprecated TBD
 	 *
 	 * @return int
 	 */
 	public function get_black_friday_end_time() {
+		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
+
 		$date = Dates::build_date_object( 'December 1st', 'UTC' );
 		$date = $date->setTime( 5, 0 );
 
@@ -109,6 +119,7 @@ class Tribe__Admin__Notice__Marketing {
 		 */
 		return apply_filters( 'tribe_black_friday_end_time', $end_time );
 	}
+
 	/**
 	 * Whether the Black Friday notice should display.
 	 *
@@ -116,10 +127,13 @@ class Tribe__Admin__Notice__Marketing {
 	 * 6am UTC is midnight for TheEventsCalendar.com, which uses the America/Los_Angeles time zone.
 	 *
 	 * @since 4.12.14
+	 * @deprecated TBD
 	 *
 	 * @return boolean
 	 */
 	public function black_friday_should_display() {
+		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
+
 		// If upsells have been manually hidden, respect that.
 		if ( tec_should_hide_upsell() ) {
 			return false;
@@ -152,10 +166,13 @@ class Tribe__Admin__Notice__Marketing {
 	 * HTML for the Black Friday notice.
 	 *
 	 * @since 4.12.14
+	 * @deprecated TBD
 	 *
 	 * @return string
 	 */
 	public function black_friday_display_notice() {
+		_deprecated_function( __METHOD__, 'TBD', 'See Tribe\Admin\Notice\Marketing\Black_Friday.' );
+
 		Tribe__Assets::instance()->enqueue( [ 'tribe-common-admin' ] );
 
 		$current_screen = get_current_screen();

--- a/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
+++ b/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
@@ -52,8 +52,8 @@ class Black_Friday extends \Tribe\Admin\Notice\Date_Based {
 		$template_args = [
 			'icon_url' => tribe_resource_url( $this->icon_url, false, null, \Tribe__Main::instance() ),
 			'cta_url'  => 'https://evnt.is/1aqi',
-			'start_date' => $this->get_start_time()->format_i18n( 'F jS' ),
-			'end_date' => $this->get_end_time()->format_i18n( 'F jS' ),
+			'start_date' => $this->get_start_time()->format( 'F jS' ),
+			'end_date' => $this->get_end_time()->format( 'F jS' ),
 		];
 
 		// Get the Black Friday notice content.

--- a/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
+++ b/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
@@ -79,7 +79,7 @@ class Black_Friday extends \Tribe\Admin\Notice\Date_Based {
 	/**
 	 * Enqueue additional assets for the notice.
 	 *
-	 * @since TBD
+	 * @since 5.1.10
 	 */
 	public function enqueue_additional_assets() {
 		if ( ! $this->should_display() ) {

--- a/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
+++ b/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
@@ -52,6 +52,7 @@ class Black_Friday extends \Tribe\Admin\Notice\Date_Based {
 		$template_args = [
 			'icon_url' => tribe_resource_url( $this->icon_url, false, null, \Tribe__Main::instance() ),
 			'cta_url'  => 'https://evnt.is/1aqi',
+			'start_date' => $this->get_start_time()->format_i18n( 'F jS' ),
 			'end_date' => $this->get_end_time()->format_i18n( 'F jS' ),
 		];
 

--- a/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
+++ b/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
@@ -25,7 +25,7 @@ class Black_Friday extends \Tribe\Admin\Notice\Date_Based {
 	/**
 	 * {@inheritDoc}
 	 */
-	public $start_date = '4th Thursday of November';
+	public $start_date = 'fourth Thursday of November';
 
 	/**
 	 * {@inheritDoc}
@@ -40,12 +40,17 @@ class Black_Friday extends \Tribe\Admin\Notice\Date_Based {
 	/**
 	 * {@inheritDoc}
 	 */
+	public $icon_url = 'images/icons/horns-white.svg';
+
+	/**
+	 * {@inheritDoc}
+	 */
 	public function display_notice() {
 		\Tribe__Assets::instance()->enqueue( [ 'tribe-common-admin' ] );
 
 		// Set up template variables.
 		$template_args = [
-			'icon_url' => \Tribe__Main::instance()->plugin_url . 'src/resources/images/icons/sale-burst.svg',
+			'icon_url' => tribe_resource_url( $this->icon_url, false, null, \Tribe__Main::instance() ),
 			'cta_url'  => 'https://evnt.is/1aqi',
 			'end_date' => $this->get_end_time()->format_i18n( 'F jS' ),
 		];
@@ -68,5 +73,18 @@ class Black_Friday extends \Tribe\Admin\Notice\Date_Based {
 		$date = $date->modify( '-3 days' );
 
 		return $date;
+	}
+
+	/**
+	 * Enqueue additional assets for the notice.
+	 *
+	 * @since TBD
+	 */
+	public function enqueue_additional_assets() {
+		if ( ! $this->should_display() ) {
+			return;
+		}
+		// Adds the Montserrat font from Google Fonts.
+		wp_enqueue_style( 'tec_black_friday_font', 'https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700' );
 	}
 }

--- a/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
+++ b/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
@@ -25,7 +25,7 @@ class Black_Friday extends \Tribe\Admin\Notice\Date_Based {
 	/**
 	 * {@inheritDoc}
 	 */
-	public $start_date = 'fourth Thursday of November';
+	public $start_date = '4th Thursday of November';
 
 	/**
 	 * {@inheritDoc}

--- a/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
+++ b/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
@@ -88,7 +88,7 @@ class Black_Friday extends \Tribe\Admin\Notice\Date_Based {
 			'tec-black-friday-font',
 			'https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700',
 			null,
-			null,
+			'admin_enqueue_scripts',
 			[
 				'type' => 'css',
 				'conditionals' => [ $this, 'should_display' ]

--- a/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
+++ b/src/Tribe/Admin/Notice/Marketing/Black_Friday.php
@@ -82,10 +82,17 @@ class Black_Friday extends \Tribe\Admin\Notice\Date_Based {
 	 * @since 5.1.10
 	 */
 	public function enqueue_additional_assets() {
-		if ( ! $this->should_display() ) {
-			return;
-		}
 		// Adds the Montserrat font from Google Fonts.
-		wp_enqueue_style( 'tec_black_friday_font', 'https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700' );
+		tribe_asset(
+			\Tribe__Main::instance(),
+			'tec-black-friday-font',
+			'https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700',
+			null,
+			null,
+			[
+				'type' => 'css',
+				'conditionals' => [ $this, 'should_display' ]
+			]
+		);
 	}
 }

--- a/src/Tribe/Admin/Notice/Service_Provider.php
+++ b/src/Tribe/Admin/Notice/Service_Provider.php
@@ -42,7 +42,7 @@ class Service_Provider extends Provider_Contract {
 	 */
 	private function hooks() {
 		add_action( 'tribe_plugins_loaded', [ $this, 'plugins_loaded'] );
-		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_additional_assets' ] );
+		add_action( 'current_screen', [ $this, 'enqueue_additional_assets' ] );
 	}
 
 	/**

--- a/src/Tribe/Admin/Notice/Service_Provider.php
+++ b/src/Tribe/Admin/Notice/Service_Provider.php
@@ -42,6 +42,7 @@ class Service_Provider extends Provider_Contract {
 	 */
 	private function hooks() {
 		add_action( 'tribe_plugins_loaded', [ $this, 'plugins_loaded'] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_additional_assets' ] );
 	}
 
 	/**
@@ -62,5 +63,9 @@ class Service_Provider extends Provider_Contract {
 		tribe( Marketing\Black_Friday::class );
         // EOY Sale disabled for 2022
 		// tribe( Marketing\End_Of_Year_Sale::class );
+	}
+
+	public function enqueue_additional_assets() {
+		tribe( Marketing\Black_Friday::class )->enqueue_additional_assets();
 	}
 }

--- a/src/Tribe/Admin/Notice/Service_Provider.php
+++ b/src/Tribe/Admin/Notice/Service_Provider.php
@@ -65,6 +65,12 @@ class Service_Provider extends Provider_Contract {
 		// tribe( Marketing\End_Of_Year_Sale::class );
 	}
 
+	/**
+	 * This method is used to enqueue additional assets for the admin notices.
+	 * Each should conditionally call an internal `enqueue_additional_assets()` function to handle the enqueueing.
+	 *
+	 * @since 5.1.10
+	 */
 	public function enqueue_additional_assets() {
 		tribe( Marketing\Black_Friday::class )->enqueue_additional_assets();
 	}

--- a/src/Tribe/Cache_Listener.php
+++ b/src/Tribe/Cache_Listener.php
@@ -216,7 +216,7 @@ class Tribe__Cache_Listener {
 	/**
 	 * Returns the list of post types that should trigger a cache invalidation on `save_post.
 	 *
-	 * @since TBD
+	 * @since 5.1.10
 	 *
 	 * @return array<string> The list of post types that should trigger a cache invalidation on `save_post`.
 	 */
@@ -226,7 +226,7 @@ class Tribe__Cache_Listener {
 		/**
 		 * Filters the list of post types that should trigger a cache invalidation on `save_post`.
 		 *
-		 * @since TBD
+		 * @since 5.1.10
 		 *
 		 * @param array<string> $post_types The list of post types that should trigger a cache invalidation on
 		 *                                  `save_post`.

--- a/src/admin-views/conditional_content/black-friday.php
+++ b/src/admin-views/conditional_content/black-friday.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Template for Black Friday Promo.
+ * Old Template for Black Friday Promo.
  *
  * @since 4.14.7
  * @var string $background_image - the url of the background image to use

--- a/src/admin-views/notices/tribe-bf-general.php
+++ b/src/admin-views/notices/tribe-bf-general.php
@@ -3,29 +3,38 @@
  * The Black Friday admin notice.
  *
  * @since 4.12.14
+ * @since TBD - reworked to make it more like the Stellar Sale banner in layout, can include an icon
  *
- * @var string $icon_url The local URL for the notice's image.
+ * @var string $icon_url The local URL for the notice's image. Can be empty.
  * @var string $cta_url The short URL for black friday.
+ * @var string $start_date - the end date of the sale.
  * @var string $end_date - the end date of the sale.
+ * @var string $extension_date - the eextension date of the sale. This overrides treh $end_date once the $end_date has passed.
  */
 ?>
-<div class="tribe-marketing-notice">
-	<div class="tribe-marketing-notice__icon">
-		<img src="<?php echo esc_url( $icon_url ); ?>"/>
+<div class="tribe-common tribe-marketing-notice">
+	<div class="tribe-marketing-notice__content-wrapper">
+			<h3 class="tribe-marketing-notice__header tribe-common-h3">
+				<?php _e( 'Save 40% on The Events Calendar', 'tribe-common' ); ?>
+			</h3>
+			<p class="tribe-marketing-notice__content tribe-common-h4">
+				<?php _e( 'Upgrade and purchase new products during the Black Friday Sale.', 'tribe-common' ); ?>
+			</p>
+			<p>
+				<span class="tribe-marketing-notice__cta tribe-marketing-notice__cta-shop-now tribe-marketing-notice__cta-shop-now--desktop">
+					<a target="_blank" href="<?php echo esc_url( $cta_url ); ?>">
+						<?php echo esc_html_x( 'Shop now', 'Shop now link text', 'tribe-common' ) ?>
+					</a>
+				</span>
+			</p>
 	</div>
-	<div class="tribe-marketing-notice__content">
-		<h3><?php echo esc_html__( 'Save 40% on every single plugin.', 'tribe-common' ); ?></h3>
-		<p>
-			<?php printf( esc_html__( 'Black Friday Sale now through %s.', 'tribe-common' ), $end_date ); ?>
-			<span class="tribe-marketing-notice__cta">
-				<a
-					href="<?php echo esc_url( $cta_url ); ?>"
-					rel="noreferrer noopener"
-					target="_blank"
-				>
-					<?php echo esc_html__( 'Shop now', 'tribe-common' ); ?>
-				</a>
-			</span>
-		</p>
+		<?php if ( ! empty( $icon_url ) ) : ?>
+		<div class="tribe-marketing-notice__image-wrapper">
+			<img
+				class="tribe-marketing-notice__image"
+				src="<?php echo esc_url( $icon_url ); ?>"
+			/>
+		</div>
+		<?php endif; ?>
 	</div>
 </div>

--- a/src/admin-views/notices/tribe-bf-general.php
+++ b/src/admin-views/notices/tribe-bf-general.php
@@ -3,7 +3,7 @@
  * The Black Friday admin notice.
  *
  * @since 4.12.14
- * @since TBD - reworked to make it more like the Stellar Sale banner in layout, can include an icon
+ * @since 5.1.10 - reworked to make it more like the Stellar Sale banner in layout, can include an icon
  *
  * @var string $icon_url The local URL for the notice's image. Can be empty.
  * @var string $cta_url The short URL for black friday.

--- a/src/admin-views/notices/tribe-bf-general.php
+++ b/src/admin-views/notices/tribe-bf-general.php
@@ -13,19 +13,19 @@
 ?>
 <div class="tribe-common tribe-marketing-notice">
 	<div class="tribe-marketing-notice__content-wrapper">
-			<h3 class="tribe-marketing-notice__header tribe-common-h3">
-				<?php _e( 'Save 40% on The Events Calendar', 'tribe-common' ); ?>
-			</h3>
-			<p class="tribe-marketing-notice__content tribe-common-h4">
-				<?php _e( 'Upgrade and purchase new products during the Black Friday Sale.', 'tribe-common' ); ?>
-			</p>
-			<p>
-				<span class="tribe-marketing-notice__cta tribe-marketing-notice__cta-shop-now tribe-marketing-notice__cta-shop-now--desktop">
-					<a target="_blank" href="<?php echo esc_url( $cta_url ); ?>">
-						<?php echo esc_html_x( 'Shop now', 'Shop now link text', 'tribe-common' ) ?>
-					</a>
-				</span>
-			</p>
+		<h3 class="tribe-marketing-notice__header tribe-common-h3">
+			<?php _e( 'Save 40% on The Events Calendar', 'tribe-common' ); ?>
+		</h3>
+		<p class="tribe-marketing-notice__content tribe-common-h4">
+			<?php _e( 'Upgrade and purchase new products during the Black Friday Sale.', 'tribe-common' ); ?>
+		</p>
+		<p>
+			<span class="tribe-marketing-notice__cta tribe-marketing-notice__cta-shop-now tribe-marketing-notice__cta-shop-now--desktop">
+				<a target="_blank" href="<?php echo esc_url( $cta_url ); ?>">
+					<?php echo esc_html_x( 'Shop now', 'Shop now link text', 'tribe-common' ) ?>
+				</a>
+			</span>
+		</p>
 	</div>
 		<?php if ( ! empty( $icon_url ) ) : ?>
 		<div class="tribe-marketing-notice__image-wrapper">

--- a/src/admin-views/notices/tribe-bf-general.php
+++ b/src/admin-views/notices/tribe-bf-general.php
@@ -9,7 +9,6 @@
  * @var string $cta_url The short URL for black friday.
  * @var string $start_date - the end date of the sale.
  * @var string $end_date - the end date of the sale.
- * @var string $extension_date - the eextension date of the sale. This overrides treh $end_date once the $end_date has passed.
  */
 ?>
 <div class="tribe-common tribe-marketing-notice">

--- a/src/resources/postcss/tribe-common-admin/_main.pcss
+++ b/src/resources/postcss/tribe-common-admin/_main.pcss
@@ -280,7 +280,7 @@ table.plugins {
 			*:first-child:not(.wp-switch-editor) {
 				margin-top: 0;
 			}
-			
+
 			@media (--viewport-medium) {
 				width: auto;
 			}
@@ -1663,7 +1663,7 @@ a.tribe-rating-link {
 				color: #e6b1fc;
 			}
 		}
-		
+
 		.tribe-marketing-notice {
 			max-width: 100%;
 		}
@@ -1836,7 +1836,7 @@ a.tribe-rating-link {
 					@media (min-width: 768px) and (max-width: 1023px) {
 						height: 11vw;
 					}
-				
+
 					@media screen and (max-width: 767px) {
 						height: 35vw;
 						right: -45vw;
@@ -4158,79 +4158,6 @@ body.tribe-welcome #fs_connect {
 		&:hover {
 			color: #161b7d;
 		}
-	}
-}
-
-/* Black Friday Promo
-============================================= */
-.black-friday-promo {
-	align-items: flex-start;
-	display: flex;
-	flex-direction: column-reverse;
-	justify-content: space-between;
-
-	.black-friday-promo__button {
-		background: #3d54ff;
-		border-color: transparent;
-		border-radius: 20px;
-		color: white;
-		font-size: 12px;
-		height: 34px;
-		line-height: 32px;
-		min-height: unset;
-		width: 115px;
-
-		&:hover,
-		&:active,
-		&:focus {
-			background: #1c39bb;
-			border-color: transparent;
-			color: white;
-		}
-	}
-}
-
-.black-friday-promo__promo {
-	background-position: center;
-	background-repeat: no-repeat;
-	border-radius: 10px;
-	display: grid;
-	grid-template-areas: "space promo-content";
-	grid-template-columns: auto 150px;
-	height: 150px;
-	margin: 10px 0;
-	max-width: 100%;
-	width: 450px;
-}
-
-.black-friday-promo__content {
-	grid-area: promo-content;
-	padding-top: 8px;
-	text-align: center;
-}
-
-.black-friday-promo__text {
-	color: #0f1031;
-	font-family: monospace;
-	font-size: 16px;
-	line-height: 1;
-	text-transform: uppercase;
-}
-
-.black-friday-promo__branding-image {
-	max-width: 390px;
-	width: 100%;
-}
-
-@media (min-width: 1024px) {
-	.black-friday-promo {
-		align-items: center;
-		flex-direction: row;
-	}
-
-	.black-friday-promo__branding {
-		padding-right: 10px;
-		width: calc(100% - 450px);
 	}
 }
 

--- a/src/resources/postcss/tribe-common-admin/notices/_all.pcss
+++ b/src/resources/postcss/tribe-common-admin/notices/_all.pcss
@@ -1,13 +1,10 @@
 /* -----------------------------------------------------------------------------
  *
- * Tribe Common Admin
+ * Tribe Common Admin - Marketing Notices
  *
  * This file is just a clearing-house.
  * Make partials (start with an underscore) for any actual css code.
  *
  * ----------------------------------------------------------------------------- */
 
-@import "_main.pcss";
-@import "_upsell.pcss";
-@import "_fields.pcss";
-@import "notices/_all.pcss";
+@import "_black-friday.pcss";

--- a/src/resources/postcss/tribe-common-admin/notices/_black-friday.pcss
+++ b/src/resources/postcss/tribe-common-admin/notices/_black-friday.pcss
@@ -1,0 +1,201 @@
+/* -----------------------------------------------------------------------------
+ *
+ * Tribe Common Admin - Black Friday Marketing Notice
+ *
+ * ----------------------------------------------------------------------------- */
+ @import "../../utilities/_all.pcss";
+
+.tribe-notice-black-friday {
+	--tec-bf-color-start: #00010c;
+	--tec-bf-color-end: #3D54FF;
+	--tec-bf-color-text: #F9FAF9;
+	--tec-bf-color-button-background: transparent;
+
+	background: linear-gradient(to right, var(--tec-bf-color-start), var(--tec-bf-color-end));
+	container: tec-bf-notice / inline-size;
+	font-family: 'Montserrat', sans-serif;
+
+	.tribe-marketing-notice {
+		flex-direction: column;
+		align-items: flex-start;
+		max-height: 367px;
+		overflow: hidden;
+
+		@container tec-bf-notice (min-width: 540px) {
+			align-items: center;
+			flex-direction: row;
+			max-height: 236px;
+		}
+
+		@container tec-bf-notice (min-width: 960px) {
+			max-height: 208px;
+		}
+
+		.tribe-marketing-notice__header,
+		.tribe-marketing-notice__content {
+			font-family: 'Montserrat', sans-serif;
+			color: var(--tec-bf-color-text);
+		}
+
+		.tribe-marketing-notice__content {
+			display: block;
+			font-weight: var(--tec-font-weight-regular);
+			margin: 0;
+			padding: 0;
+		}
+
+		.tribe-marketing-notice__header {
+			max-width: 278px;
+
+			@container tec-bf-notice (min-width: 540px) {
+				max-width: none;
+			}
+		}
+
+		.tribe-marketing-notice__content-wrapper {
+			max-width: 328px;
+			flex-grow: 1;
+
+			@container tec-bf-notice (min-width: 540px) {
+				max-width: none;
+			}
+		}
+
+		.tribe-marketing-notice__cta {
+			align-items: center;
+			border: 1px solid var(--tec-bf-color-text);
+			border-radius: 125px;
+			display: flex;
+			height: 44px;
+			justify-content: center;
+			margin-top: 20px;
+			margin-left: 0;
+			width: 136px;
+
+			a {
+				color: var(--tec-bf-color-text);
+			}
+
+			&:hover,
+			&:focus,
+			&:focus-within {
+				background-color: var(--tec-bf-color-text);
+
+				a {
+					color: var(--tec-bf-color-start);
+				}
+			}
+		}
+
+		.tribe-marketing-notice__image-wrapper {
+			bottom: 26px;
+			align-self: flex-end;
+			position: relative;
+
+			@container tec-bf-notice (min-width: 540px) {
+				bottom: -46px;
+				padding-left: 20px;
+			}
+
+			@container tec-bf-notice (min-width: 656px) {
+				bottom: -40px;
+			}
+		}
+
+		.tribe-marketing-notice__image {
+			height: 213px;
+			max-width: none;
+		}
+	}
+
+	.notice-dismiss {
+		align-self: flex-start;
+
+		&:before {
+			background-color: var(--tec-color-background);
+			background-image: svg-inline(close);
+			background-position: center;
+    		background-repeat: no-repeat;
+			background-size: 55%;
+			border-radius: 50%;
+			content: '';
+			height: 30px;
+			overflow: hidden;
+			width: 30px;
+		}
+	}
+}
+
+/* Old Black Friday Promo - unused?
+ * -------------------------------- */
+.black-friday-promo {
+	align-items: flex-start;
+	display: flex;
+	flex-direction: column-reverse;
+	justify-content: space-between;
+
+	@media (min-width: 1024px) {
+		align-items: center;
+		flex-direction: row;
+	}
+
+	.black-friday-promo__button {
+		background: #3d54ff;
+		border-color: transparent;
+		border-radius: 20px;
+		color: white;
+		font-size: 12px;
+		height: 34px;
+		line-height: 32px;
+		min-height: unset;
+		width: 115px;
+
+		&:hover,
+		&:active,
+		&:focus {
+			background: #1c39bb;
+			border-color: transparent;
+			color: white;
+		}
+	}
+}
+
+.black-friday-promo__promo {
+	background-position: center;
+	background-repeat: no-repeat;
+	border-radius: 10px;
+	display: grid;
+	grid-template-areas: "space promo-content";
+	grid-template-columns: auto 150px;
+	height: 150px;
+	margin: 10px 0;
+	max-width: 100%;
+	width: 450px;
+}
+
+.black-friday-promo__content {
+	grid-area: promo-content;
+	padding-top: 8px;
+	text-align: center;
+}
+
+.black-friday-promo__text {
+	color: #0f1031;
+	font-family: monospace;
+	font-size: 16px;
+	line-height: 1;
+	text-transform: uppercase;
+}
+
+.black-friday-promo__branding {
+	@media (min-width: 1024px) {
+		padding-right: 10px;
+		width: calc(100% - 450px);
+	}
+}
+
+.black-friday-promo__branding-image {
+	max-width: 390px;
+	width: 100%;
+}
+


### PR DESCRIPTION
Updates the template to be more like the Stellar Sale template.
Reorganizes the styles for the BF banner -
 - Removes them from `src/resources/postcss/tribe-common-admin/_main.pcss`
 - Adds a new file for the BF banner styles at `src/resources/postcss/tribe-common-admin/notices/_black-friday.pcss`
 - Sets up to do the same for the others as we change them.
 - Adds functionality to bring in outside/extra assets (like Google Fonts) in the Service Provider.
 - Imports the fonts for this year's banner.
 - Deprecates all the old Marketing functionality (which was all BF-specific anyway) as we now use the Date_Based approach.

Styling uses container queries for positioning: 
 - https://caniuse.com/css-container-queries
 - https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Container_Queries

 [ET-1890]

[ET-1890]: https://stellarwp.atlassian.net/browse/ET-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ