### PR TITLE
Fix notice bug and edge case init() that is too many.

### DIFF
--- a/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
+++ b/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
@@ -163,7 +163,9 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 		if ( $this->updated_to_merge_version && ! $this->is_child_plugin_active() ) {
 			// Leave a notice of the recent update.
 			$this->send_updated_notice();
-			$this->init_merged_plugin();
+			if( ! $this->is_activating_plugin() ) {
+				$this->init_merged_plugin();
+			}
 			return;
 		}
 
@@ -283,9 +285,9 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	 * @return string
 	 */
 	public function render_updated_notice(): string {
-		$plugins_str  = '';
 		$plugins_list = static::$plugin_updated_names;
 		$last_plugin  = array_pop( $plugins_list );
+		$plugins_str  = $last_plugin;
 
 		// Do we have more than one?
 		if ( count( $plugins_list ) ) {

--- a/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
+++ b/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
@@ -73,13 +73,13 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	 * @return string
 	 */
 	public function get_plugin_real_path(): string {
-		$plugins 		= get_option( 'active_plugins', [] );
-		$text_domain 	= $this->get_child_plugin_text_domain();
-		$plugins 		= array_filter(
+		$plugins     = get_option( 'active_plugins', [] );
+		$text_domain = $this->get_child_plugin_text_domain();
+		$plugins     = array_filter(
 			$plugins,
-			function( $plugin ) use ( $text_domain ) {
-				$plugin = get_plugin_data(WP_PLUGIN_DIR.'/'.$plugin);
-				if( ! isset( $plugin['TextDomain'] ) ) {
+			function ( $plugin ) use ( $text_domain ) {
+				$plugin = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
+				if ( ! isset( $plugin['TextDomain'] ) ) {
 					return false;
 				}
 
@@ -159,13 +159,13 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	 * @since TBD
 	 */
 	protected function is_child_plugin_active(): bool {
-		if( is_plugin_active( $this->get_plugin_file_key() ) ) {
+		if ( is_plugin_active( $this->get_plugin_file_key() ) ) {
 			return true;
 		}
 
 		$real_path = $this->get_plugin_real_path();
 
-		return $real_path && is_plugin_active($real_path);
+		return $real_path && is_plugin_active( $real_path );
 	}
 
 	/**

--- a/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
+++ b/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
@@ -213,6 +213,15 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	}
 
 	/**
+	 * Fetch the plugin text domain used for locating and checking a specific plugin.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	abstract public function get_child_plugin_text_domain(): string;
+
+	/**
 	 * Adds the hook to remove the "Plugin activated" notice from the redirect.
 	 *
 	 * @since TBD


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5116]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Works on a couple issues. The updated notice was not showing individual plugin names, and there were scenarios where the plugin path would be different and fail several steps in the merge logic, such as deactivation.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Changelog entry in the `readme.txt` file.
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[TEC-5116]: https://stellarwp.atlassian.net/browse/TEC-5116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ