### PR TITLE
Add stability to opt-in data | TCMN-166

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [5.1.13] 2023-11-08 =
+
+* Tweak - Ensure stability of opt-in data.
+
 = [5.1.12] 2023-11-01 =
 
 * Tweak - Ticketing & RSVP tab selected by default when clicking Help from the Tickets menu. [ET-1837]

--- a/src/Common/Telemetry/Opt_In.php
+++ b/src/Common/Telemetry/Opt_In.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Handles Telemetry opt-in logic.
+ *
+ * @since   TBD
+ *
+ * @package TEC\Common\Telemetry
+ */
+namespace TEC\Common\Telemetry;
+
+use TEC\Common\StellarWP\Telemetry\Config;
+use TEC\Common\StellarWP\Telemetry\Opt_In\Status as Opt_In_Status;
+use TEC\Common\StellarWP\DB\DB;
+use WP_User;
+
+/**
+ * Class Opt_In
+ *
+ * @since   TBD
+
+ * @package TEC\Common\Telemetry
+ */
+class Opt_In {
+	/**
+	 * Build the opt-in user data, store it, and fetch it.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function build_opt_in_user(): array {
+		$stellar_slug = Config::get_stellar_slug();
+
+		if ( empty( $stellar_slug ) ) {
+			return [];
+		}
+
+		$opt_in_user = get_option( Opt_In_Status::OPTION_NAME_USER_INFO, [] );
+
+		// If we already have a stored opt-in user, just return that.
+		if ( count( $opt_in_user ) > 0 && ! empty( $opt_in_user['user'] ) ) {
+			$stored_data = json_decode( $opt_in_user['user'], true );
+
+			if ( is_array( $stored_data ) ) {
+				return $stored_data;
+			}
+		}
+
+		$user = $this->get_generated_opt_in_user();
+
+		$opt_in_user_data = [
+			'name'        => null,
+			'email'       => null,
+			'opt_in_text' => null,
+			'plugin_slug' => $stellar_slug,
+		];
+
+		if ( ! empty( $user ) && ! empty( $user->user_email ) ) {
+			$opt_in_user_data['name']  = $user->display_name;
+			$opt_in_user_data['email'] = $user->user_email;
+		}
+
+		update_option( Opt_In_Status::OPTION_NAME_USER_INFO, [ 'user' => wp_json_encode( $opt_in_user_data ) ] );
+
+		return $opt_in_user_data;
+	}
+
+	/**
+	 * Get the opt-in user to be used in the opt_in_user telemetry field.
+	 *
+	 * @since TBD
+	 *
+	 * @return WP_User|null
+	 */
+	protected function get_generated_opt_in_user(): ?WP_User {
+		$admin_user = $this->get_admin_user_by_admin_email();
+
+		if ( $admin_user ) {
+			return $admin_user;
+		}
+
+		$admin_user = $this->get_first_admin_user();
+
+		return $admin_user;
+	}
+
+	/**
+	 * Get an admin user based on the admin email for the site.
+	 *
+	 * @since TBD
+	 *
+	 * @return WP_User|null
+	 */
+	protected function get_admin_user_by_admin_email(): ?WP_User {
+		$admin_email = get_option( 'admin_email' );
+
+		if ( empty( $admin_email ) ) {
+			return null;
+		}
+
+		$user = get_user_by( 'email', $admin_email );
+
+		if ( ! $user || ! $user->exists() ) {
+			return null;
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Get the first admin user from the first 5,000 users of the site.
+	 *
+	 * @since TBD
+	 *
+	 * @return WP_User|null
+	 */
+	protected function get_first_admin_user(): ?WP_User {
+		global $wpdb;
+
+		$results = DB::table( 'usermeta' )
+			->select( 'user_id', 'meta_value' )
+			->where( 'meta_key', $wpdb->prefix . 'capabilities' )
+			->orderBy( 'user_id' )
+			->limit( 5000 )
+			->getAll();
+
+		// Let's only grab administrators.
+		$results = array_filter( $results, static function( $row ) {
+			return strpos( $row->meta_value, '"administrator"' ) !== false;
+		} );
+
+		if ( empty( $results ) ) {
+			return null;
+		}
+
+		$user_row = current( $results );
+
+		if ( empty( $user_row ) || empty( $user_row->user_id ) ) {
+			return null;
+		}
+
+		$user_id = absint( $user_row->user_id );
+		$user    = get_userdata( $user_id );
+
+		if ( empty( $user ) || ! $user->exists() ) {
+			return null;
+		}
+
+		return $user;
+	}
+}

--- a/src/Common/Telemetry/Opt_In.php
+++ b/src/Common/Telemetry/Opt_In.php
@@ -2,7 +2,7 @@
 /**
  * Handles Telemetry opt-in logic.
  *
- * @since   TBD
+ * @since   5.1.13
  *
  * @package TEC\Common\Telemetry
  */
@@ -16,7 +16,7 @@ use WP_User;
 /**
  * Class Opt_In
  *
- * @since   TBD
+ * @since   5.1.13
 
  * @package TEC\Common\Telemetry
  */
@@ -24,7 +24,7 @@ class Opt_In {
 	/**
 	 * Build the opt-in user data, store it, and fetch it.
 	 *
-	 * @since TBD
+	 * @since 5.1.13
 	 *
 	 * @return array
 	 */
@@ -68,7 +68,7 @@ class Opt_In {
 	/**
 	 * Get the opt-in user to be used in the opt_in_user telemetry field.
 	 *
-	 * @since TBD
+	 * @since 5.1.13
 	 *
 	 * @return WP_User|null
 	 */
@@ -87,7 +87,7 @@ class Opt_In {
 	/**
 	 * Get an admin user based on the admin email for the site.
 	 *
-	 * @since TBD
+	 * @since 5.1.13
 	 *
 	 * @return WP_User|null
 	 */
@@ -110,7 +110,7 @@ class Opt_In {
 	/**
 	 * Get the first admin user from the first 5,000 users of the site.
 	 *
-	 * @since TBD
+	 * @since 5.1.13
 	 *
 	 * @return WP_User|null
 	 */

--- a/src/Common/Telemetry/Provider.php
+++ b/src/Common/Telemetry/Provider.php
@@ -31,6 +31,7 @@ class Provider extends Service_Provider {
 	 */
 	public function register() {
 		$this->container->bind( Telemetry::class, Telemetry::class );
+		$this->container->singleton( Opt_In::class, Opt_In::class );
 
 		$this->add_actions();
 		$this->add_filters();
@@ -87,12 +88,48 @@ class Provider extends Service_Provider {
 	}
 
 	/**
+	 * Filters the arguments for telemetry data to add the opt-in user data if missing.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $args Telemetry args.
+	 *
+	 * @return array
+	 */
+	public function filter_send_data_args( $args ) {
+		if ( ! is_array( $args ) ) {
+			return $args;
+		}
+
+		if ( empty( $args['telemetry'] ) ) {
+			return $args;
+		}
+
+		$telemetry = json_decode( $args['telemetry'], true );
+
+		if ( ! empty( $telemetry['opt_in_user'] ) ) {
+			return $args;
+		}
+
+		/** @var Opt_In $opt_in */
+		$opt_in = $this->container->get( Opt_In::class );
+
+		$telemetry['opt_in_user'] = $opt_in->build_opt_in_user();
+
+		$args['telemetry'] = wp_json_encode( $telemetry );
+
+		return $args;
+	}
+
+	/**
 	 * It's super important to make sure when hooking to WordPress actions that we don't do before we are sure that
 	 * telemetry was properly booted into the system.
 	 *
 	 * @since 5.1.3
+	 * @since TBD Added filter of send_data_args to include opt-in data.
 	 */
 	public function hook_telemetry_init(): void {
+		add_filter( "stellarwp/telemetry/tec/send_data_args", [ $this, 'filter_send_data_args' ] );
 		add_action( 'admin_init', [ $this, 'initialize_telemetry' ], 5 );
 	}
 

--- a/src/Common/Telemetry/Provider.php
+++ b/src/Common/Telemetry/Provider.php
@@ -90,7 +90,7 @@ class Provider extends Service_Provider {
 	/**
 	 * Filters the arguments for telemetry data to add the opt-in user data if missing.
 	 *
-	 * @since TBD
+	 * @since 5.1.13
 	 *
 	 * @param array $args Telemetry args.
 	 *
@@ -126,7 +126,7 @@ class Provider extends Service_Provider {
 	 * telemetry was properly booted into the system.
 	 *
 	 * @since 5.1.3
-	 * @since TBD Added filter of send_data_args to include opt-in data.
+	 * @since 5.1.13 Added filter of send_data_args to include opt-in data.
 	 */
 	public function hook_telemetry_init(): void {
 		add_filter( "stellarwp/telemetry/tec/send_data_args", [ $this, 'filter_send_data_args' ] );

--- a/tests/wpunit/Common/Telemetry/Opt_InTest.php
+++ b/tests/wpunit/Common/Telemetry/Opt_InTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace TEC\Common\Telemetry;
+
+use TEC\Common\StellarWP\Telemetry\Config as Telemetry_Config;
+use TEC\Common\StellarWP\Telemetry\Opt_In\Status;
+use TEC\Common\StellarWP\Telemetry\Telemetry\Telemetry;
+use TEC\Common\Telemetry\Telemetry as Common_Telemetry;
+
+/**
+ * Class Opt_InTest
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Telemetry
+ */
+class Opt_InTest extends \Codeception\TestCase\WPTestCase {
+	protected $request_args = [];
+
+	/**
+	 * @before
+	 */
+	public function init_telemetry() {
+		update_option( Status::OPTION_NAME, [ 'token' => 1 ] );
+		tribe( Common_Telemetry::class )->boot();
+
+		add_filter( 'stellarwp/telemetry/tec/optin_status', [ $this, 'return_1' ] );
+	}
+
+	/**
+	 * @after
+	 */
+	public function deinit_telemetry() {
+		remove_filter( 'stellarwp/telemetry/tec/optin_status', [ $this, 'return_1' ] );
+	}
+
+	public function return_1() {
+		return 1;
+	}
+
+	public function capture_http_request( $response, $parsed_args, $url ) {
+		if ( strpos( $url, 'telemetry' ) === false ) {
+			return $response;
+		}
+
+		$this->request_args = $parsed_args;
+
+		return new \WP_Error( '', '', 5 );
+	}
+
+	public function get_last_http_args() {
+		$request_args       = $this->request_args;
+		$this->request_args = [];
+		remove_filter( 'pre_http_request', [ $this, 'capture_http_request' ] );
+		return $request_args;
+	}
+
+	public function listen_for_http_request() {
+		add_filter( 'pre_http_request', [ $this, 'capture_http_request' ], 10, 3 );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_include_opt_in_user() {
+		delete_option( Status::OPTION_NAME_USER_INFO );
+		update_option( Status::OPTION_NAME_USER_INFO, [ 'user' => wp_json_encode( [
+			'name' => 'bacon',
+			'email' => 'bacon@bacon.bacon',
+			'opt_in_text' => null,
+			'plugin_slug' => 'the-events-calendar',
+		] ) ] );
+
+		$this->listen_for_http_request();
+
+		$container = Telemetry_Config::get_container();
+		$container->get( Telemetry::class )->send_data();
+
+		$request_args = $this->get_last_http_args();
+
+		$request_args = json_decode( $request_args['body']['telemetry'], true );
+
+		$this->assertArrayHasKey( 'opt_in_user', $request_args );
+		$this->assertEquals( 'bacon', $request_args['opt_in_user']['name'] );
+		$this->assertEquals( 'bacon@bacon.bacon', $request_args['opt_in_user']['email'] );
+
+		delete_option( Status::OPTION_NAME_USER_INFO );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_include_empty_opt_in_user() {
+		delete_option( Status::OPTION_NAME_USER_INFO );
+		update_option( Status::OPTION_NAME_USER_INFO, [ 'user' => wp_json_encode( [
+			'name' => null,
+			'email' => null,
+			'opt_in_text' => null,
+			'plugin_slug' => 'the-events-calendar',
+		] ) ] );
+
+		$this->listen_for_http_request();
+
+		$container = Telemetry_Config::get_container();
+		$container->get( Telemetry::class )->send_data();
+
+		$request_args = $this->get_last_http_args();
+
+		$request_args = json_decode( $request_args['body']['telemetry'], true );
+
+		$this->assertArrayHasKey( 'opt_in_user', $request_args );
+		$this->assertNull( $request_args['opt_in_user']['name'] );
+		$this->assertNull( $request_args['opt_in_user']['email'] );
+
+		delete_option( Status::OPTION_NAME_USER_INFO );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_include_opt_in_where_admin_email_has_user() {
+		delete_option( Status::OPTION_NAME_USER_INFO );
+		$this->listen_for_http_request();
+
+		$container = Telemetry_Config::get_container();
+		$container->get( Telemetry::class )->send_data();
+
+		$request_args = $this->get_last_http_args();
+
+		$request_args = json_decode( $request_args['body']['telemetry'], true );
+
+		$this->assertArrayHasKey( 'opt_in_user', $request_args );
+		$this->assertEquals( 'admin', $request_args['opt_in_user']['name'] );
+		$this->assertEquals( 'admin@wordpress.test', $request_args['opt_in_user']['email'] );
+
+		$cached_user_info = get_option( Status::OPTION_NAME_USER_INFO );
+		$cached_opt_in_user = json_decode( $cached_user_info['user'], true );
+		$this->assertEquals( 'admin', $cached_opt_in_user['name'] );
+		$this->assertEquals( 'admin@wordpress.test', $cached_opt_in_user['email'] );
+
+		delete_option( Status::OPTION_NAME_USER_INFO );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_include_opt_in_where_admin_user_is_not_admin_email() {
+		delete_option( Status::OPTION_NAME_USER_INFO );
+		$admin_user = get_user_by( 'email', 'admin@wordpress.test' );
+		wp_update_user( [
+			'ID' => $admin_user->ID,
+			'user_email' => 'bork@bork.bork',
+		] );
+
+		$this->listen_for_http_request();
+
+		$container = Telemetry_Config::get_container();
+		$container->get( Telemetry::class )->send_data();
+
+		$request_args = $this->get_last_http_args();
+
+		$request_args = json_decode( $request_args['body']['telemetry'], true );
+
+		$this->assertArrayHasKey( 'opt_in_user', $request_args );
+		$this->assertEquals( 'admin', $request_args['opt_in_user']['name'] );
+		$this->assertEquals( 'bork@bork.bork', $request_args['opt_in_user']['email'] );
+
+		wp_update_user( [
+			'ID' => $admin_user->ID,
+			'user_email' => 'admin@wordpress.test',
+		] );
+
+		$cached_user_info = get_option( Status::OPTION_NAME_USER_INFO );
+		$cached_opt_in_user = json_decode( $cached_user_info['user'], true );
+		$this->assertEquals( 'admin', $cached_opt_in_user['name'] );
+		$this->assertEquals( 'bork@bork.bork', $cached_opt_in_user['email'] );
+
+		delete_option( Status::OPTION_NAME_USER_INFO );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_include_empty_opt_in_where_there_is_no_admin() {
+		global $wpdb;
+
+		delete_option( Status::OPTION_NAME_USER_INFO );
+		$admin_user = get_user_by( 'email', 'admin@wordpress.test' );
+		$capabilities = get_user_meta( $admin_user->ID, $wpdb->prefix . 'capabilities' );
+		delete_user_meta( $admin_user->ID, $wpdb->prefix . 'capabilities' );
+		wp_update_user( [
+			'ID' => $admin_user->ID,
+			'user_email' => 'bork@bork.bork',
+		] );
+
+		$this->listen_for_http_request();
+
+		$container = Telemetry_Config::get_container();
+		$container->get( Telemetry::class )->send_data();
+
+		$request_args = $this->get_last_http_args();
+
+		$request_args = json_decode( $request_args['body']['telemetry'], true );
+
+		$this->assertArrayHasKey( 'opt_in_user', $request_args );
+		$this->assertNull( $request_args['opt_in_user']['name'] );
+		$this->assertNull( $request_args['opt_in_user']['email'] );
+
+		update_user_meta( $admin_user->ID, $wpdb->prefix . 'capabilities', $capabilities );
+		wp_update_user( [
+			'ID' => $admin_user->ID,
+			'user_email' => 'admin@wordpress.test',
+		] );
+
+		$cached_user_info = get_option( Status::OPTION_NAME_USER_INFO );
+		$cached_opt_in_user = json_decode( $cached_user_info['user'], true );
+		$this->assertNull( $cached_opt_in_user['name'] );
+		$this->assertNull( $cached_opt_in_user['email'] );
+
+		delete_option( Status::OPTION_NAME_USER_INFO );
+	}
+}

--- a/tests/wpunit/Common/Telemetry/Opt_InTest.php
+++ b/tests/wpunit/Common/Telemetry/Opt_InTest.php
@@ -10,7 +10,7 @@ use TEC\Common\Telemetry\Telemetry as Common_Telemetry;
 /**
  * Class Opt_InTest
  *
- * @since TBD
+ * @since 5.1.13
  *
  * @package TEC\Common\Telemetry
  */


### PR DESCRIPTION
This introduces a failover approach to handling opt-in data for Telemetry. Given a successfully opted-in site, we are now confidently sending opt-in data.

Added tests to handle the following scenarios:

1. When an opt-in value is already in the options table
2. When an opt-in value is missing but the admin email matches a user
3. When an opt-in value is missing and the admin email does not match a user, but there is an admin user within the first 5,000 user records
4. When an opt-in value is missing and there are no admin users within the first 5,000 user records

Collaborated on with @bordoni

:ticket: [TCMN-166]
🎥 (see Slack channel for screencast)

[TCMN-166]: https://stellarwp.atlassian.net/browse/TCMN-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ