### PR TITLE
This removes a stray closing div in the new Banner template.

### DIFF
--- a/src/admin-views/notices/tribe-bf-general.php
+++ b/src/admin-views/notices/tribe-bf-general.php
@@ -27,13 +27,12 @@
 			</span>
 		</p>
 	</div>
-		<?php if ( ! empty( $icon_url ) ) : ?>
-		<div class="tribe-marketing-notice__image-wrapper">
-			<img
-				class="tribe-marketing-notice__image"
-				src="<?php echo esc_url( $icon_url ); ?>"
-			/>
-		</div>
-		<?php endif; ?>
+	<?php if ( ! empty( $icon_url ) ) : ?>
+	<div class="tribe-marketing-notice__image-wrapper">
+		<img
+			class="tribe-marketing-notice__image"
+			src="<?php echo esc_url( $icon_url ); ?>"
+		/>
 	</div>
+	<?php endif; ?>
 </div>

--- a/src/resources/postcss/tribe-common-admin/_main.pcss
+++ b/src/resources/postcss/tribe-common-admin/_main.pcss
@@ -4051,6 +4051,12 @@ input[type="email"].tribe-events-admin-card__input {
 	background-color: #fff;
 }
 
+body.tec-troubleshooting {
+	#wpcontent {
+		padding-left: 0;
+	}
+}
+
 #tribe-ticketing,
 #tribe-community {
 	display: none;
@@ -4061,7 +4067,6 @@ input[type="email"].tribe-events-admin-card__input {
 	color: #fff;
 	font-size: 16px;
 	line-height: 1;
-	margin-left: -1.55vw;
 	padding: 24px 0;
 
 	@media screen and (max-width: 480px) {
@@ -4158,6 +4163,79 @@ body.tribe-welcome #fs_connect {
 		&:hover {
 			color: #161b7d;
 		}
+	}
+}
+
+/* Black Friday Promo
+============================================= */
+.black-friday-promo {
+	align-items: flex-start;
+	display: flex;
+	flex-direction: column-reverse;
+	justify-content: space-between;
+
+	.black-friday-promo__button {
+		background: #3d54ff;
+		border-color: transparent;
+		border-radius: 20px;
+		color: white;
+		font-size: 12px;
+		height: 34px;
+		line-height: 32px;
+		min-height: unset;
+		width: 115px;
+
+		&:hover,
+		&:active,
+		&:focus {
+			background: #1c39bb;
+			border-color: transparent;
+			color: white;
+		}
+	}
+}
+
+.black-friday-promo__promo {
+	background-position: center;
+	background-repeat: no-repeat;
+	border-radius: 10px;
+	display: grid;
+	grid-template-areas: "space promo-content";
+	grid-template-columns: auto 150px;
+	height: 150px;
+	margin: 10px 0;
+	max-width: 100%;
+	width: 450px;
+}
+
+.black-friday-promo__content {
+	grid-area: promo-content;
+	padding-top: 8px;
+	text-align: center;
+}
+
+.black-friday-promo__text {
+	color: #0f1031;
+	font-family: monospace;
+	font-size: 16px;
+	line-height: 1;
+	text-transform: uppercase;
+}
+
+.black-friday-promo__branding-image {
+	max-width: 390px;
+	width: 100%;
+}
+
+@media (min-width: 1024px) {
+	.black-friday-promo {
+		align-items: center;
+		flex-direction: row;
+	}
+
+	.black-friday-promo__branding {
+		padding-right: 10px;
+		width: calc(100% - 450px);
 	}
 }
 


### PR DESCRIPTION
It also adds a style to remove the padding-left on #wpcontent on the troubleshooting page, which was causing the banner to be off-center. and required a negative margin on the troubleshooting CTA (also removed to match).

[ET-1890]

[ET-1890]: https://stellarwp.atlassian.net/browse/ET-1890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

### Screenshots of the break:
<img width="1512" alt="Screenshot 2023-10-05 at 12 43 21 PM" src="https://github.com/the-events-calendar/tribe-common/assets/929375/d1cd3fd6-3b2b-4e91-9867-2693f0366792">
<img width="1512" alt="Screenshot 2023-10-05 at 12 43 34 PM" src="https://github.com/the-events-calendar/tribe-common/assets/929375/7c48d406-cf1f-4f96-856d-037e928f1e77">


### Screenshots of the fix:
<img width="1512" alt="Screenshot 2023-10-05 at 12 42 03 PM" src="https://github.com/the-events-calendar/tribe-common/assets/929375/cf7138ef-678d-4c67-b2e2-0f6f52401f13">
<img width="1512" alt="Screenshot 2023-10-05 at 12 41 57 PM" src="https://github.com/the-events-calendar/tribe-common/assets/929375/28784316-60fe-4383-b0ee-529476f1d663">

### Troubleshooting page with new style and no banner:
<img width="1512" alt="Screenshot 2023-10-05 at 12 41 37 PM" src="https://github.com/the-events-calendar/tribe-common/assets/929375/7785c5b9-283f-4ddd-879d-035f8b57e6d8">
