### PR TITLE
Remove dependency checks.

### DIFF
--- a/src/Common/Event_Automator/Plugin.php
+++ b/src/Common/Event_Automator/Plugin.php
@@ -133,14 +133,6 @@ class Plugin {
 		$this->container->singleton( static::class, $this );
 		$this->container->singleton( 'event-automator', $this );
 		$this->container->singleton( 'event-automator.plugin', $this );
-
-		if ( ! $this->check_plugin_dependencies() ) {
-			// If the plugin dependency manifest is not met, then bail and stop here.
-			return;
-		}
-
-		$this->register_autoloader();
-
 		$this->container->register( Hooks_Provider::class );
 		$this->container->register( Context_Provider::class );
 		$this->container->register( Zapier_Provider::class );


### PR DESCRIPTION
### 🗒️ Description

EVA plugin dependencies were being registered, this is no longer a plugin so it would cause a fatal during registration. Removed the checks and unnecessary calls.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
```PHP Warning:  Undefined array key "TEC\Event_Automator\Plugin" in /.../wp-content/plugins/the-events-calendar/common/src/Tribe/Dependency.php on line 341
PHP Fatal error:  Uncaught Error: Call to a member function add_required_plugin() on null in /.../wp-content/plugins/the-events-calendar/common/src/Tribe/Dependency.php:341
Stack trace:
#0 /.../wp-content/plugins/the-events-calendar/common/src/Tribe/Dependency.php(498): Tribe__Dependency->has_valid_dependencies(Array, Array)
#1 /.../wp-content/plugins/the-events-calendar/common/src/functions/utils.php(81): Tribe__Dependency->check_plugin('TEC\\Event_Autom...')
#2 /.../wp-content/plugins/the-events-calendar/common/src/Common/Event_Automator/Plugin.php(181): tribe_check_plugin('TEC\\Event_Autom...')
#3 /.../wp-content/plugins/the-events-calendar/common/src/Common/Event_Automator/Plugin.php(137): TEC\Event_Automator\Plugin->check_plugin_dependencies()
#4 /.../wp-content/plugins/the-events-calendar/common/src/Common/Event_Automator/Plugin.php(118): TEC\Event_Automator\Plugin->register()
#5 /.../wp-content/plugins/events-calendar-pro/src/Tribe/Integrations/Event_Automator/Service_Provider.php(47): TEC\Event_Automator\Plugin::boot()
#6 /.../wp-content/plugins/events-calendar-pro/src/Tribe/Integrations/Event_Automator/Service_Provider.php(30): Tribe\Events\Pro\Integrations\Event_Automator\Service_Provider->register_plugin()
#7 /.../wp-content/plugins/the-events-calendar/common/vendor/vendor-prefixed/lucatume/di52/src/Container.php(463): Tribe\Events\Pro\Integrations\Event_Automator\Service_Provider->register()
#8 /.../wp-content/plugins/the-events-calendar/common/src/Common/Contracts/Container.php(46): TEC\Common\lucatume\DI52\Container->register('Tribe\\Events\\Pr...')
#9 /.../wp-content/plugins/the-events-calendar/common/src/Tribe/Container.php(305): TEC\Common\Contracts\Container->register('Tribe\\Events\\Pr...')
#10 /.../wp-content/plugins/events-calendar-pro/src/Tribe/Integrations/Manager.php(165): tribe_register_provider('Tribe\\Events\\Pr...')
#11 /.../wp-content/plugins/events-calendar-pro/src/Tribe/Integrations/Manager.php(118): Tribe__Events__Pro__Integrations__Manager->load_event_automator()
#12 /.../wp-content/plugins/events-calendar-pro/src/Tribe/Main.php(194): Tribe__Events__Pro__Integrations__Manager->load_integrations()
#13 /.../wp-content/plugins/events-calendar-pro/src/Tribe/Main.php(1732): Tribe__Events__Pro__Main->__construct()
#14 /.../wp-content/plugins/events-calendar-pro/events-calendar-pro.php(119): Tribe__Events__Pro__Main::instance()
#15 /.../wp-includes/class-wp-hook.php(324): tribe_events_calendar_pro_init('')
#16 /.../wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#17 /.../wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#18 /.../wp-content/plugins/the-events-calendar/common/src/Tribe/Main.php(127): do_action('tribe_common_lo...')
#19 /.../wp-includes/class-wp-hook.php(324): Tribe__Main->plugins_loaded('')
#20 /.../wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#21 /.../wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#22 /.../wp-settings.php(550): do_action('plugins_loaded')
```


### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.