### PR TITLE
Avoid warning when passing a non string value

### DIFF
--- a/src/Tribe/Values/Abstract_Value.php
+++ b/src/Tribe/Values/Abstract_Value.php
@@ -450,6 +450,6 @@ abstract class Abstract_Value implements Value_Interface {
 	 * @return bool
 	 */
 	private function is_character_block( $block ) {
-		return empty( preg_replace( '/\D/', '', $block ) );
+		return empty( preg_replace( '/\D/', '', (string) $block ) );
 	}
 }


### PR DESCRIPTION
Avoid the below warning.

```text
PHP Deprecated:  preg_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /app/wp-content/plugins/event-tickets/common/src/Tribe/Values/Abstract_Value.php on line 453
```