### PR TITLE
Cast to int for str_split

### DIFF
--- a/src/Tribe/Cache.php
+++ b/src/Tribe/Cache.php
@@ -623,7 +623,7 @@ class Tribe__Cache implements ArrayAccess {
 
 		$inserted         = [];
 		$serialized_value = maybe_serialize( $value );
-		$chunk_size       = tribe( 'feature-detection' )->get_mysql_max_packet_size() * 0.9;
+		$chunk_size       = (int) ( tribe( 'feature-detection' )->get_mysql_max_packet_size() * 0.9 );
 		$chunks           = str_split( $serialized_value, $chunk_size );
 		foreach ( $chunks as $i => $chunk ) {
 			$chunk_transient = $transient . '_' . $i;


### PR DESCRIPTION
[ECP-1603](https://stellarwp.atlassian.net/browse/ECP-1603)

Fixes `PHP Deprecated: Implicit conversion from float 60397977.6 to int loses precision in /var/www/html/public/content/plugins/the-events-calendar/common/src/Tribe/Cache.php on line 627`.



[ECP-1603]: https://stellarwp.atlassian.net/browse/ECP-1603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ