### PR TITLE
fix(JSON-LD) refine access rights depending on user role

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Fix - Ensure correct access rights to JSON-LD data depending on the user role. [TBD]
+
 = [5.1.15.1] 2023-11-20 =
 
 * Security - Ensure all password protected posts have their settings respected. [TCMN-167]

--- a/src/Tribe/JSON_LD/Abstract.php
+++ b/src/Tribe/JSON_LD/Abstract.php
@@ -89,14 +89,21 @@ abstract class Tribe__JSON_LD__Abstract {
 			return [];
 		}
 
-		// Double check that the user can read this post.
-		if ( ! current_user_can( 'read', $post->ID ) ) {
-			return [];
-		}
-
-		// Ensure this post is not password protected.
-		if ( post_password_required( $post ) ) {
-			return [];
+		$current_user_id = get_current_user_id();
+		if ( $current_user_id === 0 ) {
+			// Visitor: only see published, not password-protected, posts.
+			if ( $post->post_status !== 'publish' || post_password_required( $post ) ) {
+				return [];
+			}
+		} else {
+			// Logged-in user: only see published posts or posts they can read.
+			$capability = $post->post_status === 'private' ? 'read_private_posts' : 'read';
+			if (
+				( post_password_required( $post ) && (int) $post->post_author !== $current_user_id )
+				|| ! current_user_can( $capability, $post->ID )
+			) {
+				return [];
+			}
 		}
 
 		$data = (object) [];


### PR DESCRIPTION
This PR fixes an issue where visitors, user `0`, would not be able to access the JSON-LD scheme of publicly-visible posts.

The PR adds test coverage for some key combinations of roles and posts' stati (private, password-protected, public).

[Demo of the issue.](https://share.cleanshot.com/rp52zfvw)
