### PR TITLE
Bug when term slugs were numeric

### DIFF
--- a/changelog/fix-Normalize-terms-when-numeric
+++ b/changelog/fix-Normalize-terms-when-numeric
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Bug when term slugs were numeric.

--- a/src/Tribe/Utils/Taxonomy.php
+++ b/src/Tribe/Utils/Taxonomy.php
@@ -108,11 +108,17 @@ class Taxonomy {
 
 		$terms = array_map( static function ( $param ) use ( $taxonomy ) {
 			$param   = preg_replace( '/^#/', '', $param );
-			$term_by = is_int( $param ) ? 'ID' : 'slug';
+			$term_by = is_numeric( $param ) ? 'ID' : 'slug';
 			$term    = get_term_by( $term_by, $param, $taxonomy );
 
 			if ( ! $term instanceof \WP_Term ) {
-				return false;
+
+				// Check if the term is a numeric string.
+				$term = get_term_by( 'slug', $param, $taxonomy );
+
+				if ( ! $term instanceof \WP_Term ) {
+					return false;
+				}
 			}
 
 			return $term->term_id;

--- a/src/Tribe/Utils/Taxonomy.php
+++ b/src/Tribe/Utils/Taxonomy.php
@@ -108,7 +108,7 @@ class Taxonomy {
 
 		$terms = array_map( static function ( $param ) use ( $taxonomy ) {
 			$param   = preg_replace( '/^#/', '', $param );
-			$term_by = is_numeric( $param ) ? 'ID' : 'slug';
+			$term_by = is_int( $param ) ? 'ID' : 'slug';
 			$term    = get_term_by( $term_by, $param, $taxonomy );
 
 			if ( ! $term instanceof \WP_Term ) {

--- a/tests/wpunit/Tribe/Utils/TaxonomyTest.php
+++ b/tests/wpunit/Tribe/Utils/TaxonomyTest.php
@@ -90,6 +90,7 @@ class TaxonomyTest extends WPTestCase {
 	 * @group        utils
 	 */
 	public function it_should_normalize_to_term_ids() {
+		$term_0 = wp_insert_term( '2024', 'post_tag', [ 'slug' => '2024' ] );
 		$term_1 = wp_insert_term( 'Event Tag 4', 'post_tag', [ 'slug' => 'event-tag-4' ] );
 		$term_2 = wp_insert_term( 'Event Tag 5', 'post_tag', [ 'slug' => 'event-tag-5' ] );
 		$term_3 = wp_insert_term( 'Event Tag 6', 'post_tag', [ 'slug' => 'event-tag-6' ] );
@@ -109,12 +110,13 @@ class TaxonomyTest extends WPTestCase {
 		);
 
 		$tax_query = Taxonomy::normalize_to_term_ids( [
+			'2024',
 			$term_1['term_id'],
 			'event-tag-5',
 			'event-tag-6'
 		], 'post_tag' );
 		$this->assertEquals(
-			[ $term_1['term_id'], $term_2['term_id'], $term_3['term_id'], ],
+			[ $term_0['term_id'], $term_1['term_id'], $term_2['term_id'], $term_3['term_id'], ],
 			$tax_query
 		);
 

--- a/tests/wpunit/Tribe/Utils/TaxonomyTest.php
+++ b/tests/wpunit/Tribe/Utils/TaxonomyTest.php
@@ -105,7 +105,7 @@ class TaxonomyTest extends WPTestCase {
 			'event-category-6'
 		], 'category' );
 		$this->assertEquals(
-			[ $term_4['term_id'], $term_5['term_id'], $term_6['term_id'], ],
+			[ $term_4['term_id'], $term_5['term_id'], $term_6['term_id'] ],
 			$tax_query
 		);
 
@@ -116,7 +116,7 @@ class TaxonomyTest extends WPTestCase {
 			'event-tag-6'
 		], 'post_tag' );
 		$this->assertEquals(
-			[ $term_0['term_id'], $term_1['term_id'], $term_2['term_id'], $term_3['term_id'], ],
+			[ $term_0['term_id'], $term_1['term_id'], $term_2['term_id'], $term_3['term_id'] ],
 			$tax_query
 		);
 


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5103]

### 🗒️ Description

When normalizing terms we are checking the passed argument to see if it is about the ID or the slug. 
The previous `is_numeric` conditional disregarded slugs that were numeric, eg. `"2024"`.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s).
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[TEC-5103]: https://stellarwp.atlassian.net/browse/TEC-5103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ