### PR TITLE
Fix Imports tab saving

### DIFF
--- a/src/Common/Admin/Entities/Base_Entity.php
+++ b/src/Common/Admin/Entities/Base_Entity.php
@@ -40,6 +40,8 @@ abstract class Base_Entity implements ArrayAccess, Element {
 	/**
 	 * Convert the entity output to a string.
 	 *
+	 * @since TBD
+	 *
 	 * @return string
 	 */
 	public function __toString() {
@@ -56,6 +58,7 @@ abstract class Base_Entity implements ArrayAccess, Element {
 	 * escaped, so it is not necessary to further escape these attributes.
 	 *
 	 * @see Element_Attributes::get_attributes_as_string()
+	 * @since TBD
 	 *
 	 * @return string
 	 */
@@ -68,6 +71,8 @@ abstract class Base_Entity implements ArrayAccess, Element {
 	/**
 	 * Get the classes for the entity.
 	 *
+	 * @since TBD
+	 *
 	 * @return string
 	 */
 	protected function get_classes(): string {
@@ -78,6 +83,8 @@ abstract class Base_Entity implements ArrayAccess, Element {
 
 	/**
 	 * Get the classes as an attribute.
+	 *
+	 * @since TBD
 	 *
 	 * @return string
 	 */
@@ -90,6 +97,8 @@ abstract class Base_Entity implements ArrayAccess, Element {
 	/**
 	 * Set the attributes for the entity.
 	 *
+	 * @since TBD
+	 *
 	 * @param Attributes $attributes
 	 *
 	 * @return void
@@ -100,6 +109,8 @@ abstract class Base_Entity implements ArrayAccess, Element {
 
 	/**
 	 * Set the classes for the entity.
+	 *
+	 * @since TBD
 	 *
 	 * @param Classes $classes The classes for the entity.
 	 *

--- a/src/Common/Admin/Entities/Br.php
+++ b/src/Common/Admin/Entities/Br.php
@@ -19,6 +19,8 @@ class Br extends Base_Entity {
 	/**
 	 * Render the element.
 	 *
+	 * @since TBD
+	 *
 	 * @return void
 	 */
 	public function render() {

--- a/src/Common/Admin/Entities/Container.php
+++ b/src/Common/Admin/Entities/Container.php
@@ -20,7 +20,7 @@ use InvalidArgumentException;
  *
  * @since TBD
  */
-class Container extends Base_Entity {
+class Container extends Base_Entity implements Element_With_Children {
 
 	use Validate_Elements;
 
@@ -67,6 +67,15 @@ class Container extends Base_Entity {
 		}
 
 		return $this;
+	}
+
+	/**
+	 * Get the children of the container.
+	 *
+	 * @return Element[]
+	 */
+	public function get_children(): array {
+		return $this->children;
 	}
 
 	/**

--- a/src/Common/Admin/Entities/Container.php
+++ b/src/Common/Admin/Entities/Container.php
@@ -41,6 +41,8 @@ class Container extends Base_Entity implements Element_With_Children {
 	/**
 	 * Add a child to the container.
 	 *
+	 * @since TBD
+	 *
 	 * @param Element $child The child to add.
 	 *
 	 * @return static
@@ -57,6 +59,8 @@ class Container extends Base_Entity implements Element_With_Children {
 	/**
 	 * Add multiple children to the container.
 	 *
+	 * @since TBD
+	 *
 	 * @param Element[] $children The children to add.
 	 *
 	 * @return static
@@ -72,6 +76,8 @@ class Container extends Base_Entity implements Element_With_Children {
 	/**
 	 * Get the children of the container.
 	 *
+	 * @since TBD
+	 *
 	 * @return Element[]
 	 */
 	public function get_children(): array {
@@ -80,6 +86,8 @@ class Container extends Base_Entity implements Element_With_Children {
 
 	/**
 	 * Render the children of the container.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */
@@ -91,6 +99,8 @@ class Container extends Base_Entity implements Element_With_Children {
 
 	/**
 	 * Render the element.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Entities/Div.php
+++ b/src/Common/Admin/Entities/Div.php
@@ -22,6 +22,8 @@ class Div extends Container {
 	/**
 	 * Div constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param ?Classes    $classes    The classes for the div.
 	 * @param ?Attributes $attributes The attributes for the div.
 	 */
@@ -37,6 +39,8 @@ class Div extends Container {
 
 	/**
 	 * Render the element.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Entities/Element.php
+++ b/src/Common/Admin/Entities/Element.php
@@ -19,6 +19,8 @@ interface Element {
 	/**
 	 * Render the element.
 	 *
+	 * @since TBD
+	 *
 	 * @return void
 	 */
 	public function render();

--- a/src/Common/Admin/Entities/Element_With_Children.php
+++ b/src/Common/Admin/Entities/Element_With_Children.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Container element.
+ *
+ * @since TBD
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\Admin\Entities;
+
+/**
+ * Interface Entity_With_Children
+ *
+ * @since TBD
+ */
+interface Element_With_Children extends Element {
+
+	/**
+	 * Get the children of the container.
+	 *
+	 * @return Element[]
+	 */
+	public function get_children(): array;
+}

--- a/src/Common/Admin/Entities/Element_With_Children.php
+++ b/src/Common/Admin/Entities/Element_With_Children.php
@@ -19,6 +19,8 @@ interface Element_With_Children extends Element {
 	/**
 	 * Get the children of the container.
 	 *
+	 * @since TBD
+	 *
 	 * @return Element[]
 	 */
 	public function get_children(): array;

--- a/src/Common/Admin/Entities/Field_Wrapper.php
+++ b/src/Common/Admin/Entities/Field_Wrapper.php
@@ -44,4 +44,13 @@ class Field_Wrapper implements Element {
 	public function render(): void {
 		$this->field->do_field();
 	}
+
+	/**
+	 * Get the field.
+	 *
+	 * @return Field
+	 */
+	public function get_field(): Field {
+		return $this->field;
+	}
 }

--- a/src/Common/Admin/Entities/Field_Wrapper.php
+++ b/src/Common/Admin/Entities/Field_Wrapper.php
@@ -30,6 +30,8 @@ class Field_Wrapper implements Element {
 	/**
 	 * FieldW_Wrapper constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param Field $field The field to wrap.
 	 */
 	public function __construct( Field $field ) {
@@ -47,6 +49,8 @@ class Field_Wrapper implements Element {
 
 	/**
 	 * Get the field.
+	 *
+	 * @since TBD
 	 *
 	 * @return Field
 	 */

--- a/src/Common/Admin/Entities/H2.php
+++ b/src/Common/Admin/Entities/H2.php
@@ -22,6 +22,8 @@ class H2 extends Heading {
 	/**
 	 * H2 constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param string      $content    The content for the heading.
 	 * @param ?Classes    $classes    The classes for the heading.
 	 * @param ?Attributes $attributes The attributes for the heading.

--- a/src/Common/Admin/Entities/H3.php
+++ b/src/Common/Admin/Entities/H3.php
@@ -22,6 +22,8 @@ class H3 extends Heading {
 	/**
 	 * H3 constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param string      $content    The content for the heading.
 	 * @param ?Classes    $classes    The classes for the heading.
 	 * @param ?Attributes $attributes The attributes for the heading.

--- a/src/Common/Admin/Entities/Heading.php
+++ b/src/Common/Admin/Entities/Heading.php
@@ -45,6 +45,8 @@ class Heading extends Base_Entity {
 	/**
 	 * Heading constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param string      $content    The content for the heading.
 	 * @param int         $level      The level for the heading.
 	 * @param ?Classes    $classes    The classes for the heading.
@@ -68,6 +70,8 @@ class Heading extends Base_Entity {
 	/**
 	 * Render the element.
 	 *
+	 * @since TBD
+	 *
 	 * @return void
 	 */
 	public function render() {
@@ -83,6 +87,8 @@ class Heading extends Base_Entity {
 
 	/**
 	 * Validate the heading level.
+	 *
+	 * @since TBD
 	 *
 	 * @param int $level The heading level.
 	 *

--- a/src/Common/Admin/Entities/Image.php
+++ b/src/Common/Admin/Entities/Image.php
@@ -28,6 +28,8 @@ class Image extends Base_Entity {
 	/**
 	 * Image constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param string      $url        The URL for the image.
 	 * @param ?Attributes $attributes The attributes for the image element.
 	 */
@@ -41,6 +43,8 @@ class Image extends Base_Entity {
 
 	/**
 	 * Render the image.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Entities/Link.php
+++ b/src/Common/Admin/Entities/Link.php
@@ -36,6 +36,8 @@ class Link extends Base_Entity {
 	/**
 	 * Link constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param string      $url        The URL for the link.
 	 * @param string      $text       The text for the link.
 	 * @param ?Classes    $classes    The classes for the link.
@@ -56,6 +58,8 @@ class Link extends Base_Entity {
 
 	/**
 	 * Render the link.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Entities/List_Item.php
+++ b/src/Common/Admin/Entities/List_Item.php
@@ -23,6 +23,8 @@ class List_Item extends Container {
 	/**
 	 * List_Item constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param ?Classes    $classes    The classes for the list item.
 	 * @param ?Attributes $attributes The attributes for the list item.
 	 */
@@ -39,6 +41,8 @@ class List_Item extends Container {
 	/**
 	 * Add a child to the container.
 	 *
+	 * @since TBD
+	 *
 	 * @param Element $child The child to add. Cannot be another List Item.
 	 *
 	 * @return static
@@ -54,6 +58,8 @@ class List_Item extends Container {
 
 	/**
 	 * Render the list item content.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Entities/Paragraph.php
+++ b/src/Common/Admin/Entities/Paragraph.php
@@ -22,6 +22,8 @@ class Paragraph extends Container {
 	/**
 	 * Paragraph constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param ?Classes    $classes    The classes for the paragraph.
 	 * @param ?Attributes $attributes The attributes for the paragraph.
 	 */
@@ -37,6 +39,8 @@ class Paragraph extends Container {
 
 	/**
 	 * Render the paragraph content.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Entities/Plain_Text.php
+++ b/src/Common/Admin/Entities/Plain_Text.php
@@ -26,6 +26,8 @@ class Plain_Text extends Base_Entity {
 	/**
 	 * Plain_Text constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param string $content The content for the text.
 	 */
 	public function __construct( string $content ) {
@@ -34,6 +36,8 @@ class Plain_Text extends Base_Entity {
 
 	/**
 	 * Render the text content.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Entities/Separator.php
+++ b/src/Common/Admin/Entities/Separator.php
@@ -22,6 +22,8 @@ class Separator extends Base_Entity {
 	/**
 	 * Separator constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param ?Classes    $classes    The classes for the separator.
 	 * @param ?Attributes $attributes The attributes for the separator.
 	 */
@@ -37,6 +39,8 @@ class Separator extends Base_Entity {
 
 	/**
 	 * Render the element.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Entities/Unordered_List.php
+++ b/src/Common/Admin/Entities/Unordered_List.php
@@ -34,6 +34,8 @@ class Unordered_List extends Container {
 	/**
 	 * Unordered_List constructor.
 	 *
+	 * @since TBD
+	 *
 	 * @param ?Classes    $classes    The classes for the unordered list.
 	 * @param ?Attributes $attributes The attributes for the unordered list.
 	 */
@@ -50,6 +52,8 @@ class Unordered_List extends Container {
 	/**
 	 * Add a child to the container.
 	 *
+	 * @since TBD
+	 *
 	 * @param List_Item $child The child to add.
 	 *
 	 * @return static
@@ -62,6 +66,8 @@ class Unordered_List extends Container {
 	/**
 	 * Add multiple children to the container.
 	 *
+	 * @since TBD
+	 *
 	 * @param List_Item[] $children The children to add.
 	 *
 	 * @return static
@@ -73,6 +79,8 @@ class Unordered_List extends Container {
 
 	/**
 	 * Render the unordered list content.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Entities/Validate_Elements.php
+++ b/src/Common/Admin/Entities/Validate_Elements.php
@@ -21,6 +21,8 @@ trait Validate_Elements {
 	/**
 	 * Validate that an object is an instance of a class.
 	 *
+	 * @since TBD
+	 *
 	 * @param object $thing     The object to validate.
 	 * @param string $classname The class name to validate against.
 	 *

--- a/src/Common/Admin/Section.php
+++ b/src/Common/Admin/Section.php
@@ -31,6 +31,8 @@ abstract class Section {
 	/**
 	 * Set the title for the sidebar.
 	 *
+	 * @since TBD
+	 *
 	 * @param Heading $heading The title for the sidebar.
 	 *
 	 * @return static
@@ -44,6 +46,8 @@ abstract class Section {
 	/**
 	 * Render the title for the sidebar.
 	 *
+	 * @since TBD
+	 *
 	 * @return void
 	 */
 	protected function render_title() {
@@ -56,6 +60,8 @@ abstract class Section {
 
 	/**
 	 * Render the section content.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Settings_Section.php
+++ b/src/Common/Admin/Settings_Section.php
@@ -28,6 +28,8 @@ class Settings_Section extends Section {
 	/**
 	 * Add an element to the section.
 	 *
+	 * @since TBD
+	 *
 	 * @param Element $element The element to add.
 	 *
 	 * @return static
@@ -40,6 +42,8 @@ class Settings_Section extends Section {
 
 	/**
 	 * Add multiple elements to the section.
+	 *
+	 * @since TBD
 	 *
 	 * @param Element[] $elements The elements to add.
 	 *
@@ -56,6 +60,8 @@ class Settings_Section extends Section {
 	/**
 	 * Render the section content.
 	 *
+	 * @since TBD
+	 *
 	 * @return void
 	 */
 	public function render() {
@@ -69,6 +75,8 @@ class Settings_Section extends Section {
 
 	/**
 	 * Render the elements for the section.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Common/Admin/Settings_Sidebar.php
+++ b/src/Common/Admin/Settings_Sidebar.php
@@ -35,6 +35,8 @@ class Settings_Sidebar extends Section {
 	/**
 	 * Render the sidebar.
 	 *
+	 * @since TBD
+	 *
 	 * @return void
 	 */
 	public function render() {
@@ -63,6 +65,8 @@ class Settings_Sidebar extends Section {
 	/**
 	 * Set the header image for the sidebar.
 	 *
+	 * @since TBD
+	 *
 	 * @param Image $image The image to set.
 	 *
 	 * @return void
@@ -74,6 +78,8 @@ class Settings_Sidebar extends Section {
 	/**
 	 * Add a section to the sidebar.
 	 *
+	 * @since TBD
+	 *
 	 * @param Section $section The section to add.
 	 *
 	 * @return void
@@ -84,6 +90,8 @@ class Settings_Sidebar extends Section {
 
 	/**
 	 * Render the header image for the sidebar.
+	 *
+	 * @since TBD
 	 *
 	 * @return void
 	 */

--- a/src/Tribe/Field.php
+++ b/src/Tribe/Field.php
@@ -228,7 +228,8 @@ if ( ! class_exists( 'Tribe__Field' ) ) {
 			];
 
 			// Merge the defaults with the passed args.
-			$args = wp_parse_args( $field, $this->defaults );
+			$args       = wp_parse_args( $field, $this->defaults );
+			$this->args = $args;
 
 			// Set the valid field types.
 			$this->setup_field_types();

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -1095,7 +1095,7 @@ class Tribe__Settings {
 		$current_settings_tab = tribe_get_request_var( 'current-settings-tab', $this->get_current_tab() );
 
 		// Return if we don't have POST and variables.
-		if ( ! $tribe_save_settings || ! $current_settings_tab ) {
+		if ( ! ( $tribe_save_settings && $current_settings_tab ) ) {
 			return;
 		}
 

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -10,6 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( '-1' );
 }
 
+use TEC\Common\Admin\Entities\Element_With_Children;
+use TEC\Common\Admin\Entities\Field_Wrapper;
 use Tribe\Admin\Pages as Admin_Pages;
 
 if ( did_action( 'tec_settings_init' ) ) {
@@ -1091,80 +1093,112 @@ class Tribe__Settings {
 		// Check that the right POST && variables are set.
 		$tribe_save_settings  = tribe_get_request_var( 'tribe-save-settings', false );
 		$current_settings_tab = tribe_get_request_var( 'current-settings-tab', $this->get_current_tab() );
-		if ( $tribe_save_settings && $current_settings_tab ) {
-			// Check permissions.
-			if ( ! current_user_can( Admin_Pages::get_capability() ) ) {
-				$this->errors[]    = esc_html__( "You don't have permission to do that.", 'tribe-common' );
-				$this->major_error = true;
-			}
 
-			// Check the nonce.
-			if ( ! wp_verify_nonce( $tribe_save_settings, 'saving' ) ) {
-				$this->errors[]    = esc_html__( 'The request was sent insecurely.', 'tribe-common' );
-				$this->major_error = true;
-			}
+		// Return if we don't have POST and variables.
+		if ( ! $tribe_save_settings || ! $current_settings_tab ) {
+			return;
+		}
 
-			// Check that the request originated from the current tab.
-			if ( $current_settings_tab !== $this->current_tab ) {
-				$this->errors[]    = esc_html__( "The request wasn't sent from this tab.", 'tribe-common' );
-				$this->major_error = true;
-			}
+		// Check permissions.
+		if ( ! current_user_can( Admin_Pages::get_capability() ) ) {
+			$this->errors[]    = esc_html__( "You don't have permission to do that.", 'tribe-common' );
+			$this->major_error = true;
+		}
 
-			// Bail if we have errors.
-			if ( count( $this->errors ) ) {
-				remove_action( 'shutdown', [ $this, 'delete_options' ] );
-				add_option( 'tribe_settings_errors', $this->errors );
-				add_option( 'tribe_settings_major_error', $this->major_error );
-				wp_safe_redirect( $this->get_settings_page_url() );
-				exit;
-			}
+		// Check the nonce.
+		if ( ! wp_verify_nonce( $tribe_save_settings, 'saving' ) ) {
+			$this->errors[]    = esc_html__( 'The request was sent insecurely.', 'tribe-common' );
+			$this->major_error = true;
+		}
 
-			do_action( 'tribe_settings_validate', $admin_page );
-			do_action( 'tribe_settings_validate_tab_' . $this->current_tab, $admin_page );
+		// Check that the request originated from the current tab.
+		if ( $current_settings_tab !== $this->current_tab ) {
+			$this->errors[]    = esc_html__( "The request wasn't sent from this tab.", 'tribe-common' );
+			$this->major_error = true;
+		}
 
-			// Set the current fields.
-			$this->current_fields = $this->fields_for_save[ $this->current_tab ];
-			$fields               = $this->current_fields;
+		// Bail if we have errors.
+		if ( count( $this->errors ) ) {
+			remove_action( 'shutdown', [ $this, 'delete_options' ] );
+			add_option( 'tribe_settings_errors', $this->errors );
+			add_option( 'tribe_settings_major_error', $this->major_error );
+			wp_safe_redirect( $this->get_settings_page_url() );
+			exit;
+		}
 
-			if ( is_array( $fields ) ) {
-				// Loop through the fields and validate them.
-				foreach ( $fields as $field_id => $field ) {
-					// Get the value.
-					$value = tribe_get_request_var( $field_id, null );
-					$value = apply_filters( 'tribe_settings_validate_field_value', $value, $field_id, $field );
+		do_action( 'tribe_settings_validate', $admin_page );
+		do_action( 'tribe_settings_validate_tab_' . $this->current_tab, $admin_page );
 
-					// Make sure it has validation set up for it, else do nothing.
-					if (
-						( ! isset( $field['conditional'] ) || $field['conditional'] )
-						&& ( ! empty( $field['validation_type'] ) || ! empty( $field['validation_callback'] ) )
-					) {
-						do_action( 'tribe_settings_validate_field', $field_id, $value, $field );
-						do_action( 'tribe_settings_validate_field_' . $field_id, $value, $field );
+		// Set the current fields.
+		$this->current_fields = $this->fields_for_save[ $this->current_tab ];
+		$fields               = $this->current_fields;
 
-						// Validate this field.
-						$validate = new Tribe__Validate( $field_id, $field, $value );
+		if ( ! is_array( $fields ) ) {
+			return;
+		}
 
-						if ( isset( $validate->result->error ) ) {
-							// Validation failed.
-							$this->errors[ $field_id ] = $validate->result->error;
-						} elseif ( $validate->result->valid ) {
-							// Validation passed.
-							$this->validated[ $field_id ]        = new stdClass();
-							$this->validated[ $field_id ]->field = $validate->field;
-							$this->validated[ $field_id ]->value = $validate->value;
-						}
+		// Loop through the fields and validate them.
+		foreach ( $fields as $field_id => $field ) {
+			// If the field is an Element with children, check each of its children.
+			if ( $field instanceof Element_With_Children ) {
+				$children = $field->get_children();
+				foreach ( $children as $child ) {
+					if ( ! $child instanceof Field_Wrapper ) {
+						continue;
 					}
-				}
 
-				// Do not generate errors for dependent fields that should not show.
-				if ( ! empty( $this->errors ) ) {
-					$keep         = array_filter( array_keys( $this->errors ), [ $this, 'dependency_checks' ] );
-					$compare      = empty( $keep ) ? [] : array_combine( $keep, $keep );
-					$this->errors = array_intersect_key( $this->errors, $compare );
+					$this->validate_field( $child->get_field()->id, $child->get_field()->args );
 				}
+			} else {
+				$this->validate_field( $field_id, $field );
+			}
+		}
 
-				// Run the save method.
-				$this->save();
+		// Do not generate errors for dependent fields that should not show.
+		if ( ! empty( $this->errors ) ) {
+			$keep         = array_filter( array_keys( $this->errors ), [ $this, 'dependency_checks' ] );
+			$compare      = empty( $keep ) ? [] : array_combine( $keep, $keep );
+			$this->errors = array_intersect_key( $this->errors, $compare );
+		}
+
+		// Run the save method.
+		$this->save();
+	}
+
+	/**
+	 * Validate the value of a field to save.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $field_id The field ID.
+	 * @param array  $field    The field data.
+	 *
+	 * @return void
+	 */
+	protected function validate_field( $field_id, $field ) {
+		// Get the value.
+		$value = tribe_get_request_var( $field_id, null );
+		$value = apply_filters( 'tribe_settings_validate_field_value', $value, $field_id, $field );
+
+		// Make sure it has validation set up for it, else do nothing.
+		if (
+			( ! isset( $field['conditional'] ) || $field['conditional'] )
+			&& ( ! empty( $field['validation_type'] ) || ! empty( $field['validation_callback'] ) )
+		) {
+			do_action( 'tribe_settings_validate_field', $field_id, $value, $field );
+			do_action( 'tribe_settings_validate_field_' . $field_id, $value, $field );
+
+			// Validate this field.
+			$validate = new Tribe__Validate( $field_id, $field, $value );
+
+			if ( isset( $validate->result->error ) ) {
+				// Validation failed.
+				$this->errors[ $field_id ] = $validate->result->error;
+			} elseif ( $validate->result->valid ) {
+				// Validation passed.
+				$this->validated[ $field_id ]        = new stdClass();
+				$this->validated[ $field_id ]->field = $validate->field;
+				$this->validated[ $field_id ]->value = $validate->value;
 			}
 		}
 	}


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5133]

### 🗒️ Description

This fixes an issue with the fields in the Imports tab not saving properly.

The logic in `Tribe__Settings::validate()` was updated to properly handle `Element` objects that contain fields via the `Field_Wrapper` object.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5133]: https://stellarwp.atlassian.net/browse/TEC-5133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ