### PR TITLE
`get_plugin_real_path` check if plugin exists

### DIFF
--- a/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
+++ b/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
@@ -73,8 +73,16 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	 * @return string
 	 */
 	public function get_plugin_real_path(): string {
-		$plugins     = get_option( 'active_plugins', [] );
+		static $plugins_path = [];
+
 		$text_domain = $this->get_child_plugin_text_domain();
+
+		// Check if the result is already memoized.
+		if ( isset( $plugins_path[ $text_domain ] ) ) {
+			return $plugins_path[ $text_domain ];
+		}
+
+		$plugins     = get_option( 'active_plugins', [] );
 		$plugin_path = '';
 
 		foreach ( $plugins as $plugin ) {
@@ -94,6 +102,9 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 				break;
 			}
 		}
+
+		// Memoize the result.
+		$plugins_path[ $text_domain ] = $plugin_path;
 
 		return $plugin_path;
 	}

--- a/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
+++ b/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
@@ -75,19 +75,27 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	public function get_plugin_real_path(): string {
 		$plugins     = get_option( 'active_plugins', [] );
 		$text_domain = $this->get_child_plugin_text_domain();
-		$plugins     = array_filter(
-			$plugins,
-			function ( $plugin ) use ( $text_domain ) {
-				$plugin = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
-				if ( ! isset( $plugin['TextDomain'] ) ) {
-					return false;
-				}
+		$plugin_path = '';
 
-				return $plugin['TextDomain'] === $text_domain;
+		foreach ( $plugins as $plugin ) {
+			$plugin_file_path = WP_PLUGIN_DIR . '/' . $plugin;
+
+			// Skip if the path is a directory or the file does not exist.
+			if ( is_dir( $plugin_file_path ) || ! file_exists( $plugin_file_path ) ) {
+				continue;
 			}
-		);
 
-		return (string) array_pop( $plugins );
+			// Get plugin data.
+			$plugin_data = get_plugin_data( $plugin_file_path );
+
+			// Check for TextDomain and match.
+			if ( isset( $plugin_data['TextDomain'] ) && $plugin_data['TextDomain'] === $text_domain ) {
+				$plugin_path = $plugin;
+				break;
+			}
+		}
+
+		return $plugin_path;
 	}
 
 	/**


### PR DESCRIPTION
This code adds an additional check to make sure that the plugin we are checking actually exists. When testing the original code in ECP it was causing tests to fail because `get_option( 'active_plugins', [] )` had active plugins that didn't exist in the plugin directory.