### PR TITLE
Replace get_class() with __CLASS__

### DIFF
--- a/src/Tribe/Values/Value_Update.php
+++ b/src/Tribe/Values/Value_Update.php
@@ -8,8 +8,7 @@ trait Value_Update {
 	 * @inheritDoc
 	 */
 	public function get_setters() {
-
-		if ( Abstract_Value::class !== get_class() ) {
+		if ( Abstract_Value::class !== __CLASS__ ) {
 			$setters = parent::get_setters();
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Replace the call to `get_classs()` with `__CLASS__` in the `Value_Update` trait. Calling `get_class()` without a parameter is deprecated in PHP 8.3, and this results in ***thousands*** of deprecation notices due to how many times this method is called.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
