### PR TITLE
Fix php 8.2 deprecation error with date_only, test, changelog.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,7 @@
 == Changelog ==
 = [TBD] TBD =
 
+* Fix - Resolves a PHP 8.2 deprecation error on `Date_Utils` - `PHP Deprecated:  strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in /.../wp-content/plugins/the-events-calendar/common/src/Tribe/Date_Utils.php on line 256`.
 * Fix - This fixes an issue where a template with a duplicate name but located in different folders is called it would always reference the first file. Updated the key to be unique by folder as well. [ECP-1627]
 
 = [5.2.3] 2024-02-19 =

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -253,7 +253,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 * @return string The date only in DB format.
 		 */
 		public static function date_only( $date, $isTimestamp = false, $format = null ) {
-			$date = $isTimestamp ? $date : strtotime( $date );
+			$date = $isTimestamp ? $date : strtotime( $date ?? 'now' );
 
 			if ( is_null( $format ) ) {
 				$format = self::DBDATEFORMAT;

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -246,14 +246,14 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		/**
 		 * Returns the date only.
 		 *
-		 * @param int|string $date        The date (timestamp or string).
-		 * @param bool       $isTimestamp Is $date in timestamp format?
-		 * @param string|null $format The format used
+		 * @param int|string  $date         The date (timestamp or string).
+		 * @param bool        $is_timestamp Is $date in timestamp format?
+		 * @param string|null $format       The format used
 		 *
 		 * @return string The date only in DB format.
 		 */
-		public static function date_only( $date, $isTimestamp = false, $format = null ) {
-			$date = $isTimestamp ? $date : strtotime( $date ?? 'now' );
+		public static function date_only( $date, $is_timestamp = false, $format = null ) {
+			$date = $is_timestamp ? $date : strtotime( $date ?? 'now' );
 
 			if ( is_null( $format ) ) {
 				$format = self::DBDATEFORMAT;

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -246,7 +246,7 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		/**
 		 * Returns the date only.
 		 *
-		 * @param int|string  $date         The date (timestamp or string).
+		 * @param int|string  $date         The date (timestamp or string). If an empty or null date is provided it will default to 'now'.
 		 * @param bool        $is_timestamp Whether or not $date is in timestamp format.
 		 * @param string|null $format       The format used.
 		 *

--- a/src/Tribe/Date_Utils.php
+++ b/src/Tribe/Date_Utils.php
@@ -247,8 +247,8 @@ if ( ! class_exists( 'Tribe__Date_Utils' ) ) {
 		 * Returns the date only.
 		 *
 		 * @param int|string  $date         The date (timestamp or string).
-		 * @param bool        $is_timestamp Is $date in timestamp format?
-		 * @param string|null $format       The format used
+		 * @param bool        $is_timestamp Whether or not $date is in timestamp format.
+		 * @param string|null $format       The format used.
 		 *
 		 * @return string The date only in DB format.
 		 */

--- a/tests/wpunit/Tribe/Date_UtilsTest.php
+++ b/tests/wpunit/Tribe/Date_UtilsTest.php
@@ -483,4 +483,41 @@ class Date_UtilsTest extends \Codeception\TestCase\WPTestCase {
 
 		$this->assertEquals( $expected, $end_of_day->format( Date_Utils::DBDATETIMEFORMAT ) );
 	}
+
+	public function date_only_data_provider() {
+		return [
+			'null'               => [
+				date( 'Y-m-d' ),
+				null,
+			],
+			'2023-01-03 3:22am'  => [
+				'2023-01-03',
+				'2023-01-03 3:22am',
+			],
+			'2022-12-03'         => [
+				'2022-12-03',
+				'2022-12-03',
+			],
+			'december 12th 2010' => [
+				'2010-12-12',
+				'december 12th 2010',
+			],
+			'1702341373'         => [
+				'2023-12-12',
+				1702341373,
+				true,
+			],
+		];
+	}
+
+	/**
+	 * Validates date_only() works as expected.
+	 *
+	 * @dataProvider date_only_data_provider
+	 * @test
+	 */
+	public function test_date_only( $expected, $date, $is_timestamp = false ) {
+		$date_only = Date_Utils::date_only( $date, $is_timestamp );
+		$this->assertEquals( $expected, $date_only );
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[ECP-1620]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Fixes an unrelated deprecation error that was displaying on the Site Editor page.

### 🎥 Artifacts <!-- if applicable-->

`PHP Deprecated:  strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in /.../wp-content/plugins/the-events-calendar/common/src/Tribe/Date_Utils.php on line 256`

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ECP-1620]: https://stellarwp.atlassian.net/browse/ECP-1620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ