### PR TITLE
[ET-2115] Update steallarwp/assets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "stellarwp/models": "dev-main",
     "stellarwp/schema": "^1.1.3",
     "stellarwp/telemetry": "^2.3.1",
-    "stellarwp/assets": "^1.2.1"
+    "stellarwp/assets": "^1.2.2"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d03ba22a6b50c06b8f6af8e4a188eb4",
+    "content-hash": "07abb2abd32ed40b0e7d1903d2cec044",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -295,16 +295,16 @@
         },
         {
             "name": "stellarwp/assets",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/assets.git",
-                "reference": "c5cbed2dcda2f075403440da5c46a96f53d74af9"
+                "reference": "3e097e16b8d6c12c697d4688ec07a079fe46a2ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/assets/zipball/c5cbed2dcda2f075403440da5c46a96f53d74af9",
-                "reference": "c5cbed2dcda2f075403440da5c46a96f53d74af9",
+                "url": "https://api.github.com/repos/stellarwp/assets/zipball/3e097e16b8d6c12c697d4688ec07a079fe46a2ce",
+                "reference": "3e097e16b8d6c12c697d4688ec07a079fe46a2ce",
                 "shasum": ""
             },
             "require-dev": {
@@ -345,9 +345,9 @@
             "description": "A library for managing asset registration and enqueuing in WordPress.",
             "support": {
                 "issues": "https://github.com/stellarwp/assets/issues",
-                "source": "https://github.com/stellarwp/assets/tree/1.2.1"
+                "source": "https://github.com/stellarwp/assets/tree/1.2.2"
             },
-            "time": "2024-05-03T13:01:10+00:00"
+            "time": "2024-06-05T15:58:22+00:00"
         },
         {
             "name": "stellarwp/container-contract",
@@ -6930,5 +6930,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
### 🎫 Ticket

[ET-2115]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Bring's over a fix in stellarwp/assets - https://github.com/stellarwp/assets/pull/10

`stellarwp/assets` would fail to detect minified versions of scripts that would reside outside of the path defined by `StellarWP\Assets\Config::set_relative_asset_path()`.

This is particularly an issue for scripts that are shipped minified only. e.g. `vendor/jquery-tribe-timepicker/jquery.timepicker.js` for which its unminified version is ignored by the `.distfiles` file.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ET-2115]: https://stellarwp.atlassian.net/browse/ET-2115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ