### PR TITLE
Uplink - Licensing Tests

### DIFF
--- a/src/Common/Libraries/Provider.php
+++ b/src/Common/Libraries/Provider.php
@@ -5,6 +5,7 @@ namespace TEC\Common\Libraries;
 use TEC\Common\Contracts\Service_Provider;
 use TEC\Common\StellarWP\Assets;
 use TEC\Common\StellarWP\DB;
+use TEC\Common\StellarWP\Schema;
 use Tribe__Main as Common;
 
 class Provider extends Service_Provider {

--- a/tests/wpunit/Common/Libraries/Uplink/Controller_Test.php
+++ b/tests/wpunit/Common/Libraries/Uplink/Controller_Test.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace TEC\Common\Libraries\Uplink;
+
+use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
+use TEC\Common\StellarWP\Uplink\Register;
+use Tribe__Main;
+
+class Controller_Test extends \Codeception\TestCase\WPTestCase {
+	use SnapshotAssertions;
+
+	/**
+	 * @before
+	 */
+	public function register_uplink() {
+		tribe( Controller::class )->register_uplink();
+		$this->register_plugin();
+	}
+
+	public function register_plugin() {
+		Register::plugin(
+			'common-test-slug',
+			'common-test',
+			'1.0.0',
+			dirname( __FILE__ ),
+			tribe( Tribe__Main::class )
+		);
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_setup_license_fields() {
+		$fields         = [
+			'tribe-form-content-start' => [],
+		];
+		$license_fields = tribe( Controller::class )->register_license_fields( $fields );
+		$this->assertMatchesHtmlSnapshot( $license_fields );
+	}
+}

--- a/tests/wpunit/Common/Libraries/Uplink/Controller_Test.php
+++ b/tests/wpunit/Common/Libraries/Uplink/Controller_Test.php
@@ -5,19 +5,23 @@ namespace TEC\Common\Libraries\Uplink;
 use tad\Codeception\SnapshotAssertions\SnapshotAssertions;
 use TEC\Common\StellarWP\Uplink\Register;
 use Tribe__Main;
+use Tribe\Tests\Traits\With_Uopz;
 
 class Controller_Test extends \Codeception\TestCase\WPTestCase {
 	use SnapshotAssertions;
+	use With_Uopz;
 
 	/**
 	 * @before
 	 */
-	public function register_uplink() {
+	public function setup_uplink() {
+		// Register Uplink and the test plugin before each test
 		tribe( Controller::class )->register_uplink();
 		$this->register_plugin();
 	}
 
 	public function register_plugin() {
+		// Register the test plugin
 		Register::plugin(
 			'common-test-slug',
 			'common-test',
@@ -31,10 +35,69 @@ class Controller_Test extends \Codeception\TestCase\WPTestCase {
 	 * @test
 	 */
 	public function it_should_setup_license_fields() {
-		$fields         = [
+		// Mock the wp_create_nonce function
+		$this->set_fn_return( 'wp_create_nonce', '123456789', false );
+
+		$fields = [
 			'tribe-form-content-start' => [],
 		];
+
+		// Register license fields and assert the HTML snapshot
 		$license_fields = tribe( Controller::class )->register_license_fields( $fields );
 		$this->assertMatchesHtmlSnapshot( $license_fields );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_add_actions_on_do_register() {
+		$controller = tribe( Controller::class );
+		$controller->do_register();
+
+		// Assert actions were added
+		$this->assertNotFalse( has_action( 'init', [ $controller, 'register_uplink' ] ) );
+		$this->assertNotFalse( has_filter( 'tribe_license_fields', [ $controller, 'register_license_fields' ] ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_remove_actions_on_unregister() {
+		$controller = tribe( Controller::class );
+		$controller->do_register(); // First add them
+		$controller->unregister(); // Then remove them
+
+		// Assert actions were removed
+		$this->assertFalse( has_action( 'init', [ $controller, 'register_uplink' ] ) );
+		$this->assertFalse( has_filter( 'tribe_license_fields', [ $controller, 'register_license_fields' ] ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_handle_unregister_before_register() {
+		$controller = tribe( Controller::class );
+		$controller->unregister(); // Call unregister before register
+
+		// Assert actions were not added
+		$this->assertFalse( has_action( 'init', [ $controller, 'register_uplink' ] ) );
+		$this->assertFalse( has_filter( 'tribe_license_fields', [ $controller, 'register_license_fields' ] ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_modify_fields_with_filter() {
+		$fields = [
+			'tribe-form-content-start' => [],
+		];
+
+		// Apply the filter
+		$modified_fields = apply_filters( 'tribe_license_fields', $fields );
+
+		// Assert that the filter modified the fields array
+		$this->assertNotEmpty( $modified_fields );
+		$this->assertArrayHasKey( 'stellarwp-uplink_common-test-slug-heading', $modified_fields );
+		$this->assertArrayHasKey( 'stellarwp-uplink_common-test-slug', $modified_fields );
 	}
 }

--- a/tests/wpunit/Common/Libraries/Uplink/Controller_Test.php
+++ b/tests/wpunit/Common/Libraries/Uplink/Controller_Test.php
@@ -66,7 +66,11 @@ class Controller_Test extends \Codeception\TestCase\WPTestCase {
 
 		// Register license fields and assert the HTML snapshot
 		$license_fields = $this->controller->register_license_fields( $fields );
-		$this->assertMatchesHtmlSnapshot( $license_fields );
+
+		$html = $license_fields['stellarwp-uplink_common-test-slug']['html'];
+		$html = str_replace( dirname( __DIR__, 5 ), '{__DIR__}', $html );
+
+		$this->assertMatchesHtmlSnapshot( $html );
 	}
 
 	/**

--- a/tests/wpunit/Common/Libraries/Uplink/Controller_Test.php
+++ b/tests/wpunit/Common/Libraries/Uplink/Controller_Test.php
@@ -72,19 +72,13 @@ class Controller_Test extends \Codeception\TestCase\WPTestCase {
 	/**
 	 * @test
 	 */
-	public function it_should_add_actions_on_do_register() {
+	public function it_should_add_actions_on_do_register_and_unregister() {
 		$this->controller->do_register();
 
 		// Assert actions were added
 		$this->assertNotFalse( has_action( 'init', [ $this->controller, 'register_uplink' ] ) );
 		$this->assertNotFalse( has_filter( 'tribe_license_fields', [ $this->controller, 'register_license_fields' ] ) );
-	}
 
-	/**
-	 * @test
-	 */
-	public function it_should_remove_actions_on_unregister() {
-		$this->controller->do_register(); // First add them
 		$this->controller->unregister(); // Then remove them
 
 		// Assert actions were removed

--- a/tests/wpunit/Common/Libraries/Uplink/__snapshots__/Controller_Test__it_should_setup_license_fields__0.snapshot.html
+++ b/tests/wpunit/Common/Libraries/Uplink/__snapshots__/Controller_Test__it_should_setup_license_fields__0.snapshot.html
@@ -1,10 +1,9 @@
-a:3:{s:24:"tribe-form-content-start";a:0:{}s:41:"stellarwp-uplink_common-test-slug-heading";a:2:{s:4:"type";s:7:"heading";s:5:"label";s:11:"common-test";}s:33:"stellarwp-uplink_common-test-slug";a:3:{s:4:"type";s:4:"html";s:5:"label";s:0:"";s:4:"html";s:1529:"
 				<div class="stellarwp-uplink__license-field">
 					<div
 						class="stellarwp-uplink-license-key-field"
-						id="/var/www/html/wp-content/plugins/tribe-common/tests/wpunit/Common/Libraries/Uplink"
-						data-slug="/var/www/html/wp-content/plugins/tribe-common/tests/wpunit/Common/Libraries/Uplink"
-						data-plugin="/var/www/html/wp-content/plugins/tribe-common/tests/wpunit/Common/Libraries/Uplink"
+						id="{__DIR__}/tests/wpunit/Common/Libraries/Uplink"
+						data-slug="{__DIR__}/tests/wpunit/Common/Libraries/Uplink"
+						data-plugin="{__DIR__}/tests/wpunit/Common/Libraries/Uplink"
 						data-plugin-slug="common-test-slug"
 						data-action="tec"
 					>
@@ -25,4 +24,3 @@ a:3:{s:24:"tribe-form-content-start";a:0:{}s:41:"stellarwp-uplink_common-test-sl
 						</fieldset>
 						<input type="hidden" class="wp-nonce-fluent" name="stellarwp-uplink-license-key-nonce__common-test-slug" value="123456789" />					</div>
 				</div>
-";}}

--- a/tests/wpunit/Common/Libraries/Uplink/__snapshots__/Controller_Test__it_should_setup_license_fields__0.snapshot.html
+++ b/tests/wpunit/Common/Libraries/Uplink/__snapshots__/Controller_Test__it_should_setup_license_fields__0.snapshot.html
@@ -1,0 +1,28 @@
+a:3:{s:24:"tribe-form-content-start";a:0:{}s:41:"stellarwp-uplink_common-test-slug-heading";a:2:{s:4:"type";s:7:"heading";s:5:"label";s:11:"common-test";}s:33:"stellarwp-uplink_common-test-slug";a:3:{s:4:"type";s:4:"html";s:5:"label";s:0:"";s:4:"html";s:1502:"
+				<div class="stellarwp-uplink__license-field">
+					<div
+						class="stellarwp-uplink-license-key-field"
+						id="/var/www/html/wp-content/plugins/tribe-common/tests/wpunit/Common/Libraries/Uplink"
+						data-slug="/var/www/html/wp-content/plugins/tribe-common/tests/wpunit/Common/Libraries/Uplink"
+						data-plugin="/var/www/html/wp-content/plugins/tribe-common/tests/wpunit/Common/Libraries/Uplink"
+						data-plugin-slug="common-test-slug"
+						data-action="tec"
+					>
+						<fieldset class="stellarwp-uplink__settings-group">
+							<input type='hidden' name='option_page' value='stellarwp_uplink_group_common-test-slug' /><input type="hidden" name="action" value="update" /><input type="hidden" id="_wpnonce" name="_wpnonce" value="123456789" /><input type="hidden" name="_wp_http_referer" value="" />							<input
+								type="text"
+								name="pue_install_key_common_test_slug"
+								value=""
+								placeholder="License key"
+								class="regular-text stellarwp-uplink__settings-field"
+							/>
+							<p class="tooltip description">
+	A valid license key is required for support and updates</p>
+<div class="license-test-results">
+	<img src="http://wordpress.test/wp-admin/images/wpspin_light.gif" class="ajax-loading-license" alt="Loading" style="display: none"/>
+	<div class="key-validity"></div>
+</div>
+						</fieldset>
+						<input type="hidden" class="wp-nonce-fluent" name="stellarwp-uplink-license-key-nonce__common-test-slug" value="123456789" />					</div>
+				</div>
+";}}

--- a/tests/wpunit/Common/Libraries/Uplink/__snapshots__/Controller_Test__it_should_setup_license_fields__0.snapshot.html
+++ b/tests/wpunit/Common/Libraries/Uplink/__snapshots__/Controller_Test__it_should_setup_license_fields__0.snapshot.html
@@ -1,4 +1,4 @@
-a:3:{s:24:"tribe-form-content-start";a:0:{}s:41:"stellarwp-uplink_common-test-slug-heading";a:2:{s:4:"type";s:7:"heading";s:5:"label";s:11:"common-test";}s:33:"stellarwp-uplink_common-test-slug";a:3:{s:4:"type";s:4:"html";s:5:"label";s:0:"";s:4:"html";s:1502:"
+a:3:{s:24:"tribe-form-content-start";a:0:{}s:41:"stellarwp-uplink_common-test-slug-heading";a:2:{s:4:"type";s:7:"heading";s:5:"label";s:11:"common-test";}s:33:"stellarwp-uplink_common-test-slug";a:3:{s:4:"type";s:4:"html";s:5:"label";s:0:"";s:4:"html";s:1529:"
 				<div class="stellarwp-uplink__license-field">
 					<div
 						class="stellarwp-uplink-license-key-field"
@@ -12,7 +12,7 @@ a:3:{s:24:"tribe-form-content-start";a:0:{}s:41:"stellarwp-uplink_common-test-sl
 							<input type='hidden' name='option_page' value='stellarwp_uplink_group_common-test-slug' /><input type="hidden" name="action" value="update" /><input type="hidden" id="_wpnonce" name="_wpnonce" value="123456789" /><input type="hidden" name="_wp_http_referer" value="" />							<input
 								type="text"
 								name="pue_install_key_common_test_slug"
-								value=""
+								value="license_keycommon-test-slug"
 								placeholder="License key"
 								class="regular-text stellarwp-uplink__settings-field"
 							/>


### PR DESCRIPTION
Tests for the Uplink Controller.

Tests are failing due to the live Uplink library not being updated with our new logic.

To test locally with dev Uplink branch `composer require stellarwp/uplink:dev-feat/fluent-form-builder --prefer-source`