### PR TITLE
Ensure that only float values are passed to number_format

### DIFF
--- a/changelog/fix-ETP-962-float-number-value
+++ b/changelog/fix-ETP-962-float-number-value
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Ensure that number_format is used with a float value to prevent issues with PHP 8.0+. [ETP-962]

--- a/src/Tribe/Admin/Help_Page.php
+++ b/src/Tribe/Admin/Help_Page.php
@@ -546,7 +546,7 @@ class Tribe__Admin__Help_Page {
 
 			if ( ! is_wp_error( $data ) ) {
 				// Format Downloaded Infomation.
-				$data->downloaded = $data->downloaded ? number_format( $data->downloaded ) : _x( 'n/a', 'not available', 'tribe-common' );
+				$data->downloaded = $data->downloaded ? number_format( (float) $data->downloaded ) : _x( 'n/a', 'not available', 'tribe-common' );
 			} else {
 				// If there was a bug on the Current Request just leave.
 				return false;
@@ -969,7 +969,7 @@ class Tribe__Admin__Help_Page {
 					<dd><?php echo esc_html__( 'WordPress ', 'tribe-common' ) . esc_html( $api_data->requires ); ?>+</dd>
 
 					<dt><?php esc_html_e( 'Active Users:', 'tribe-common' ); ?></dt>
-					<dd><?php echo esc_html( number_format( $api_data->active_installs ) ); ?>+</dd>
+					<dd><?php echo esc_html( number_format( (float) $api_data->active_installs ) ); ?>+</dd>
 
 					<dt><?php esc_html_e( 'Rating:', 'tribe-common' ); ?></dt>
 					<dd>

--- a/src/Tribe/Cost_Utils.php
+++ b/src/Tribe/Cost_Utils.php
@@ -109,7 +109,7 @@ class Tribe__Cost_Utils {
 
 		if (
 			is_numeric( $cost_with_period )
-			&& '0.00' === number_format( $cost_with_period, 2, '.', ',' )
+			&& '0.00' === number_format( (float) $cost_with_period, 2, '.', ',' )
 		) {
 			return esc_html__( 'Free', 'tribe-common' );
 		}
@@ -353,7 +353,7 @@ class Tribe__Cost_Utils {
 
 			if ( is_numeric( $numeric_cost ) ) {
 				// Creates a Well Balanced Index that will perform good on a Key Sorting method
-				$index = str_replace( [ '.', ',' ], '', number_format( $numeric_cost, $max ) );
+				$index = str_replace( [ '.', ',' ], '', number_format( (float) $numeric_cost, $max ) );
 			} else {
 				// Makes sure that we have "index-safe" string
 				$index = sanitize_title( $numeric_cost );


### PR DESCRIPTION
PHP 8.0+ throws fatals when non-float values are passed to number_format, which can occur from time to time. A customer reported this issue happening and he has to modify the code each time a release happens. This should fix that for him!

:ticket: [ETP-962]
Related: 
* https://github.com/the-events-calendar/event-tickets-plus/pull/1694
* https://github.com/the-events-calendar/event-tickets/pull/3429

The passing tests will act as the artifact for this PR as the change is incredibly low-level.


[ETP-962]: https://stellarwp.atlassian.net/browse/ETP-962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ