### PR TITLE
Ensure we allow script tags in html/wrapped html fields

### DIFF
--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -443,6 +443,11 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 					$tags['option']   = $common_attributes;
 					$tags['fieldset'] = _wp_add_global_attributes( [] );
 
+					// Allow the script tag for HTML fields (inserting script localization).
+					if ( $this->type === 'html' || $this->type === 'wrapped_html' ) {
+						$tags['script'] = true;
+					}
+
 					return $tags;
 				};
 
@@ -1180,7 +1185,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 		 * @return bool
 		 */
 		public function has_field_value() {
-			// Cetain "field" types have no value.
+			// Certain "field" types have no value.
 			if ( in_array( $this->type, [ 'heading', 'html', 'wrapped_html' ], true ) ) {
 				return false;
 			}

--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -445,8 +445,8 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 
 					// Allow the script tag for HTML fields (inserting script localization).
 					if ( $this->type === 'html' || $this->type === 'wrapped_html' ) {
-						$tags['script']   = $common_attributes;
-						$tags['template'] = true;
+						$tags['script']   = _wp_add_global_attributes( [ 'type' => true ] );
+						$tags['template'] = _wp_add_global_attributes( [ 'type' => true ] );
 					}
 
 					return $tags;

--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -445,7 +445,8 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 
 					// Allow the script tag for HTML fields (inserting script localization).
 					if ( $this->type === 'html' || $this->type === 'wrapped_html' ) {
-						$tags['script'] = true;
+						$tags['script']   = $common_attributes;
+						$tags['template'] = true;
 					}
 
 					return $tags;

--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -443,7 +443,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 					$tags['option']   = $common_attributes;
 					$tags['fieldset'] = _wp_add_global_attributes( [] );
 
-					// Allow the script tag for HTML fields (inserting script localization).
+					// Allow the script and template tags for HTML fields (inserting script localization, js templates).
 					if ( $this->type === 'html' || $this->type === 'wrapped_html' ) {
 						$tags['script']   = _wp_add_global_attributes( [ 'type' => true ] );
 						$tags['template'] = _wp_add_global_attributes( [ 'type' => true ] );

--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -124,7 +124,7 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 		public $options;
 
 		/**
-		 * @var string
+		 * @var mixed
 		 */
 		public $value;
 


### PR DESCRIPTION
for script localization and modals

### 🎫 Ticket

[NO TICKET]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Added script to the wp_kses allowed tags for `html` and `wrapped-html` fields.

### 🎥 Artifacts <!-- if applicable-->
Broken: (modal shows up, script tags missing)
<img width="1792" alt="Screenshot 2024-09-18 at 12 07 18 PM" src="https://github.com/user-attachments/assets/560eca7e-ed29-4595-a362-dbcf8c775559">
Fixed:
<img width="1792" alt="Screenshot 2024-09-18 at 12 07 29 PM" src="https://github.com/user-attachments/assets/01f78cb9-c45a-4c4e-95e9-d44993195896">
Open modal
<img width="1792" alt="Screenshot 2024-09-18 at 4 11 46 PM" src="https://github.com/user-attachments/assets/cc380d62-bb4b-4b63-a423-0159ebb96c99">



### ✔️ Checklist
- [ n/a ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
