### PR TITLE
[TEC-5118] Modify notice id so it is unique per plugin

### DIFF
--- a/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
+++ b/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
@@ -217,7 +217,7 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	 * @since TBD
 	 */
 	public function send_updated_notice(): void {
-		$notice_slug = 'updated-to-merge-version-consolidated-notice';
+		$notice_slug = $this->get_merge_notice_slug() . '-version-consolidated-notice';
 		// Remove dismissed flag since we want to show the notice everytime this is triggered.
 		Tribe__Admin__Notices::instance()->undismiss( $notice_slug );
 


### PR DESCRIPTION
### 🎫 Ticket
[TEC-5118]

### 🗒️ Description
The notices weren't unique, so when several plugins were updated at once, only one notice was showing.

### 🎥 Artifacts <!-- if applicable-->
![image](https://github.com/the-events-calendar/tribe-common/assets/7432506/b699d7a5-c9aa-41d6-8d4b-265699689d94)

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.