### PR TITLE
Add a new field type to settings called `image_id`

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 == Changelog ==
 
-= [5.1.8] TBD =
+= [5.1.8] 2023-09-13 =
 
 * Tweak - Compress the size of all images used by the Common module, to reduce the size of the plugin
 * Tweak - Set background image to none on the button element to prevent general button styling overrides. [ET-1815]

--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -127,6 +127,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 				'color',
 				'image',
 				'toggle',
+				'image_id',
 			];
 
 			$this->valid_field_types = apply_filters( 'tribe_valid_field_types', $this->valid_field_types );
@@ -778,6 +779,51 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 			$field .= '<div class="tec-admin__settings-image-field-image-container hidden">';
 			if ( $image_exists ) {
 				$field .= '<img src="' . esc_url( $this->value ) . '" />';
+			}
+			$field .= '</div>';
+			$field .= '<button class="tec-admin__settings-image-field-btn-remove hidden">' . $remove_image_text . '</button>';
+			$field .= $this->do_screen_reader_label();
+			$field .= $this->do_field_div_end();
+			$field .= $this->do_field_end();
+
+			return $field;
+		}
+
+		/**
+		 * Generate an image field that uses the attachment instead of URL.
+		 *
+		 * @since TBD
+		 *
+		 * @return string The field.
+		 */
+		public function image_id() {
+
+			tribe( Settings::class )->maybe_load_image_field_assets();
+
+			$image_exists = ! empty( $this->value );
+			$upload_image_text = esc_html__( 'Select Image', 'tribe-common' );
+			$remove_image_text = esc_html__( 'Remove Image', 'tribe-common' );
+
+			// Add default fieldset attributes if none exist.
+			$image_fieldset_attributes = [
+				'data-select-image-text' => esc_html__( 'Select an image', 'tribe-common' ),
+				'data-use-image-text'    => esc_html__( 'Use this image', 'tribe-common' ),
+				'data-image-id'          => 1,
+			];
+			$this->fieldset_attributes = array_merge( $image_fieldset_attributes, $this->fieldset_attributes );
+
+			$field = $this->do_field_start();
+			$field .= $this->do_field_label();
+			$field .= $this->do_field_div_start();
+			$field .= '<input type="hidden" class="tec-admin__settings-image-field-input"';
+			$field .= $this->do_field_name();
+			$field .= $this->do_field_value();
+			$field .= $this->do_field_attributes();
+			$field .= '/>';
+			$field .= '<button type="button" class="button tec-admin__settings-image-field-btn-add">' . $upload_image_text . '</button>';
+			$field .= '<div class="tec-admin__settings-image-field-image-container hidden">';
+			if ( $image_exists ) {
+				$field .= '<img src="' . esc_url( wp_get_attachment_image_url( $this->value ) ) . '" />';
 			}
 			$field .= '</div>';
 			$field .= '<button class="tec-admin__settings-image-field-btn-remove hidden">' . $remove_image_text . '</button>';

--- a/src/resources/js/admin-image-field.js
+++ b/src/resources/js/admin-image-field.js
@@ -47,7 +47,7 @@ tribe.settings.fields.image = {};
 	 * @type {PlainObject}
 	 */
 	obj.selectors = {
-		imageFieldContainer: '.tribe-field-image',
+		imageFieldContainer: '.tribe-field-image, .tribe-field-image_id',
 		addImgLink: '.tec-admin__settings-image-field-btn-add',
 		removeImgLink: '.tec-admin__settings-image-field-btn-remove',
 		imgContainer: '.tec-admin__settings-image-field-image-container',
@@ -80,14 +80,19 @@ tribe.settings.fields.image = {};
 	 * @return {void}
 	 */
 	obj.onImageSelect = function( $fieldParent ) {
-		const attachment = obj.frame.state().get('selection').first().toJSON(),
-			$imgContainer = $fieldParent.find( obj.selectors.imgContainer );
+		const attachment = obj.frame.state().get('selection').first().toJSON();
+		const $imgContainer = $fieldParent.find( obj.selectors.imgContainer );
 		if ( $imgContainer.find( 'img' ).length > 0 ) {
 			$imgContainer.find( 'img' ).attr( 'src', attachment.url );
 		} else {
 			$imgContainer.html( '<img src="' + attachment.url + '" />' );
 		}
-		$fieldParent.find( obj.selectors.imgIdInput ).val( attachment.url );
+
+		if ( $fieldParent.is( '[data-image-id=1]' ) ) {
+			 $fieldParent.find( obj.selectors.imgIdInput ).val( attachment.id );
+		} else {
+			$fieldParent.find( obj.selectors.imgIdInput ).val( attachment.url );
+		}
 		obj.hideElements( $fieldParent );
 	};
 


### PR DESCRIPTION
This field type will store the ID of the attachment instead of the URL on our settings, which is highly helpful.