### PR TITLE
Show close modal button on twentytwenty with !important

### DIFF
--- a/src/resources/postcss/dialog.pcss
+++ b/src/resources/postcss/dialog.pcss
@@ -84,7 +84,8 @@ This can include modals, toasters, confirms. alerts.
 	/* The "close" button */
 	.tribe-dialog__close-button {
 		background: var(--tec-dialog-close-background);
-		background-image: svg-inline(close-secondary);
+		/* We overwrite this for twentytwenty while we still need it. */
+		background-image: svg-inline(close-secondary) !important;
 		background-repeat: no-repeat;
 		background-size: contain;
 		cursor: pointer;


### PR DESCRIPTION
### 🎫 Ticket

Part of gsheet issue 119.

The close modal button would render invisible cause of `background` property overwrittes.

Fixing the root issue, creates other issues with the rest of the buttons. So adding `!important` seemed like a good fit for the specific case.