### PR TITLE
Fix admin notices for new Settings design

### DIFF
--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -512,13 +512,13 @@ class Tribe__Settings {
 	 */
 	public function do_page_header( $admin_page ): void {
 		?>
+		<div class="tribe-notice-wrap">
+			<div class="wp-header-end"></div>
+		</div>
 		<h1>
 			<?php echo wp_kses_post( $this->get_page_logo( $admin_page ) ); ?>
 			<?php echo esc_html( $this->get_page_title( $admin_page ) ); ?>
 		</h1>
-		<div class="tribe-notice-wrap">
-			<div class="wp-header-end"></div>
-		</div>
 		<?php
 	}
 

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -516,6 +516,9 @@ class Tribe__Settings {
 			<?php echo wp_kses_post( $this->get_page_logo( $admin_page ) ); ?>
 			<?php echo esc_html( $this->get_page_title( $admin_page ) ); ?>
 		</h1>
+		<div class="tribe-notice-wrap">
+			<div class="wp-header-end"></div>
+		</div>
 		<?php
 	}
 

--- a/src/resources/postcss/tribe-common-admin/settings/_page.pcss
+++ b/src/resources/postcss/tribe-common-admin/settings/_page.pcss
@@ -39,6 +39,17 @@
 			justify-content: flex-start;
 			padding-bottom: var(--tec-spacer-7);
 		}
+
+		.tribe-notice-wrap {
+			background-color: var(--tec-color-background);
+			box-sizing: border-box;
+			padding: 0 var(--tec-spacer-7);
+			width: 100%;
+
+			@media (min-width: 500px) and (max-width: 1259px) {
+				padding: 0 var(--tec-spacer-5);
+			}
+		}
 	}
 
 	.tribe_settings.wrap h1 {

--- a/src/resources/postcss/tribe-common-admin/settings/_page.pcss
+++ b/src/resources/postcss/tribe-common-admin/settings/_page.pcss
@@ -42,12 +42,15 @@
 
 		.tribe-notice-wrap {
 			background-color: var(--tec-color-background);
-			box-sizing: border-box;
-			padding: 0 var(--tec-spacer-7);
 			width: 100%;
 
-			@media (min-width: 500px) and (max-width: 1259px) {
-				padding: 0 var(--tec-spacer-5);
+			> div {
+				box-sizing: border-box;
+				margin: var(--tec-spacer-1) var(--tec-spacer-7);
+
+				@media (min-width: 500px) and (max-width: 1259px) {
+					margin: var(--tec-spacer-1) var(--tec-spacer-5);
+				}
 			}
 		}
 	}

--- a/src/resources/postcss/tribe-common-admin/settings/_page.pcss
+++ b/src/resources/postcss/tribe-common-admin/settings/_page.pcss
@@ -45,6 +45,7 @@
 			width: 100%;
 
 			> div {
+				border-radius: var(--tec-border-radius-default);
 				box-sizing: border-box;
 				margin: var(--tec-spacer-1) var(--tec-spacer-7);
 


### PR DESCRIPTION
### 🎫 Ticket

From the spreadsheet

### 🗒️ Description

This updates how Admin notices are displayed in the new settings page.

This change takes advantage of how WordPress handles Admin notices. Once an admin page loads, WordPress uses a piece of JavaScript to relocate the notices within the DOM. Here are the pieces of JavasScript that do this:

https://github.com/WordPress/wordpress-develop/blob/b20e852a56c0970684a44166fcffa3d041f05eb8/src/js/_enqueues/admin/common.js#L855

https://github.com/WordPress/wordpress-develop/blob/b20e852a56c0970684a44166fcffa3d041f05eb8/src/js/_enqueues/admin/common.js#L1075-L1084

The `$headerEnd` variable correlates to an element with the class `.wp-header-end`. By adding an element with this class, we can determine the exact location that WordPress will move the notices within the DOM. In this PR, I've put this element within a container element that allows for styling that aligns with the overall style of the page.


### 🎥 Artifacts <!-- if applicable-->

<img width="1755" alt="Screenshot 2024-08-29 at 16 05 16" src="https://github.com/user-attachments/assets/0134e486-d6b2-4a52-b2a0-f2d151a85b7d">

<img width="430" alt="Screenshot 2024-08-29 at 16 05 54" src="https://github.com/user-attachments/assets/0f7c98a7-a9bb-4172-8a1f-a73aab0b660d">

<img width="512" alt="Screenshot 2024-08-29 at 16 06 17" src="https://github.com/user-attachments/assets/918ff821-121d-4b88-9875-8f47ca1e84d2">

<img width="794" alt="Screenshot 2024-08-29 at 16 06 54" src="https://github.com/user-attachments/assets/58bd054f-737e-46f4-9799-2c9fa3065309">

<img width="925" alt="Screenshot 2024-08-29 at 16 07 22" src="https://github.com/user-attachments/assets/91f05133-1c68-46cd-b8f9-fe3a642c06e1">

<img width="1009" alt="Screenshot 2024-08-29 at 16 07 51" src="https://github.com/user-attachments/assets/0b2b10b4-e736-43be-8a72-6cb8f12aed49">


### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
