### PR TITLE
Undefined funcs, reference this scope directly instead.

### DIFF
--- a/tests/_support/Provider/Controller_Test_Case.php
+++ b/tests/_support/Provider/Controller_Test_Case.php
@@ -99,7 +99,7 @@ class Controller_Test_Case extends WPTestCase {
 		$test_services = clone $original_services;
 
 		// From now on calls to the Service Locator (the `tribe` function) will be redirected to a test Service Locator.
-		set_fn_return(
+		$this->set_fn_return(
 			'tribe',
 			static function ( $key = null ) use ( $test_services ) {
 				return $key ? $test_services->get( $key ) : $test_services;
@@ -107,7 +107,7 @@ class Controller_Test_Case extends WPTestCase {
 			true
 		);
 		// Redirect calls to init the container too.
-		set_fn_return( Container::class, 'init', $test_services );
+		$this->set_fn_return( Container::class, 'init', $test_services );
 		$this->test_services = $test_services;
 
 		// We should now be working with the test Service Locator.
@@ -357,7 +357,7 @@ class Controller_Test_Case extends WPTestCase {
 		// Here we use the controller to let use know what filters it would hook to by
 		// intercepting the `add_filter` function.
 		$hooked = [];
-		set_fn_return(
+		$this->set_fn_return(
 			'add_filter',
 			function ( $tag, $function_to_add, $priority = 10 ) use ( &$hooked ) {
 				if ( ! ( is_array( $function_to_add ) && $function_to_add[0] instanceof Controller ) ) {


### PR DESCRIPTION

### 🗒️ Description

This was causing [a test failure in ECP](https://github.com/the-events-calendar/events-pro/actions/runs/9323336909/job/25741112702?pr=2478). Calling the set_fn_return on `$this` now.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

![image](https://github.com/the-events-calendar/tribe-common/assets/2826045/ab76494a-a1af-4816-a778-d00c7f539a63)

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.