### PR TITLE
Moved the render to a deferred inline html render, instead of a callb…

### DIFF
--- a/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
+++ b/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
@@ -237,12 +237,25 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	}
 
 	/**
-	 * Send admin notice about the updates of Tickets Plus.
+	 * Send admin notice about the updates in the merged version.
 	 *
 	 * @since TBD
 	 */
 	public function send_updated_notice(): void {
 		$this->register_update();
+
+		// Defer so we have time to register updates for each plugin.
+		add_action( 'admin_init', [ $this, 'register_updated_notice' ], 99 );
+	}
+
+	/**
+	 * Registers the notice transient with the rendered message.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_updated_notice(): void {
 		$notice_slug = 'updated-to-merge-version-consolidated-notice';
 
 		// Remove dismissed flag since we want to show the notice every time this is triggered.
@@ -250,7 +263,7 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 
 		tribe_transient_notice(
 			$notice_slug,
-			__CLASS__ . '::render_updated_notice',
+			$this->render_updated_notice(),
 			[
 				'type'            => 'success',
 				'dismiss'         => true,
@@ -269,7 +282,7 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	 *
 	 * @return string
 	 */
-	public static function render_updated_notice(): string {
+	public function render_updated_notice(): string {
 		$plugins_str  = '';
 		$plugins_list = static::$plugin_updated_names;
 		$last_plugin  = array_pop( $plugins_list );


### PR DESCRIPTION

### 🎫 Ticket

[TEC-5118]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Moved the updated notice render into a deferred html render, instead of a callback from the admin notice renderer.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[TEC-5118]: https://stellarwp.atlassian.net/browse/TEC-5118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ