### PR TITLE
Don't use tag_escape yet, add a test to catch the issue

### DIFF
--- a/src/Tribe/Utils/Element_Attributes.php
+++ b/src/Tribe/Utils/Element_Attributes.php
@@ -106,6 +106,7 @@ class Element_Attributes {
 		$this->parse_array( $this->arguments );
 
 		foreach ( $this->results as $key => $val ) {
+
 			if ( ! $val && '0' !== $val ) {
 				continue;
 			}
@@ -116,7 +117,13 @@ class Element_Attributes {
 				// Remove double quotes that might be surrounding the value.
 				$val          = trim( $val, '"' );
 				// @todo replace the first usage of esc_attr with tag_esc when our minimum WP version is 6.5.5 or greater.
-				$attributes[] = esc_attr( $key ) . '="' . esc_attr( $val ) . '"';
+				global $wp_version;
+				if ( version_compare( $wp_version, '6.5.5', '<' ) ) {
+					$attributes[] = esc_attr( $key ) . '="' . esc_attr( $val ) . '"';
+				} else {
+					$attributes[] = tag_escape( $key ) . '="' . esc_attr( $val ) . '"';
+
+				}
 			}
 		}
 

--- a/src/Tribe/Utils/Element_Attributes.php
+++ b/src/Tribe/Utils/Element_Attributes.php
@@ -115,7 +115,8 @@ class Element_Attributes {
 			} else {
 				// Remove double quotes that might be surrounding the value.
 				$val          = trim( $val, '"' );
-				$attributes[] = tag_escape( $key ) . '="' . esc_attr( $val ) . '"';
+				// @todo replace the first usage of esc_attr with tag_esc when our minimum WP version is 6.5.5 or greater.
+				$attributes[] = esc_attr( $key ) . '="' . esc_attr( $val ) . '"';
 			}
 		}
 

--- a/tests/wpunit/Tribe/Utils/Element_AttributesTest.php
+++ b/tests/wpunit/Tribe/Utils/Element_AttributesTest.php
@@ -44,12 +44,13 @@ class Element_AttributesTest extends \Codeception\TestCase\WPTestCase {
 			'disabled' => false,
 			'checked'  => true,
 			'foo'      => 'bar',
-			'baz'      => 'woot'
+			'baz'      => 'woot',
+			'data-foo' => 'baz',
 		] );
 
-		$this->assertEquals( [ 'checked', 'foo="bar"', 'baz="woot"' ], $attributes->get_attributes_array() );
-		$this->assertEquals( 'checked foo="bar" baz="woot"', $attributes->get_attributes_as_string() );
-		$this->assertEquals( ' checked foo="bar" baz="woot" ', $attributes->get_attributes() );
+		$this->assertEquals( [ 'checked', 'foo="bar"', 'baz="woot"', 'data-foo="baz"' ], $attributes->get_attributes_array() );
+		$this->assertEquals( 'checked foo="bar" baz="woot" data-foo="baz"', $attributes->get_attributes_as_string() );
+		$this->assertEquals( ' checked foo="bar" baz="woot" data-foo="baz" ', $attributes->get_attributes() );
 	}
 
 	/**
@@ -58,7 +59,7 @@ class Element_AttributesTest extends \Codeception\TestCase\WPTestCase {
 	public function test_with_string_arguments() {
 		$attributes = new Element_Attributes( 'checked foo="bar" baz="woot" data-foo="baz"' );
 
-		$this->assertEquals( [ 'checked', 'foo="bar"', 'baz="woot", data-foo="baz"' ], $attributes->get_attributes_array() );
+		$this->assertEquals( [ 'checked', 'foo="bar"', 'baz="woot"', 'data-foo="baz"' ], $attributes->get_attributes_array() );
 		$this->assertEquals( 'checked foo="bar" baz="woot data-foo="baz""', $attributes->get_attributes_as_string() );
 		$this->assertEquals( ' checked foo="bar" baz="woot data-foo="baz"" ', $attributes->get_attributes() );
 	}
@@ -115,9 +116,9 @@ class Element_AttributesTest extends \Codeception\TestCase\WPTestCase {
 	 * Test __toString
 	 */
 	public function test__to_string() {
-		$attributes = new Element_Attributes( 'checked foo="bar"' );
+		$attributes = new Element_Attributes( 'checked foo="bar" data-foo="baz"' );
 
-		$this->assertEquals( ' checked foo="bar" ', '' . $attributes );
+		$this->assertEquals( ' checked foo="bar" data-foo="baz" ', '' . $attributes );
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Utils/Element_AttributesTest.php
+++ b/tests/wpunit/Tribe/Utils/Element_AttributesTest.php
@@ -56,7 +56,7 @@ class Element_AttributesTest extends \Codeception\TestCase\WPTestCase {
 	 * Test with string arguments
 	 */
 	public function test_with_string_arguments() {
-		$attributes = new Element_Attributes( 'checked foo="bar" baz="woot"' );
+		$attributes = new Element_Attributes( 'checked foo="bar" baz="woot" data-foo="baz"' );
 
 		$this->assertEquals( [ 'checked', 'foo="bar"', 'baz="woot"' ], $attributes->get_attributes_array() );
 		$this->assertEquals( 'checked foo="bar" baz="woot"', $attributes->get_attributes_as_string() );

--- a/tests/wpunit/Tribe/Utils/Element_AttributesTest.php
+++ b/tests/wpunit/Tribe/Utils/Element_AttributesTest.php
@@ -58,9 +58,9 @@ class Element_AttributesTest extends \Codeception\TestCase\WPTestCase {
 	public function test_with_string_arguments() {
 		$attributes = new Element_Attributes( 'checked foo="bar" baz="woot" data-foo="baz"' );
 
-		$this->assertEquals( [ 'checked', 'foo="bar"', 'baz="woot"' ], $attributes->get_attributes_array() );
-		$this->assertEquals( 'checked foo="bar" baz="woot"', $attributes->get_attributes_as_string() );
-		$this->assertEquals( ' checked foo="bar" baz="woot" ', $attributes->get_attributes() );
+		$this->assertEquals( [ 'checked', 'foo="bar"', 'baz="woot", data-foo="baz"' ], $attributes->get_attributes_array() );
+		$this->assertEquals( 'checked foo="bar" baz="woot data-foo="baz""', $attributes->get_attributes_as_string() );
+		$this->assertEquals( ' checked foo="bar" baz="woot data-foo="baz"" ', $attributes->get_attributes() );
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Utils/Element_AttributesTest.php
+++ b/tests/wpunit/Tribe/Utils/Element_AttributesTest.php
@@ -60,8 +60,8 @@ class Element_AttributesTest extends \Codeception\TestCase\WPTestCase {
 		$attributes = new Element_Attributes( 'checked foo="bar" baz="woot" data-foo="baz"' );
 
 		$this->assertEquals( [ 'checked', 'foo="bar"', 'baz="woot"', 'data-foo="baz"' ], $attributes->get_attributes_array() );
-		$this->assertEquals( 'checked foo="bar" baz="woot data-foo="baz""', $attributes->get_attributes_as_string() );
-		$this->assertEquals( ' checked foo="bar" baz="woot data-foo="baz"" ', $attributes->get_attributes() );
+		$this->assertEquals( 'checked foo="bar" baz="woot" data-foo="baz"', $attributes->get_attributes_as_string() );
+		$this->assertEquals( ' checked foo="bar" baz="woot" data-foo="baz" ', $attributes->get_attributes() );
 	}
 
 	/**


### PR DESCRIPTION
### 🗒️ Description

While tag_escape is now the correct function to use here, it will escape the hypens in data attributes on WP versions < 6.5.5.

Continue to use 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
