### PR TITLE
BTRIA-2100/missing timezone parameter

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Correct `tribe_get_end_date` to return dates in the correct time zone. [BTRIA-2100]
+
 = [5.1.12] 2023-11-01 =
 
 * Tweak - Ticketing & RSVP tab selected by default when clicking Help from the Tickets menu. [ET-1837]

--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -387,7 +387,7 @@ if ( ! function_exists( 'tribe_get_end_date' ) ) {
 
 			// @todo [BTRIA-584]: Move timezones to Common.
 			if ( class_exists( 'Tribe__Events__Timezones' ) ) {
-				$end_date = Tribe__Events__Timezones::event_end_timestamp( $event->ID );
+				$end_date = Tribe__Events__Timezones::event_end_timestamp( $event->ID, $timezone );
 			} else {
 				return null;
 			}


### PR DESCRIPTION
[BTRIA-2100]

The `$timezone` parameter seems to be missing from `tribe_get_end_date`. As a result, the method returns UTC time zone.
I added the missing parameter based on how it's done for `tribe_get_start_date`.