### PR TITLE
Remove unsupported font smoothing

### DIFF
--- a/src/resources/postcss/resets/skeleton/_reset.pcss
+++ b/src/resources/postcss/resets/skeleton/_reset.pcss
@@ -1,7 +1,6 @@
 .tribe-common {
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
-	font-smoothing: antialiased;
 
 	/* -----------------------------------------------------------------------------
 	 *


### PR DESCRIPTION
### 🗒️ Description

This change removes the unsupported font-smoothing class. The webkit and moz versions are valid, but font-smoothing is not standard. In the case of the Chrome engine, it takes the webkit classes.

More info: [https://caniuse.com/mdn-css_properties_font-smooth](https://caniuse.com/mdn-css_properties_font-smooth)

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

![tribe_pr](https://github.com/the-events-calendar/tribe-common/assets/26112509/972728a6-c94e-47ba-beca-f1539ebc5997)

W3C validator
![tribe_w3c](https://github.com/the-events-calendar/tribe-common/assets/26112509/84a37b57-6106-46b9-aba6-3d6db06bfd02)

### ✔️ Checklist
- [ ] Changelog entry
 in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.