### PR TITLE
Fix tests for Notifications

### DIFF
--- a/src/Common/Notifications/Conditionals.php
+++ b/src/Common/Notifications/Conditionals.php
@@ -58,17 +58,20 @@ class Conditionals {
 				}
 
 				$matches = [];
-				foreach ( $item['conditions'] as $k => $condition ) {
-					switch ( $k ) {
-						case 'php_version':
-							$matches['php_version'] = self::check_php_version( $condition );
-							break;
-						case 'wp_version':
-							$matches['wp_version'] = self::check_wp_version( $condition );
-							break;
-						case 'plugin_version':
-							$matches['plugin_version'] = self::check_plugin_version( (array) $condition );
-							break;
+				foreach ( $item['conditions'] as $condition ) {
+					if ( 0 === strpos( $condition, 'wp_version' ) ) {
+						$version = substr( $condition, strlen( 'wp_version' ) );
+
+						$matches['wp_version'] = self::check_wp_version( $version );
+					} elseif ( 0 === strpos( $condition, 'php_version' ) ) {
+						$version = substr( $condition, strlen( 'php_version' ) );
+
+						$matches['php_version'] = self::check_php_version( $version );
+					} elseif ( 0 === strpos( $condition, 'plugin_version' ) ) {
+						$split   = explode( '=>', $condition );
+						$plugins = explode( ',', $split[1] );
+
+						$matches['plugin_version'] = self::check_plugin_version( (array) $plugins );
 					}
 				}
 

--- a/src/Common/Notifications/Conditionals.php
+++ b/src/Common/Notifications/Conditionals.php
@@ -61,13 +61,13 @@ class Conditionals {
 				foreach ( $item['conditions'] as $k => $condition ) {
 					switch ( $k ) {
 						case 'php_version':
-							$matches['php_version'] = self::check_php_version( $condition['php_version'] );
+							$matches['php_version'] = self::check_php_version( $condition );
 							break;
 						case 'wp_version':
-							$matches['wp_version'] = self::check_wp_version( $condition['wp_version'] );
+							$matches['wp_version'] = self::check_wp_version( $condition );
 							break;
 						case 'plugin_version':
-							$matches['plugin_version'] = self::check_plugin_version( $condition['plugin_version'] );
+							$matches['plugin_version'] = self::check_plugin_version( (array) $condition );
 							break;
 					}
 				}

--- a/tests/wpunit/Common/Notifications/NotificationsTest.php
+++ b/tests/wpunit/Common/Notifications/NotificationsTest.php
@@ -162,7 +162,7 @@ class NotificationsTest extends \Codeception\TestCase\WPTestCase {
 
 		// Add a condition that will never be met.
 		$feed[0]['conditions'] = [
-			'php_version>=8.8',
+			'php_version<=1.8',
 		];
 
 		$filtered_feed = Conditionals::filter_feed( $feed );
@@ -196,11 +196,11 @@ class NotificationsTest extends \Codeception\TestCase\WPTestCase {
 
 		// Add conditions that will never be met.
 		$feed[0]['conditions'] = [
-			'plugin_version=>events-calendar-pro@>=7.0.0',
+			'plugin_version=>events-calendar-pro@<=1.0.0',
 		];
 
 		$feed[1]['conditions'] = [
-			'plugin_version=>woocommerce@>=5.0.0',
+			'plugin_version=>woocommerce@<=2.0.0',
 		];
 
 		$filtered_feed = Conditionals::filter_feed( $feed );

--- a/tests/wpunit/Common/Notifications/NotificationsTest.php
+++ b/tests/wpunit/Common/Notifications/NotificationsTest.php
@@ -51,7 +51,7 @@ class NotificationsTest extends \Codeception\TestCase\WPTestCase {
 					],
 				],
 				'dismissible' => true,
-				'conditions'  => [],
+				'conditions'  => [ 'wp_version>=5.8', 'php_version>=7.0' ],
 			],
 			[
 				'id'          => '102',
@@ -67,7 +67,7 @@ class NotificationsTest extends \Codeception\TestCase\WPTestCase {
 					],
 				],
 				'dismissible' => true,
-				'conditions'  => [],
+				'conditions'  => [ 'plugin_version=>the-events-calendar@>=5.0.0' ],
 			],
 			[
 				'id'          => '103',
@@ -162,7 +162,7 @@ class NotificationsTest extends \Codeception\TestCase\WPTestCase {
 
 		// Add a condition that will never be met.
 		$feed[0]['conditions'] = [
-			'php_version' => '>=8.5',
+			'php_version>=8.8',
 		];
 
 		$filtered_feed = Conditionals::filter_feed( $feed );
@@ -177,11 +177,11 @@ class NotificationsTest extends \Codeception\TestCase\WPTestCase {
 
 		// Add conditions that will never be met.
 		$feed[0]['conditions'] = [
-			'wp_version' => '>=8',
+			'php_version>=8.8',
 		];
 
 		$feed[1]['conditions'] = [
-			'wp_version' => '<=4',
+			'wp_version<=4',
 		];
 
 		$filtered_feed = Conditionals::filter_feed( $feed );
@@ -196,11 +196,11 @@ class NotificationsTest extends \Codeception\TestCase\WPTestCase {
 
 		// Add conditions that will never be met.
 		$feed[0]['conditions'] = [
-			'plugin_version' => [ 'the-events-calendar@>=7.0.0' ],
+			'plugin_version=>events-calendar-pro@>=7.0.0',
 		];
 
 		$feed[1]['conditions'] = [
-			'plugin_version' => [ 'woocommerce@>=5.0.0' ],
+			'plugin_version=>woocommerce@>=5.0.0',
 		];
 
 		$filtered_feed = Conditionals::filter_feed( $feed );

--- a/tests/wpunit/Common/Notifications/NotificationsTest.php
+++ b/tests/wpunit/Common/Notifications/NotificationsTest.php
@@ -151,7 +151,7 @@ class NotificationsTest extends \Codeception\TestCase\WPTestCase {
 		$feed = $this->get_mocked_feed();
 		$filtered_feed = Conditionals::filter_feed( $feed );
 		$this->assertIsArray( $filtered_feed, 'Filtered feed should be an array' );
-		$this->assertCount( 3, $filtered_feed, 'Filtered feed should have one item' );
+		$this->assertCount( 3, $filtered_feed, 'Filtered feed should have three items' );
 	}
 
 	/**

--- a/tests/wpunit/Common/Notifications/NotificationsTest.php
+++ b/tests/wpunit/Common/Notifications/NotificationsTest.php
@@ -177,7 +177,7 @@ class NotificationsTest extends \Codeception\TestCase\WPTestCase {
 
 		// Add conditions that will never be met.
 		$feed[0]['conditions'] = [
-			'php_version>=8.8',
+			'php_version<=1.8',
 		];
 
 		$feed[1]['conditions'] = [


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5165]

### 🗒️ Description
Fixing test for Notifications. Removed live queries to the API and used a mocked JSON feed.

Follow up to https://github.com/the-events-calendar/tribe-common/pull/2251

[TEC-5165]: https://stellarwp.atlassian.net/browse/TEC-5165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ