### PR TITLE
Moving plugin path defin up.

### DIFF
--- a/src/Common/Event_Automator/Plugin.php
+++ b/src/Common/Event_Automator/Plugin.php
@@ -85,6 +85,22 @@ class Plugin extends \tad_DI52_ServiceProvider {
 	protected $container;
 
 	/**
+	 * Plugin constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param \tad_DI52_Container $container The container to use.
+	 */
+	public function __construct( \tad_DI52_Container $container ) {
+		$this->container = $container;
+
+		// Set up the plugin provider properties.
+		$this->plugin_path = trailingslashit( Tribe__Main::instance()->plugin_path );
+		$this->plugin_dir  = trailingslashit( basename( $this->plugin_path ) );
+		$this->plugin_url  = plugins_url( $this->plugin_dir, $this->plugin_path );
+	}
+
+	/**
 	 * Sets the container for the class.
 	 *
 	 * Note this specifically doesn't have a typing for the container, just a type hinting via Docblocks, it helps
@@ -124,11 +140,6 @@ class Plugin extends \tad_DI52_ServiceProvider {
 	 * This always executes even if the required plugins are not present.
 	 */
 	public function register() {
-		// Set up the plugin provider properties.
-		$this->plugin_path = trailingslashit( Tribe__Main::instance()->plugin_path );
-		$this->plugin_dir  = trailingslashit( basename( $this->plugin_path ) );
-		$this->plugin_url  = plugins_url( $this->plugin_dir, $this->plugin_path );
-
 		// Register this provider as the main one and use a bunch of aliases.
 		$this->container->singleton( static::class, $this );
 		$this->container->singleton( 'event-automator', $this );


### PR DESCRIPTION
### 🎫 Ticket

[EVA-162]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Plugin path was not resolved in time for the admin template, causing a fatal when trying to resolve the template origin.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

```
PHP Fatal error:  Uncaught TEC\Common\Exceptions\Not_Bound_Exception: Error while making TEC\Event_Automator\Plugin: is_dir(): Argument #1 ($filename) must be of type string, TEC\Event_Automator\Plugin given. in /.../wp-content/plugins/event-tickets/common/src/Common/Contracts/Container.php:27
Stack trace:
#0 /.../wp-content/plugins/event-tickets/common/vendor/vendor-prefixed/lucatume/di52/src/Container.php(271): TEC\Common\Contracts\Container->get('TEC\\Event_Autom...')
#1 /.../wp-content/plugins/event-tickets-plus/src/Tribe/Integrations/Event_Automator/Zapier_Provider.php(103): TEC\Common\lucatume\DI52\Container->make('TEC\\Event_Autom...')
#2 /.../wp-includes/class-wp-hook.php(324): Tribe\Tickets\Plus\Integrations\Event_Automator\Zapier_Provider->add_endpoints_to_dashboard('')
#3 /.../wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#4 /.../wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#5 /.../wp-admin/admin.php(175): do_action('admin_init')
#6 /.../wp-admin/edit.php(10): require_once('/Users/victorza...')
#7 {main}
  thrown in /.../wp-content/plugins/event-tickets/common/src/Common/Contracts/Container.php on line 27
```

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[EVA-162]: https://stellarwp.atlassian.net/browse/EVA-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ