### PR TITLE
Add Tribe__Cache::has method

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= [TBD] TBD =
+
+* Feature - Add the `Tribe__Cache::has( string $key, string $expiration_trigger = '' )`; add the `&$found` parameter to the `Tribe__Cache::get` method.
+
 = [5.2.3] 2024-02-19 =
 
 * Tweak - Refactor JS logic to prevent ticketing of recurring events. [ET-1936]

--- a/src/Tribe/Cache.php
+++ b/src/Tribe/Cache.php
@@ -99,17 +99,21 @@ class Tribe__Cache implements ArrayAccess {
 	 *
 	 * Note: When a default value or callback is specified, this value gets set in the cache.
 	 *
+	 * @since 4.11.0
+	 * @since TBD Added the `$found` parameter.
+	 *
 	 * @param string       $id                 The key for the cached value.
 	 * @param string|array $expiration_trigger Optional. Hook to trigger cache invalidation.
 	 * @param mixed        $default            Optional. A default value or callback that returns a default value.
 	 * @param int          $expiration         Optional. When the default value expires, if it gets set.
 	 * @param mixed        $args               Optional. Args passed to callback.
+	 * @param bool         $found              Optional. Whether the value was found in the cache. Set by reference.
 	 *
 	 * @return mixed
 	 */
-	public function get( $id, $expiration_trigger = '', $default = false, $expiration = 0, $args = [] ) {
+	public function get( $id, $expiration_trigger = '', $default = false, $expiration = 0, $args = [], ?bool &$found = false ) {
 		$group   = isset( $this->non_persistent_keys[ $id ] ) ? 'tribe-events-non-persistent' : 'tribe-events';
-		$value   = wp_cache_get( $this->get_id( $id, $expiration_trigger ), $group );
+		$value = wp_cache_get( $this->get_id( $id, $expiration_trigger ), $group, false, $found );
 
 		// Value found.
 		if ( false !== $value ) {
@@ -642,5 +646,22 @@ class Tribe__Cache implements ArrayAccess {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Checks whether a value is set in the cache or not.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $id                 The key for the cached value.
+	 * @param string $expiration_trigger Optional. Hook to trigger cache invalidation.
+	 *
+	 * @return bool Whether the value is set in the cache or not.
+	 */
+	public function has( $id, $expiration_trigger = '' ): bool {
+		$group = isset( $this->non_persistent_keys[ $id ] ) ? 'tribe-events-non-persistent' : 'tribe-events';
+		wp_cache_get( $this->get_id( $id, $expiration_trigger ), $group, false, $found );
+
+		return $found;
 	}
 }

--- a/tests/wpunit/Tribe/CacheTest.php
+++ b/tests/wpunit/Tribe/CacheTest.php
@@ -4,6 +4,7 @@ namespace Tribe;
 
 use Tribe\Tests\Traits\With_Uopz;
 use Tribe__Cache as Cache;
+use Tribe__Cache_Listener as Triggers;
 
 class CacheTest extends \Codeception\TestCase\WPTestCase {
 	use With_Uopz;
@@ -595,4 +596,47 @@ class CacheTest extends \Codeception\TestCase\WPTestCase {
 		 // The value from the cache should be the same that was stored.
 		 $this->assertSame( $value, $cache->get_chunkable_transient( '__test___retrival__from__cache', [ 'save_post' ] ) );
 	 }
+
+	/**
+	 * It should allow knowing whether a value is in cache or not
+	 *
+	 * @test
+	 */
+	public function should_allow_knowing_whether_a_value_is_in_cache_or_not(): void {
+		$cache = tribe_cache();
+
+		$this->assertFalse( $cache->has( 'foo-bar' ) );
+		$this->assertFalse( $cache->has( 'foo-bar-save-post', Triggers::TRIGGER_SAVE_POST ) );
+		$this->assertFalse( $cache->has( 'foo-bar-updated-option', Triggers::TRIGGER_UPDATED_OPTION ) );
+		$this->assertFalse( $cache->has( 'foo-bar-generate-rewrite-rules', Triggers::TRIGGER_GENERATE_REWRITE_RULES ) );
+
+		$this->assertFalse( $cache->get( 'foo-bar', '', false, 0, [], $found ) );
+		$this->assertFalse( $found );
+		$this->assertFalse( $cache->get( 'foo-bar-save-post', Triggers::TRIGGER_SAVE_POST, false, 0, [], $found ) );
+		$this->assertFalse( $found );
+		$this->assertFalse( $cache->get( 'foo-bar-updated-option', Triggers::TRIGGER_UPDATED_OPTION, false, 0, [], $found ) );
+		$this->assertFalse( $found );
+		$this->assertFalse( $cache->get( 'foo-bar-generate-rewrite-rules', Triggers::TRIGGER_GENERATE_REWRITE_RULES, false, 0, [], $found ) );
+		$this->assertFalse( $found );
+
+		$cache->set( 'foo-bar', 'bar' );
+		$this->assertTrue( $cache->has( 'foo-bar' ) );
+		$this->assertEquals('bar', $cache->get( 'foo-bar','', false, 0, [], $found ) );
+		$this->assertTrue( $found );
+
+		$cache->set( 'foo-bar-save-post', 'bar', 0, Triggers::TRIGGER_SAVE_POST );
+		$this->assertTrue( $cache->has( 'foo-bar-save-post', Triggers::TRIGGER_SAVE_POST ) );
+		$this->assertEquals('bar', $cache->get( 'foo-bar-save-post', Triggers::TRIGGER_SAVE_POST, false, 0, [], $found ) );
+		$this->assertTrue( $found );
+
+		$cache->set( 'foo-bar-updated-option', 'bar', 0, Triggers::TRIGGER_UPDATED_OPTION );
+		$this->assertTrue( $cache->has( 'foo-bar-updated-option', Triggers::TRIGGER_UPDATED_OPTION ) );
+		$this->assertEquals('bar', $cache->get( 'foo-bar-updated-option', Triggers::TRIGGER_UPDATED_OPTION, false, 0, [], $found ) );
+		$this->assertTrue( $found );
+
+		$cache->set( 'foo-bar-generate-rewrite-rules', 'bar', 0, Triggers::TRIGGER_GENERATE_REWRITE_RULES );
+		$this->assertTrue( $cache->has( 'foo-bar-generate-rewrite-rules', Triggers::TRIGGER_GENERATE_REWRITE_RULES ) );
+		$this->assertEquals('bar', $cache->get( 'foo-bar-generate-rewrite-rules', Triggers::TRIGGER_GENERATE_REWRITE_RULES, false, 0, [], $found ) );
+		$this->assertTrue( $found );
+	}
 }


### PR DESCRIPTION
 add found in get method,For back-compatibility purposes, I've not modified existing methods like `offsetGet`.
This add a `$found` flag, set by reference, to the `get` method similarly to the one set by the `wp_cache_get` function.
To just check on a value, I've added the `has` method.

### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.