### PR TITLE
feat(modules/utils) add the noRsvpsOnRecurring utility function

### DIFF
--- a/src/modules/utils/recurrence.js
+++ b/src/modules/utils/recurrence.js
@@ -40,5 +40,5 @@ export const noTicketsOnRecurring = () => {
  * @returns {boolean} Whether RSVPs are allowed on Recurring events or not.
  */
 export const noRsvpsOnRecurring = () => {
-	return document.body.classList.contains('tec-no-rsvp-on-recurring')
+	return document.body.classList.contains( 'tec-no-rsvp-on-recurring' )
 };

--- a/src/modules/utils/recurrence.js
+++ b/src/modules/utils/recurrence.js
@@ -25,8 +25,20 @@ export const hasRecurrenceRules = ( state ) => {
  * Returns whether tickets are allowed on Recurring events or not.
  *
  * @since 5.0.0
+ *
  * @returns {boolean} Whether tickets are allowed on Recurring events or not.
  */
 export const noTicketsOnRecurring = () => {
 	return document.body.classList.contains( 'tec-no-tickets-on-recurring' );
+};
+
+/**
+ * Returns whether RSVPs are allowed on Recurring events or not.
+ *
+ * @since 5.8.0
+ *
+ * @returns {boolean} Whether RSVPs are allowed on Recurring events or not.
+ */
+export const noRsvpsOnRecurring = () => {
+	return document.body.classList.contains('tec-no-rsvp-on-recurring')
 };


### PR DESCRIPTION
Add the `noTicketsOnRsvp` function to the utilities to pick up the `tec-no-rsvps-on-recurring` body class.

The method is used by the Event Tickets plugin to discern whether RSVP ticktes should be added to recurrring Events or not.
