### PR TITLE
fix(Assets) enqueue the minified version of a package if available

### DIFF
--- a/src/Tribe/Assets.php
+++ b/src/Tribe/Assets.php
@@ -347,7 +347,7 @@ class Tribe__Assets {
 			return false;
 		}
 
-		$extension   = substr( $file, strrpos( $file, '.' ) + 1 );
+		$extension = substr( $file, strrpos( $file, '.' ) + 1 );
 		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		$plugin_path = ! empty( $origin->plugin_path ) ? $origin->plugin_path : $origin->pluginPath;
 


### PR DESCRIPTION
This PR fixes an issue where the `Tribe__Assets::register()` method would not correctly register the minified version of assets.

This is a follow-up fix to the work done in #2093.

The minified version of the files will be loaded if:
1. The non-minified version of the file does not exist; this is the case for vendor files whose non-minified version will not be included in the plugin package.
2. The `SCRIPT_DEBUG` constant is not set or set to `false` indicating that, where possible, the minified version of the files should be loaded.
