### PR TITLE
Updating the memoized transient notice, and test validating.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -3,6 +3,7 @@
 = [TBD] TBD =
 
 * Fix - The Decorated repository was not returning values from `save()` and other methods. Now they return as expected. [BTRIA-2310]
+* Fix - Resolved an issue where transient notices would disappear given a certain order of operations. [ECP-1804]
 
 = [5.2.7] 2024-05-14 =
 

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -808,6 +808,8 @@ class Tribe__Admin__Notices {
 	protected function set_transients( $notices ) {
 		$transient = self::$transient_notices_name;
 		set_transient( $transient, $notices, MONTH_IN_SECONDS );
+		// Manually memoize the value so we don't have to fetch it again.
+		tribe( 'cache' )['transient_admin_notices'] = $notices;
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Notices/NoticesTest.php
+++ b/tests/wpunit/Tribe/Notices/NoticesTest.php
@@ -1,0 +1,74 @@
+<?php
+
+class NoticesTest extends \Codeception\TestCase\WPTestCase {
+	/**
+	 * Take the Admin Notice instance and verify the notice registered is memoized in the Cache.
+	 *
+	 * @test
+	 */
+	public function should_memoize_notice() {
+		// Verify the notice is not memoized in the Cache.
+		$cache     = tribe( 'cache' );
+		$cache_key = 'transient_admin_notices';
+		$this->assertEmpty( $cache[ $cache_key ] );
+
+		// Register a notice.
+		$notice       = Tribe__Admin__Notices::instance();
+		$message      = '<p>test</p>';
+		$message_slug = 'test';
+		$notice->register_transient( $message_slug, $message );
+
+		// The memoized notice should be in the Cache.
+		$this->assertEquals( $message, $cache[ $cache_key ][ $message_slug ][0] );
+	}
+
+	/**
+	 * Take the Admin Notice instance and verify the notice cache busts.
+	 *
+	 * @test
+	 */
+	public function should_clear_memoize_notice() {
+		// Verify the notice is not memoized in the Cache.
+		$cache     = tribe( 'cache' );
+		$cache_key = 'transient_admin_notices';
+		$this->assertEmpty( $cache[ $cache_key ] );
+
+		// Register a notice.
+		$notice       = Tribe__Admin__Notices::instance();
+		$message      = '<p>test</p>';
+		$message_slug = 'test';
+		$notice->register_transient( $message_slug, $message );
+		$notice->remove_transient( $message_slug );
+
+		// The memoized notice should not be in the Cache.
+		$this->assertFalse( isset( $cache[ $cache_key ][ $message_slug ] ) );
+	}
+
+	/**
+	 * Take the Admin Notice instance and verify the notice updates.
+	 *
+	 * @test
+	 */
+	public function should_update_memoize_notice() {
+		// Verify the notice is not memoized in the Cache.
+		$cache     = tribe( 'cache' );
+		$cache_key = 'transient_admin_notices';
+		$this->assertEmpty( $cache[ $cache_key ] );
+
+		// Register a notice.
+		$notice       = Tribe__Admin__Notices::instance();
+		$message      = '<p>test</p>';
+		$message_slug = 'test';
+		$notice->register_transient( $message_slug, $message );
+
+		// Register another notice.
+		$message2      = '<p>test 2</p>';
+		$message_slug2 = 'test 2';
+		$notice->register_transient( $message_slug2, $message2 );
+
+		// The Notice store should be updated with both.
+		$this->assertTrue( $notice->showing_transient_notice( $message_slug ) );
+		$this->assertTrue( $notice->showing_transient_notice( $message_slug2 ) );
+		$this->assertFalse( $notice->showing_transient_notice( 'nonsense-faux-slug' ) );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[ECP-1804]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

There was a bug that would show given a certain order of operations. The transient notices would memoize the set of notices prior to a new one being registered and the memoized value would not update, thus failing to render the notice.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Changelog entry in the `readme.txt` file.
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ECP-1804]: https://stellarwp.atlassian.net/browse/ECP-1804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ