### PR TITLE
Don't prime term cache when no posts are passed

### DIFF
--- a/src/Tribe/Utils/Taxonomy.php
+++ b/src/Tribe/Utils/Taxonomy.php
@@ -141,9 +141,9 @@ class Taxonomy {
 	 * @return array<int, array>
 	 */
 	public static function prime_term_cache( array $posts = [], array $taxonomies = [ 'post_tag', \Tribe__Events__Main::TAXONOMY ], bool $prime_term_meta = false ): array {
-                if ( count( $posts ) === 0 ) {
+		if ( count( $posts ) === 0 ) {
 			return [];
-                }
+		}
 
 		$first = reset( $posts );
 		$is_numeric = ( ! $first instanceof \WP_Post );

--- a/src/Tribe/Utils/Taxonomy.php
+++ b/src/Tribe/Utils/Taxonomy.php
@@ -141,6 +141,10 @@ class Taxonomy {
 	 * @return array<int, array>
 	 */
 	public static function prime_term_cache( array $posts = [], array $taxonomies = [ 'post_tag', \Tribe__Events__Main::TAXONOMY ], bool $prime_term_meta = false ): array {
+                if ( count( $posts ) === 0 ) {
+			return [];
+                }
+
 		$first = reset( $posts );
 		$is_numeric = ( ! $first instanceof \WP_Post );
 		if ( $is_numeric ) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


**What is the current behavior?** (You can also link to an open issue here)
When using a permanent object cache, any cache priming is unnecessary because the items are most likely already in the permanent cache.

To make matters worse, the `Tribe\Utils\Taxonomy::prime_term_cache` method has a major performance problem when called with an empty `$posts` array. This is the case, for example, when no future events are to be displayed in the "Events List" widget.

In this part of the method: https://github.com/the-events-calendar/tribe-common/blob/3be81d60381a34c435a5ec1bede724899c5b8871/src/Tribe/Utils/Taxonomy.php#L160-L165

the following values are passed:
```php
$args = [
  'fields' => 'all_with_object_id',
  'object_ids' => [], // this is the offending part
  'taxonomy'  => ['post_tag', \Tribe__Events__Main::TAXONOMY],
];
$terms = get_terms($args);
```

This is highly insufficient for systems with a large number of post tags because _all_ post tags will be fetched and passed to `_prime_term_caches()`. On a project with ~12,000 post tags, we had ~100k requests to the cache.


**What is the new behavior (if this is a feature change)?**
If the `$posts` array is empty (i.e. no events are displayed in the widget), bail early and return an empty array. With ~12,000 post tags, we saw a reduction from ~100k requests to ~20k.


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
I don't expect this to be a breaking change.


**Other information**:
There's an incomplete sentence in the function's DocBlock: `Important to note that`.
Tagging some of the maintainers to get visibility: @lucatume, @bordoni, @Camwyn (sorry for the notification spam)