### PR TITLE
Uplink - Fix incorrect `uopz_redefine` arguments used within `set_const_value`

### DIFF
--- a/tests/_support/Traits/With_Uopz.php
+++ b/tests/_support/Traits/With_Uopz.php
@@ -138,7 +138,7 @@ trait With_Uopz {
 				Assert::assertEquals( $previous_value, constant( $class . '::' . $const ) );
 			};
 		}
-		uopz_redefine( $const, ...$args );
+		uopz_redefine( $class, ...$args );
 		self::$uopz_redefines[] = $restore_callback;
 	}
 


### PR DESCRIPTION
While implementing `set_const_value` I found that the `uopz_redefine` was using `$const` instead of `$class` which was generating an error.