### PR TITLE
Detect plugins before trying to hook plugin functions.

### DIFF
--- a/src/Common/Event_Automator/Zapier/Zapier_Provider.php
+++ b/src/Common/Event_Automator/Zapier/Zapier_Provider.php
@@ -140,7 +140,8 @@ class Zapier_Provider extends Service_Provider {
 		// Add endpoints to settings dashboard.
 		add_action( 'admin_init', [ $this, 'add_endpoints_to_dashboard' ] );
 
-		$this->setup_add_to_queues();
+		// Wait until plugins are loaded and then add queues for our various plugins.
+		add_action( 'tribe_plugins_loaded', [ $this, 'setup_add_to_queues' ] );
 	}
 
 	/**
@@ -149,12 +150,37 @@ class Zapier_Provider extends Service_Provider {
 	 * @since 6.0.0 Migrated to Common from Event Automator
 	 */
 	protected function setup_add_to_queues() {
+		$this->add_tec_setup();
+		$this->add_et_setup();
+	}
+
+	/**
+	 * Adds the actions required for The Events Calendar.
+	 *
+	 * @since TBD
+	 */
+	protected function add_tec_setup(): void {
+		if ( ! defined( 'TRIBE_EVENTS_FILE' ) ) {
+			return;
+		}
+
 		// Canceled Events.
 		add_action( 'tribe_events_event_status_update_post_meta', [ $this, 'add_canceled_to_queue' ], 10, 2 );
 		// New Events.
 		add_action( 'wp_insert_post', [ $this, 'add_to_queue' ], 10, 3 );
 		// Updated Events.
 		add_action( 'post_updated', [ $this, 'add_updated_to_queue' ], 10, 3 );
+	}
+
+	/**
+	 * Adds the actions required for Event Tickets.
+	 *
+	 * @since TBD
+	 */
+	protected function add_et_setup(): void {
+		if ( ! defined( 'EVENT_TICKETS_DIR' ) ) {
+			return;
+		}
 
 		// Attendees.
 		add_action( 'event_tickets_rsvp_attendee_created', [ $this, 'add_rsvp_attendee_to_queue' ], 10, 4 );

--- a/src/Common/Event_Automator/Zapier/Zapier_Provider.php
+++ b/src/Common/Event_Automator/Zapier/Zapier_Provider.php
@@ -160,7 +160,7 @@ class Zapier_Provider extends Service_Provider {
 	 * @since TBD
 	 */
 	protected function add_tec_setup(): void {
-		if ( ! defined( 'TRIBE_EVENTS_FILE' ) ) {
+		if ( ! defined( 'tribe_events_first_boot' ) ) {
 			return;
 		}
 
@@ -178,7 +178,7 @@ class Zapier_Provider extends Service_Provider {
 	 * @since TBD
 	 */
 	protected function add_et_setup(): void {
-		if ( ! defined( 'EVENT_TICKETS_DIR' ) ) {
+		if ( ! did_action( 'tribe_tickets_plugin_loaded' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
We hook to third-party plugins (Woocommerce) and run functions from our plugin (ET) that _might not be present_

[EVA-166]

[EVA-166]: https://stellarwp.atlassian.net/browse/EVA-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ