### PR TITLE
Fix - Make use of `get_post` method to get proper `WP_POST` object always.

### DIFF
--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -304,8 +304,7 @@ if ( ! function_exists( 'tribe_get_start_date' ) ) {
 		static $cache_var_name = __FUNCTION__;
 
 		if ( is_null( $event ) ) {
-			global $post;
-			$event = $post;
+			$event = get_post();
 		}
 
 		if ( is_numeric( $event ) ) {
@@ -371,8 +370,7 @@ if ( ! function_exists( 'tribe_get_end_date' ) ) {
 		static $cache_var_name = __FUNCTION__;
 
 		if ( is_null( $event ) ) {
-			global $post;
-			$event = $post;
+			$event = get_post();
 		}
 
 		if ( is_numeric( $event ) ) {


### PR DESCRIPTION
* For Community Events submission page the global post was setting `event` as a simple StdObject instead of the expected `WP_Post` causing the type hinting from applied filters to throw fatals.
* This change makes sure the `$event` value is always a instance of `WP_Post`.

