### PR TITLE
Fix AM/PM time format for French locale in the `tribe_format_date()` function.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,8 @@
 
 = [5.1.12] TBD =
 
+* Fix - AM/PM time formats `g:i A` and `g:i a` are now respected for the French locale. [TEC-4807]
+
 = [5.1.9] 2023-10-03 =
 
 * Tweak - Updated focus state for relevant elements to have default outline ensuring improved accessibility and consistent browser behavior. [TEC-4888]

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -55,8 +55,7 @@ if ( ! function_exists( 'tribe_format_date' ) ) {
 		$original_locale = get_locale();
 
 		/**
-		 * Temporarily override locale for French AM/PM time display.
-		 * This addresses an issue where the French locale was not respecting the AM/PM time format.
+		 * Temporarily override locale to English (US) for French AM/PM time display, as French does not have a dedicated AM/PM system.
 		 */
 		if ( 'fr_FR' === $original_locale && ( 'g:i A' === $date_format || 'g:i a' === $date_format ) ) {
 			switch_to_locale( 'en_US' );

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -54,10 +54,13 @@ if ( ! function_exists( 'tribe_format_date' ) ) {
 
 		$original_locale = get_locale();
 
+		// Check if the current locale is French and if the date format is using AM/PM.
+		$should_override = 'fr_FR' === $original_locale && ( 'g:i A' === $date_format || 'g:i a' === $date_format );
+
 		/**
 		 * Temporarily override locale to English (US) for French AM/PM time display, as French does not have a dedicated AM/PM system.
 		 */
-		if ( 'fr_FR' === $original_locale && ( 'g:i A' === $date_format || 'g:i a' === $date_format ) ) {
+		if ( $should_override ) {
 			switch_to_locale( 'en_US' );
 		}
 
@@ -66,7 +69,7 @@ if ( ! function_exists( 'tribe_format_date' ) ) {
 		/**
 		 * Revert back to original locale to ensure there are no unexpected side effects elsewhere.
 		 */
-		if ( 'fr_FR' === $original_locale && ( 'g:i A' === $date_format || 'g:i a' === $date_format ) ) {
+		if ( $should_override ) {
 			switch_to_locale( $original_locale );
 		}
 

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -20,7 +20,7 @@ if ( ! function_exists( 'tribe_format_date' ) ) {
 	 *
 	 * Returns formatted date
 	 * 
-	 * @since    TBD Added logic to handle French AM/PM time formats `g:i A` and `g:i a` display.
+	 * @since    TBD Introduced a temporary locale switch to handle the AM/PM format specifically for French language settings.
 	 *
 	 * @category Events
 	 *

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -19,6 +19,8 @@ if ( ! function_exists( 'tribe_format_date' ) ) {
 	 * Formatted Date
 	 *
 	 * Returns formatted date
+	 * 
+	 * @since    TBD Added logic to handle French AM/PM time formats `g:i A` and `g:i a` display.
 	 *
 	 * @category Events
 	 *
@@ -50,7 +52,24 @@ if ( ! function_exists( 'tribe_format_date' ) ) {
 			}
 		}
 
+		$original_locale = get_locale();
+
+		/**
+		 * Temporarily override locale for French AM/PM time display.
+		 * This addresses an issue where the French locale was not respecting the AM/PM time format.
+		 */
+		if ( 'fr_FR' === $original_locale && ( 'g:i A' === $date_format || 'g:i a' === $date_format ) ) {
+			switch_to_locale( 'en_US' );
+		}
+
 		$date = date_i18n( $format, $date );
+
+		/**
+		 * Revert back to original locale to ensure there are no unexpected side effects elsewhere.
+		 */
+		if ( 'fr_FR' === $original_locale && ( 'g:i A' === $date_format || 'g:i a' === $date_format ) ) {
+			switch_to_locale( $original_locale );
+		}
 
 		/**
 		 * Deprecated tribe_event_formatted_date in 4.0 in favor of tribe_formatted_date. Remove in 5.0

--- a/tests/wpunit/Template_Tags/DateTest.php
+++ b/tests/wpunit/Template_Tags/DateTest.php
@@ -42,7 +42,7 @@ class DateTest extends \Codeception\TestCase\WPTestCase {
 
 		// Check if date formatting is in English format.
 		$this->assertEquals( '10:10 AM', $formattedDateA );
-		$this->assertEquals( '10:10 pm', $formattedDatea );  // Adjusted to expect lowercase
+		$this->assertEquals( '10:10 pm', $formattedDatea );
 
 		// Revert locale back to English
 		switch_to_locale( 'en_US' );

--- a/tests/wpunit/Template_Tags/DateTest.php
+++ b/tests/wpunit/Template_Tags/DateTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Template_Tags;
+
+use Tribe__Date_Utils;
+
+class DateTest extends \Codeception\TestCase\WPTestCase {
+
+	protected function setUp() {
+		parent::setUp();
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_convert_string_date_to_timestamp() {
+		$date     = '2023-10-10 10:10:10';
+		$expected = strtotime( $date );
+		$actual   = Tribe__Date_Utils::is_timestamp( tribe_format_date( $date, true, 'U' ) );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_use_date_format_if_provided() {
+		$date = '2023-10-10 10:10:10';
+
+		$this->assertEquals( '2023', tribe_format_date( $date, true, 'Y' ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_switch_to_en_locale_for_french_ampm_format() {
+		// Switch locale to French
+		switch_to_locale( 'fr_FR' );
+
+		$formattedDateA = tribe_format_date( '2023-10-10 10:10:10 AM', true, 'g:i A' );
+		$formattedDatea = tribe_format_date( '2023-10-10 10:10:10 PM', true, 'g:i a' );
+
+		// Check if date formatting is in English format.
+		$this->assertEquals( '10:10 AM', $formattedDateA );
+		$this->assertEquals( '10:10 pm', $formattedDatea );  // Adjusted to expect lowercase
+
+		// Revert locale back to English
+		switch_to_locale( 'en_US' );
+	}
+}
+


### PR DESCRIPTION
## Ticket
[TEC-4807](https://stellarwp.atlassian.net/browse/TEC-4807)

## 🛠️ Changes
This fixes an issue where the French locale was not respecting the `AM/PM` time format for the `g:i A` and `g:i a` time formats.

To fix this issue, the `tribe_format_date()` function now temporarily overrides the locale to `English (US)` when formatting dates and times with the French locale and either of the `g:i A` or `g:i a` time formats. This ensures that the `AM/PM time` format is respected.

This change is necessary because French does not have a dedicated `AM/PM` system. Instead, French speakers use 24-hour time.

## 📸 Screenshots

### Before

![image](https://github.com/the-events-calendar/tribe-common/assets/22029087/a8235ed9-66d1-410f-980c-0e391eea6ce6)

### After

![image](https://github.com/the-events-calendar/tribe-common/assets/22029087/a1c118cc-dd35-4203-a7fc-439ef615c149)

[TEC-4807]: https://stellarwp.atlassian.net/browse/TEC-4807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ