### PR TITLE
Resolve `Uncaught ReferenceError: regeneratorRuntime is not defined`

### DIFF
--- a/src/modules/store/index.js
+++ b/src/modules/store/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import 'regenerator-runtime/runtime';
-
-/**
  * Internal dependencies
  */
 import configureStore from './configure-store';


### PR DESCRIPTION
### 🎫 Ticket

[TECTRIA-149]

### 🗒️ Description

Resolves the problem reported with WordPress 6.6 Release Candidate.

Causing: `Uncaught ReferenceError: regeneratorRuntime is not defined`

Since this is a polyfill WordPress is removing I am 95% sure we are not making use of this in any way, but QA will be needed here.

**Steps to recreate:**

1. Start with a test site running the latest WP 6.6 RC, Twenty Twenty, and the Events Calendar plugin. For the first one, I also installed the WordPress Beta tester plugin to update to RC2.
1. Navigate to WP Admin > Events > Settings, and check “Enable the Gutenberg block editor interface for creating events.”
1. Create a new event.
1. Note that each block displays an error (like “Your site doesn’t include support for the `“tribe/event-datetime”` block. You can leave this block intact or remove it entirely.”).
1. Open the browser inspector; there will be errors like `Uncaught ReferenceError: regeneratorRuntime is not defined`.


Resolves: https://wordpress.org/support/topic/wordpress-6-6-rc-errors-in-block-editor-for-events-in-classic-block-themes/

[TECTRIA-149]: https://stellarwp.atlassian.net/browse/TECTRIA-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ