### PR TITLE
Updating logic to retain dismissable notices until dismissed.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 
 = [TBD] TBD =
 
+* Fix - Fixed an issue where admin transient notices with the dismiss flag not persisting passed the first page load. [ECP-1808]
 * Fix - The Decorated repository was not returning values from `save()` and other methods. Now they return as expected. [BTRIA-2310]
 * Fix - Resolved an issue where transient notices would disappear given a certain order of operations. [ECP-1804]
 * Tweak - Added a new action hook `tec_event_automator_zapier_provider_registered` to fire after the Zapier service has successfully registered. [EVA-159]

--- a/src/Tribe/Admin/Notices.php
+++ b/src/Tribe/Admin/Notices.php
@@ -234,6 +234,11 @@ class Tribe__Admin__Notices {
 			// Return the rendered HTML.
 			$html = $this->render( $slug, $content, false, $wrap );
 
+			// If the notice is dismissible, we need to check if it has been dismissed before removing it.
+			if ( $notice->dismiss ) {
+				return $html;
+			}
+
 			// Remove the notice and the transient (if any) since it's been rendered.
 			$this->remove( $slug );
 			$this->remove_transient( $slug );
@@ -404,21 +409,6 @@ class Tribe__Admin__Notices {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Checks if a given user has dismissed a given notice.
-	 *
-	 * @since      4.3
-	 * @deprecated 4.13.0 Deprecated in favor of correcting the typo.
-	 *
-	 * @param string   $slug    The Name of the Notice
-	 * @param int|null $user_id The user ID
-	 *
-	 * @return boolean
-	 */
-	public function has_user_dimissed( $slug, $user_id = null ) {
-		return $this->has_user_dismissed( $slug, $user_id );
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[ECP-1808]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

If an admin notice has been flagged as dismissable, the notice shouldn't disappear from the first render. My assumption is that the nature of dismissing means it is persisting too.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
https://www.loom.com/share/6d80a90f91c14a49bb64a5626121dc89?sid=dcf694b7-ca37-4259-b789-0c856444a37d

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[ECP-1808]: https://stellarwp.atlassian.net/browse/ECP-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ