### PR TITLE
From WordPress 6.3 leverage the Script API strategy feature to add defer/async.

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -39,7 +39,11 @@ class Tribe__Assets {
 		// Hook the actual registering of.
 		add_action( 'init', [ $this, 'register_in_wp' ], 1, 0 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_stellar_wp_fonts' ] );
-		add_filter( 'script_loader_tag', [ $this, 'filter_tag_async_defer' ], 50, 2 );
+
+		// From 6.3 leverage the build in defer/async strategy feature.
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.3', '<' ) ) {
+			add_filter( 'script_loader_tag', [ $this, 'filter_tag_async_defer' ], 50, 2 );
+		}
 		add_filter( 'script_loader_tag', [ $this, 'filter_modify_to_module' ], 50, 2 );
 		add_filter( 'script_loader_tag', [ $this, 'filter_print_before_after_script' ], 100, 2 );
 
@@ -705,7 +709,7 @@ class Tribe__Assets {
 
 		// Clean these
 		$asset->priority  = absint( $asset->priority );
-		$asset->in_footer = (bool) $asset->in_footer;
+		$asset->in_footer = $asset->in_footer; // Since WordPress 6.3, this parameter accepts an array argument.
 		$asset->media     = esc_attr( $asset->media );
 
 		// Ensures that we have a priority over 1.

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -637,6 +637,7 @@ class Tribe__Assets {
 			'print'         => false,
 
 			'async'         => false,
+			'defer'         => false,
 			'module'        => false,
 
 			// Print before and after.

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -563,6 +563,7 @@ class Tribe__Assets {
 	 * Register an Asset and attach a callback to the required action to display it correctly.
 	 *
 	 * @since 4.3
+	 * @since 5.2 The `$in_footer` parameter was expanded to accept a boolean or an array, mirroring the change in WordPress core.
 	 *
 	 * @param object            $origin    The main object for the plugin you are enqueueing the asset for.
 	 * @param string            $slug      Slug to save the asset - passes through `sanitize_title_with_dashes()`.
@@ -580,7 +581,7 @@ class Tribe__Assets {
 	 *     @type array              $deps           An array of other asset as dependencies.
 	 *     @type string             $version        Version number, used for cache expiring.
 	 *     @type string             $media          Used only for CSS, when to load the file.
-	 *     @type bool               $in_footer      A boolean determining if the javascript should be loaded on the footer.
+	 *     @type bool|array         $in_footer      A boolean determining if the javascript should be loaded on the footer; or an array of arguments.
 	 *     @type array|object       $localize       {
 	 *          Variables needed on the JavaScript side.
 	 *

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -710,7 +710,7 @@ class Tribe__Assets {
 
 		// Clean these
 		$asset->priority  = absint( $asset->priority );
-		$asset->in_footer = $asset->in_footer; // Since WordPress 6.3, this parameter accepts an array argument.
+		$asset->in_footer = is_array($asset->in_footer) ? $asset->in_footer : (bool)$asset->in_footer; // Since WordPress 6.3, this parameter accepts an array argument.
 		$asset->media     = esc_attr( $asset->media );
 
 		// Ensures that we have a priority over 1.

--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -40,7 +40,7 @@ class Tribe__Assets {
 		add_action( 'init', [ $this, 'register_in_wp' ], 1, 0 );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_stellar_wp_fonts' ] );
 
-		// From 6.3 leverage the build in defer/async strategy feature.
+		// From WordPress 6.3 leverage the Script API strategy feature to add defer/async.
 		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '6.3', '<' ) ) {
 			add_filter( 'script_loader_tag', [ $this, 'filter_tag_async_defer' ], 50, 2 );
 		}
@@ -637,7 +637,6 @@ class Tribe__Assets {
 			'print'         => false,
 
 			'async'         => false,
-			'defer'         => false,
 			'module'        => false,
 
 			// Print before and after.

--- a/src/Tribe/Assets_Pipeline.php
+++ b/src/Tribe/Assets_Pipeline.php
@@ -37,7 +37,7 @@ class Tribe__Assets_Pipeline {
 			$dir = Tribe__Main::instance()->plugin_url . 'src/resources/js';
 			$tag = "<script src='{$dir}/underscore-before.js' defer></script>\n"
 			       . $tag
-			       . "<script src='{$dir}/underscore-after.js' defer></script defer>\n";
+			       . "<script src='{$dir}/underscore-after.js' defer></script>\n";
 		}
 
 		return $tag;

--- a/src/Tribe/Assets_Pipeline.php
+++ b/src/Tribe/Assets_Pipeline.php
@@ -35,9 +35,9 @@ class Tribe__Assets_Pipeline {
 
 		if ( 'underscore' === $handle ) {
 			$dir = Tribe__Main::instance()->plugin_url . 'src/resources/js';
-			$tag = "<script src='{$dir}/underscore-before.js'></script>\n"
+			$tag = "<script src='{$dir}/underscore-before.js' defer></script>\n"
 			       . $tag
-			       . "<script src='{$dir}/underscore-after.js'></script>\n";
+			       . "<script src='{$dir}/underscore-after.js'></script defer>\n";
 		}
 
 		return $tag;

--- a/src/Tribe/Assets_Pipeline.php
+++ b/src/Tribe/Assets_Pipeline.php
@@ -37,7 +37,7 @@ class Tribe__Assets_Pipeline {
 			$dir = Tribe__Main::instance()->plugin_url . 'src/resources/js';
 			$tag = "<script src='{$dir}/underscore-before.js' defer></script>\n"
 			       . $tag
-			       . "<script src='{$dir}/underscore-after.js'></script defer>\n";
+			       . "<script src='{$dir}/underscore-after.js' defer></script defer>\n";
 		}
 
 		return $tag;

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -232,7 +232,7 @@ class Tribe__Main {
 			$this,
 			[
 				[ 'tribe-accessibility-css', 'accessibility.css' ],
-				[ 'tribe-query-string', 'utils/query-string.js' ],
+				[ 'tribe-query-string', 'utils/query-string.js', null, null, [ 'in_footer' => ['strategy' => 'defer' ] ] ],
 				[ 'tribe-clipboard', 'node_modules/clipboard/dist/clipboard.min.js' ],
 				[ 'datatables', 'vendor/datatables/datatables.js', [ 'jquery' ] ],
 				[ 'tribe-select2', 'vendor/tribe-selectWoo/dist/js/selectWoo.full.js', [ 'jquery' ] ],
@@ -297,6 +297,7 @@ class Tribe__Main {
 			'admin_enqueue_scripts',
 			[
 				'priority' => 0,
+				'in_footer' => array ( 'strategy' => 'defer' ),
 			]
 		);
 

--- a/src/resources/js/underscore-after.js
+++ b/src/resources/js/underscore-after.js
@@ -10,10 +10,13 @@
 	 * On a third scenario when lodash is not included this will either be executed which will allow to use
 	 * something like: window.underscore || window._ to fallback to the correct value of underscore in the plugins.
 	 */
-	if ( window._lodash_tmp !== false && typeof window._lodash_tmp === 'function' ) {
-		// Remove reference to _ if is underscore
-		window.underscore = _.noConflict();
-		// Restore reference to lodash if present
-		window._ = window._lodash_tmp;
-	}
+	// Wait until the domContentLoaded event since underscore is loaded using `defer`.
+	document.addEventListener('DOMContentLoaded', function() {
+		if ( window._lodash_tmp !== false && typeof window._lodash_tmp === 'function' ) {
+			// Remove reference to _ if is underscore
+			window.underscore = _.noConflict();
+			// Restore reference to lodash if present
+			window._ = window._lodash_tmp;
+		}
+	}, false);
 })();

--- a/src/resources/js/underscore-after.js
+++ b/src/resources/js/underscore-after.js
@@ -10,13 +10,10 @@
 	 * On a third scenario when lodash is not included this will either be executed which will allow to use
 	 * something like: window.underscore || window._ to fallback to the correct value of underscore in the plugins.
 	 */
-	// Wait until the domContentLoaded event since underscore is loaded using `defer`.
-	document.addEventListener('DOMContentLoaded', function() {
-		if ( window._lodash_tmp !== false && typeof window._lodash_tmp === 'function' ) {
-			// Remove reference to _ if is underscore
-			window.underscore = _.noConflict();
-			// Restore reference to lodash if present
-			window._ = window._lodash_tmp;
-		}
-	}, false);
+	if ( window._lodash_tmp !== false && typeof window._lodash_tmp === 'function' ) {
+		// Remove reference to _ if is underscore
+		window.underscore = _.noConflict();
+		// Restore reference to lodash if present
+		window._ = window._lodash_tmp;
+	}
 })();


### PR DESCRIPTION
## Context
WordPress introduced a new strategy feature in the Script API in version 6.3. See [this post](https://make.wordpress.org/core/2023/07/14/registering-scripts-with-async-and-defer-attributes-in-wordpress-6-3/) for more details.

I am working on a [PR](https://github.com/the-events-calendar/the-events-calendar/pull/4392) that leverages this new feature to add `defer` and `async` (focusing on front end scripts for now). In order for this to actually work in The Events Calendar, some changes are also needed here in the common library.

## Details
* From WordPress 6.3 forward, no longer add the `script_loader_tag` hooked `filter_tag_async_defer` function which was used to add async/defer previously
* No longer cast `in_footer` argument to a boolean, from WP 6.3 this argument can be an array
* Add defer to the underscore before/after scripts to ensure their execution order remains intact.
* Ensure front end scripts are deferred including 'tribe-query-string' and 'tribe-common'

Note that using this core strategy feature means that if any other scripts depends on a script marked for defer is not itself deferrable, neither script will be deferred. This is to ensure script execution order remains intact.
 