### PR TITLE
ETWP DQA: Add size param to image ID field

### DIFF
--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -823,7 +823,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 			$field .= '<button type="button" class="button tec-admin__settings-image-field-btn-add">' . $upload_image_text . '</button>';
 			$field .= '<div class="tec-admin__settings-image-field-image-container hidden">';
 			if ( $image_exists ) {
-				$field .= '<img src="' . esc_url( wp_get_attachment_image_url( $this->value ) ) . '" />';
+				$field .= '<img src="' . esc_url( wp_get_attachment_image_url( $this->value, 'medium' ) ) . '" />';
 			}
 			$field .= '</div>';
 			$field .= '<button class="tec-admin__settings-image-field-btn-remove hidden">' . $remove_image_text . '</button>';


### PR DESCRIPTION
### Description
When displaying the image preview, the image seems to be cut off. This is because we weren't adding the `size` parameter to the `wp_get_attachment_image_url` function when displaying the image. This caused it to default to the `thumbnail` size.

### Artifacts
Before:
![image](https://github.com/the-events-calendar/tribe-common/assets/7432506/c716d0e5-34c9-40a1-946c-95a1316621f6)

After:
![image](https://github.com/the-events-calendar/tribe-common/assets/7432506/5c286989-555d-44cf-9431-6db93666428c)
