### PR TITLE
Controller_Test_Case - looser type-hint

### DIFF
--- a/tests/_support/Provider/Controller_Test_Case.php
+++ b/tests/_support/Provider/Controller_Test_Case.php
@@ -233,7 +233,7 @@ class Controller_Test_Case extends WPTestCase {
 			'add_filter',
 			function (
 				string $tag,
-				callable $callback,
+				$callback,
 				int $priority = 10,
 				int $args = 1
 			) use (
@@ -251,7 +251,7 @@ class Controller_Test_Case extends WPTestCase {
 			'remove_filter',
 			function (
 				string $tag,
-				callable $callback,
+				$callback,
 				int $priority = 10
 			) use (
 				$controller_class,


### PR DESCRIPTION
Names of existing functions, strings, will resolve to the `callable`
type if they exist. When that is not the case, the strict typehint will
fail.
This commit removes that strict type-hinting to allow for strings that
do not resolve to actually callable functions.
