### PR TITLE
Fix issue with telemetry opt-in arguments

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [5.1.11] 2023-10-19 =
 
 * Fix - AM/PM time formats `g:i A` and `g:i a` are now respected for the French locale. [TEC-4807]
+* Tweak - Pass the appropriate arguments to telemetry opt-ins.
 * Language - 0 new strings added, 0 updated, 1 fuzzied, and 0 obsoleted
 
 = [5.1.10.1] 2023-10-12 =

--- a/src/Common/Telemetry/Provider.php
+++ b/src/Common/Telemetry/Provider.php
@@ -75,13 +75,13 @@ class Provider extends Service_Provider {
 	 * @param array  $parsed_args An array of HTTP request arguments.
 	 * @param string $url         The request URL.
 	 */
-	function filter_telemetry_http_request_args( $parsed_args, $url ) {
-		if ( false === stripos( $url, 'stellarwp.com/api/v1/telemetry' ) ) {
+	public function filter_telemetry_http_request_args( $parsed_args, $url ) {
+		if ( false === stripos( $url, 'telemetry.stellarwp.com/api/v1/opt-in' ) ) {
 			return $parsed_args;
 		}
 
-		$parsed_args['integration_id']      = 'tec_common';
-		$parsed_args['integration_version'] = Tribe__Main::VERSION;
+		$parsed_args['body']['integration_id']      = 'tec_common';
+		$parsed_args['body']['integration_version'] = Tribe__Main::VERSION;
 
 		return $parsed_args;
 	}


### PR DESCRIPTION
This fixes an issue where the telemetry opt-in arguments were not being passed correctly to the telemetry server.

## Request
![Screenshot 2023-10-18 172941](https://github.com/the-events-calendar/tribe-common/assets/430385/1682de09-cf17-4422-ac77-5a0849fc0b6d)


## Result
![Screenshot 2023-10-18 173012](https://github.com/the-events-calendar/tribe-common/assets/430385/1c0ad4a5-9343-431d-8023-b68f385aefa2)

