### PR TITLE
Include a way to get request variables without sanatization

### DIFF
--- a/changelog/fix-TEC-5283-before-after-removing-html
+++ b/changelog/fix-TEC-5283-before-after-removing-html
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent new Settings pages to over sanitize textarea fields, thus removing HTML from before/after in the Events UI.

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -1181,7 +1181,7 @@ class Tribe__Settings {
 	 */
 	protected function validate_field( $field_id, $field ) {
 		// Get the value.
-		$value = tribe_get_request_var( $field_id, null );
+		$value = tribe_get_request_var( $field_id, null, false );
 		$value = apply_filters( 'tribe_settings_validate_field_value', $value, $field_id, $field );
 
 		// Make sure it has validation set up for it, else do nothing.

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -1181,7 +1181,7 @@ class Tribe__Settings {
 	 */
 	protected function validate_field( $field_id, $field ) {
 		// Get the value.
-		$value = tribe_get_request_var( $field_id, null, false );
+		$value = tec_get_request_var_raw( $field_id, null );
 		$value = apply_filters( 'tribe_settings_validate_field_value', $value, $field_id, $field );
 
 		// Make sure it has validation set up for it, else do nothing.

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -160,13 +160,13 @@ if ( ! function_exists( 'tribe_get_request_var' ) ) {
 	 *
 	 * @see   tec_get_request_var()
 	 *
-	 * @param string|array $var           The variable to check for.
+	 * @param string|array $request_var   The variable to check for.
 	 * @param mixed        $default_value The default value to return if the variable is not set.
 	 *
 	 * @return mixed
 	 */
-	function tribe_get_request_var( $var, $default_value = null ) {
-		return tec_get_request_var( $var, $default_value );
+	function tribe_get_request_var( $request_var, $default_value = null ) {
+		return tec_get_request_var( $request_var, $default_value );
 	}
 }
 
@@ -187,13 +187,13 @@ if ( ! function_exists( 'tec_get_request_var' ) ) {
 	 * @see   Tribe__Utils__Array::get_in_any()
 	 * @see   tribe_sanitize_deep()
 	 *
-	 * @param string|array $var           The variable to check for.
+	 * @param string|array $request_var   The variable to check for.
 	 * @param mixed        $default_value The default value to return if the variable is not set.
 	 *
 	 * @return mixed
 	 */
-	function tec_get_request_var( $var, $default_value = null ) {
-		$unsafe = tec_get_request_var_raw( $var, $default_value );
+	function tec_get_request_var( $request_var, $default_value = null ) {
+		$unsafe = tec_get_request_var_raw( $request_var, $default_value );
 
 		// Sanitize and return.
 		return tribe_sanitize_deep( $unsafe );
@@ -216,12 +216,12 @@ if ( ! function_exists( 'tec_get_request_var_raw' ) ) {
 	 *
 	 * @see   Tribe__Utils__Array::get_in_any()
 	 *
-	 * @param string|array $var            The variable to check for.
+	 * @param string|array $request_var    The variable to check for.
 	 * @param mixed        $default_value  The default value to return if the variable is not set.
 	 *
 	 * @return mixed
 	 */
-	function tec_get_request_var_raw( $var, $default_value = null ) {
+	function tec_get_request_var_raw( $request_var, $default_value = null ) {
 		$requests = [];
 
 		// Prevent a slew of warnings every time we call this.
@@ -241,7 +241,7 @@ if ( ! function_exists( 'tec_get_request_var_raw' ) ) {
 			return $default_value;
 		}
 
-		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default_value );
+		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $request_var, $default_value );
 
 		// Return the value as is.
 		return $unsafe;

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -241,10 +241,8 @@ if ( ! function_exists( 'tec_get_request_var_raw' ) ) {
 			return $default_value;
 		}
 
-		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $request_var, $default_value );
-
 		// Return the value as is.
-		return $unsafe;
+		return Tribe__Utils__Array::get_in_any( $requests, $request_var, $default_value );
 	}
 }
 

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -226,15 +226,15 @@ if ( ! function_exists( 'tec_get_request_var_raw' ) ) {
 
 		// Prevent a slew of warnings every time we call this.
 		if ( isset( $_REQUEST ) ) {
-			$requests[] = (array) $_REQUEST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+			$requests[] = (array) $_REQUEST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
 		}
 
 		if ( isset( $_GET ) ) {
-			$requests[] = (array) $_GET; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+			$requests[] = (array) $_GET; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
 		}
 
 		if ( isset( $_POST ) ) {
-			$requests[] = (array) $_POST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+			$requests[] = (array) $_POST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended, WordPress.Security.NonceVerification.Missing
 		}
 
 		if ( empty( $requests ) ) {

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -213,7 +213,7 @@ if ( ! function_exists( 'tec_get_request_var' ) ) {
 		}
 
 		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default_value );
-
+return tribe_sanitize_deep( tec_get_request_var_raw( $var, $default ) );
 		// Sanitize and return.
 		return tribe_sanitize_deep( $unsafe );
 	}

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -156,17 +156,43 @@ if ( ! function_exists( 'tribe_get_request_var' ) ) {
 	 * The variable being tested for can be an array if you wish to find a nested value.
 	 *
 	 * @since 4.9.17 Included explicit check against $_REQUEST.
-	 * @since TBD Included a param to allow for returning the value as is, without sanitizing it.
+	 * @since TBD Renamed from `tribe_get_request_var` to `tec_get_request_var`.
 	 *
-	 * @see   Tribe__Utils__Array::get()
+	 * @see   tec_get_request_var()
 	 *
-	 * @param string|array $var        The variable to check for.
-	 * @param mixed        $default   The default value to return if the variable is not set.
-	 * @param bool         $sanitize  Whether to return the value as is, without sanitizing it.
+	 * @param string|array $var     The variable to check for.
+	 * @param mixed        $default The default value to return if the variable is not set.
 	 *
 	 * @return mixed
 	 */
-	function tribe_get_request_var( $var, $default = null, bool $sanitize = true ) {
+	function tribe_get_request_var( $var, $default = null ) {
+		return tec_get_request_var( $var, $default );
+	}
+}
+
+if ( ! function_exists( 'tec_get_request_var' ) ) {
+	/**
+	 * Tests to see if the requested variable is set either as a post field or as a URL
+	 * param and returns the value if so.
+	 *
+	 * Post data takes priority over fields passed in the URL query. If the field is not
+	 * set then $default (null unless a different value is specified) will be returned.
+	 *
+	 * The variable being tested for can be an array if you wish to find a nested value.
+	 *
+	 * This function will sanitize the value before returning it.
+	 *
+	 * @since TBD
+	 *
+	 * @see   Tribe__Utils__Array::get_in_any()
+	 * @see   tribe_sanitize_deep()
+	 *
+	 * @param string|array $var     The variable to check for.
+	 * @param mixed        $default The default value to return if the variable is not set.
+	 *
+	 * @return mixed
+	 */
+	function tec_get_request_var( $var, $default = null ) {
 		$requests = [];
 
 		// Prevent a slew of warnings every time we call this.
@@ -188,12 +214,56 @@ if ( ! function_exists( 'tribe_get_request_var' ) ) {
 
 		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default );
 
-		// If we're not sanitizing, return the value as is.
-		if ( ! $sanitize ) {
-			return $unsafe;
+		// Sanitize and return.
+		return tribe_sanitize_deep( $unsafe );
+	}
+}
+
+if ( ! function_exists( 'tec_get_request_var_raw' ) ) {
+	/**
+	 * Tests to see if the requested variable is set either as a post field or as a URL
+	 * param and returns the value if so.
+	 *
+	 * Post data takes priority over fields passed in the URL query. If the field is not
+	 * set then $default (null unless a different value is specified) will be returned.
+	 *
+	 * The variable being tested for can be an array if you wish to find a nested value.
+	 *
+	 * This function will NOT sanitize the value before returning it.
+	 *
+	 * @since TBD
+	 *
+	 * @see   Tribe__Utils__Array::get_in_any()
+	 *
+	 * @param string|array $var        The variable to check for.
+	 * @param mixed        $default   The default value to return if the variable is not set.
+	 *
+	 * @return mixed
+	 */
+	function tec_get_request_var_raw( $var, $default = null ) {
+		$requests = [];
+
+		// Prevent a slew of warnings every time we call this.
+		if ( isset( $_REQUEST ) ) {
+			$requests[] = (array) $_REQUEST;
 		}
 
-		return tribe_sanitize_deep( $unsafe );
+		if ( isset( $_GET ) ) {
+			$requests[] = (array) $_GET;
+		}
+
+		if ( isset( $_POST ) ) {
+			$requests[] = (array) $_POST;
+		}
+
+		if ( empty( $requests ) ) {
+			return $default;
+		}
+
+		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default );
+
+		// Return the value as is.
+		return $unsafe;
 	}
 }
 

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -156,15 +156,17 @@ if ( ! function_exists( 'tribe_get_request_var' ) ) {
 	 * The variable being tested for can be an array if you wish to find a nested value.
 	 *
 	 * @since 4.9.17 Included explicit check against $_REQUEST.
+	 * @since TBD Included a param to allow for returning the value as is, without sanitizing it.
 	 *
 	 * @see   Tribe__Utils__Array::get()
 	 *
-	 * @param string|array $var
-	 * @param mixed        $default
+	 * @param string|array $var        The variable to check for.
+	 * @param mixed        $default   The default value to return if the variable is not set.
+	 * @param bool         $sanitize  Whether to return the value as is, without sanitizing it.
 	 *
 	 * @return mixed
 	 */
-	function tribe_get_request_var( $var, $default = null ) {
+	function tribe_get_request_var( $var, $default = null, bool $sanitize = true ) {
 		$requests = [];
 
 		// Prevent a slew of warnings every time we call this.
@@ -185,6 +187,12 @@ if ( ! function_exists( 'tribe_get_request_var' ) ) {
 		}
 
 		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default );
+
+		// If we're not sanitizing, return the value as is.
+		if ( ! $sanitize ) {
+			return $unsafe;
+		}
+
 		return tribe_sanitize_deep( $unsafe );
 	}
 }

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -160,13 +160,13 @@ if ( ! function_exists( 'tribe_get_request_var' ) ) {
 	 *
 	 * @see   tec_get_request_var()
 	 *
-	 * @param string|array $var     The variable to check for.
-	 * @param mixed        $default The default value to return if the variable is not set.
+	 * @param string|array $var           The variable to check for.
+	 * @param mixed        $default_value The default value to return if the variable is not set.
 	 *
 	 * @return mixed
 	 */
-	function tribe_get_request_var( $var, $default = null ) {
-		return tec_get_request_var( $var, $default );
+	function tribe_get_request_var( $var, $default_value = null ) {
+		return tec_get_request_var( $var, $default_value );
 	}
 }
 
@@ -187,32 +187,32 @@ if ( ! function_exists( 'tec_get_request_var' ) ) {
 	 * @see   Tribe__Utils__Array::get_in_any()
 	 * @see   tribe_sanitize_deep()
 	 *
-	 * @param string|array $var     The variable to check for.
-	 * @param mixed        $default The default value to return if the variable is not set.
+	 * @param string|array $var           The variable to check for.
+	 * @param mixed        $default_value The default value to return if the variable is not set.
 	 *
 	 * @return mixed
 	 */
-	function tec_get_request_var( $var, $default = null ) {
+	function tec_get_request_var( $var, $default_value = null ) {
 		$requests = [];
 
 		// Prevent a slew of warnings every time we call this.
 		if ( isset( $_REQUEST ) ) {
-			$requests[] = (array) $_REQUEST;
+			$requests[] = (array) $_REQUEST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		}
 
 		if ( isset( $_GET ) ) {
-			$requests[] = (array) $_GET;
+			$requests[] = (array) $_GET; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		}
 
 		if ( isset( $_POST ) ) {
-			$requests[] = (array) $_POST;
+			$requests[] = (array) $_POST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		}
 
 		if ( empty( $requests ) ) {
-			return $default;
+			return $default_value;
 		}
 
-		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default );
+		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default_value );
 
 		// Sanitize and return.
 		return tribe_sanitize_deep( $unsafe );
@@ -235,32 +235,32 @@ if ( ! function_exists( 'tec_get_request_var_raw' ) ) {
 	 *
 	 * @see   Tribe__Utils__Array::get_in_any()
 	 *
-	 * @param string|array $var        The variable to check for.
-	 * @param mixed        $default   The default value to return if the variable is not set.
+	 * @param string|array $var            The variable to check for.
+	 * @param mixed        $default_value  The default value to return if the variable is not set.
 	 *
 	 * @return mixed
 	 */
-	function tec_get_request_var_raw( $var, $default = null ) {
+	function tec_get_request_var_raw( $var, $default_value = null ) {
 		$requests = [];
 
 		// Prevent a slew of warnings every time we call this.
 		if ( isset( $_REQUEST ) ) {
-			$requests[] = (array) $_REQUEST;
+			$requests[] = (array) $_REQUEST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		}
 
 		if ( isset( $_GET ) ) {
-			$requests[] = (array) $_GET;
+			$requests[] = (array) $_GET; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		}
 
 		if ( isset( $_POST ) ) {
-			$requests[] = (array) $_POST;
+			$requests[] = (array) $_POST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		}
 
 		if ( empty( $requests ) ) {
-			return $default;
+			return $default_value;
 		}
 
-		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default );
+		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default_value );
 
 		// Return the value as is.
 		return $unsafe;

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -193,27 +193,8 @@ if ( ! function_exists( 'tec_get_request_var' ) ) {
 	 * @return mixed
 	 */
 	function tec_get_request_var( $var, $default_value = null ) {
-		$requests = [];
+		$unsafe = tec_get_request_var_raw( $var, $default_value );
 
-		// Prevent a slew of warnings every time we call this.
-		if ( isset( $_REQUEST ) ) {
-			$requests[] = (array) $_REQUEST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-		}
-
-		if ( isset( $_GET ) ) {
-			$requests[] = (array) $_GET; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-		}
-
-		if ( isset( $_POST ) ) {
-			$requests[] = (array) $_POST; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-		}
-
-		if ( empty( $requests ) ) {
-			return $default_value;
-		}
-
-		$unsafe = Tribe__Utils__Array::get_in_any( $requests, $var, $default_value );
-return tribe_sanitize_deep( tec_get_request_var_raw( $var, $default ) );
 		// Sanitize and return.
 		return tribe_sanitize_deep( $unsafe );
 	}


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5283]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Resolves the problem where because we are using `tribe_get_request_var` it will strip all HTML.

### 📹 Artifact

https://i.bordoni.me/Zt3Zk5Bd

[TEC-5283]: https://stellarwp.atlassian.net/browse/TEC-5283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ