### PR TITLE
Check nonce on AJAX select2 source

### DIFF
--- a/src/Tribe/Ajax/Dropdown.php
+++ b/src/Tribe/Ajax/Dropdown.php
@@ -275,6 +275,8 @@ class Tribe__Ajax__Dropdown { // phpcs:ignore-next-line  PEAR.NamingConventions.
 		// Push all POST params into a Default set of data.
 		$args = $this->parse_params( empty( $_POST ) ? [] : $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
+		check_ajax_referer( 'tribe_dropdown', 'nonce' );
+
 		if ( empty( $args->source ) ) {
 			$this->error( esc_attr__( 'Missing data source for this dropdown', 'tribe-common' ) );
 		}

--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -511,6 +511,10 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 				foreach ( $this->attributes as $key => $value ) {
 					$return .= ' ' . $key . '="' . $value . '"';
 				}
+
+				if ( ! empty( $this->attributes['data-source'] ) ) {
+					$return .= ' data-source-nonce="' . esc_attr( wp_create_nonce( 'tribe_dropdown' ) ) . '"';
+				}
 			}
 
 			return apply_filters( 'tribe_field_attributes', $return, $this->name, $this );

--- a/src/resources/js/dropdowns.js
+++ b/src/resources/js/dropdowns.js
@@ -399,6 +399,7 @@ var tribe_dropdowns = window.tribe_dropdowns || {};
 					search: search,
 					page: page,
 					args: $select.data( 'source-args' ),
+					nonce: $select.data( 'source-nonce' ),
 				};
 			};
 		}


### PR DESCRIPTION
### 🎫 Ticket

[ET-2123]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Adding nonce check for AJAX dropdown endpoint.

### 🎥 Artifacts <!-- if applicable-->
![image](https://github.com/the-events-calendar/tribe-common/assets/29694484/887341d4-0901-469a-ad5f-7c7fd8907733)


### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[ET-2123]: https://stellarwp.atlassian.net/browse/ET-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ