### PR TITLE
This checks notice transients for serialized classes 

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [5.1.10.1] 2023-10-12 =
+
+* Fix - Correct a problem that can cause a fatal when plugins are deactivated in a certain order. [TEC-4951]
+
 = [5.1.10] 2023-10-11 =
 
 * Tweak - Add the `tec_cache_listener_save_post_types` filter to allow filtering the post types that should trigger a cache invalidation on post save. [ET-1887]


### PR DESCRIPTION
...and if it finds one that does not exist, it deletes the notice transient entirely.

Also fixes some logic behind transient pruning.

[TEC-4951]

[TEC-4951]: https://stellarwp.atlassian.net/browse/TEC-4951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ