### PR TITLE
[TECTRIA-549] Help Hub - Valid License Transient Issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "stellarwp/telemetry": "^2.3.1",
     "stellarwp/assets": "1.4.2",
     "stellarwp/admin-notices": "^1.1",
-    "stellarwp/uplink": "2.2.1"
+    "stellarwp/uplink": "2.2.2"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c62c55b2f96b21c6942947c11925cc1f",
+    "content-hash": "4a063d7c5ba67c09c3ff597cc59e3620",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -782,16 +782,16 @@
         },
         {
             "name": "stellarwp/uplink",
-            "version": "v2.2.1",
+            "version": "v2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/uplink.git",
-                "reference": "57eb6264994662cb8da368cc3a9227ec716edc70"
+                "reference": "5bc1f115efe629dd4244bff08809aea45ed9d8f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/uplink/zipball/57eb6264994662cb8da368cc3a9227ec716edc70",
-                "reference": "57eb6264994662cb8da368cc3a9227ec716edc70",
+                "url": "https://api.github.com/repos/stellarwp/uplink/zipball/5bc1f115efe629dd4244bff08809aea45ed9d8f1",
+                "reference": "5bc1f115efe629dd4244bff08809aea45ed9d8f1",
                 "shasum": ""
             },
             "require": {
@@ -843,9 +843,9 @@
             "description": "A library that integrates a WordPress product with the StellarWP Licensing system.",
             "support": {
                 "issues": "https://github.com/stellarwp/uplink/issues",
-                "source": "https://github.com/stellarwp/uplink/tree/v2.2.1"
+                "source": "https://github.com/stellarwp/uplink/tree/v2.2.2"
             },
-            "time": "2024-09-30T22:46:40+00:00"
+            "time": "2024-12-05T19:13:16+00:00"
         }
     ],
     "packages-dev": [
@@ -926,15 +926,15 @@
             "type": "project",
             "extra": {
                 "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-changelogger",
                 "branch-alias": {
                     "dev-trunk": "4.2.x-dev"
                 },
-                "mirror-repo": "Automattic/jetpack-changelogger",
-                "version-constants": {
-                    "::VERSION": "src/Application.php"
-                },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
+                },
+                "version-constants": {
+                    "::VERSION": "src/Application.php"
                 }
             },
             "autoload": {
@@ -1498,29 +1498,27 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
+                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
-                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/31610dbb31faa98e6b5447b62340826f54fbc4e9",
+                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9",
-                "phpstan/phpstan": "1.4.10 || 1.10.15",
-                "phpstan/phpstan-phpunit": "^1.0",
+                "doctrine/coding-standard": "^9 || ^12",
+                "phpstan/phpstan": "1.4.10 || 2.0.3",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psalm/plugin-phpunit": "0.18.4",
-                "psr/log": "^1 || ^2 || ^3",
-                "vimeo/psalm": "4.30.0 || 5.12.0"
+                "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -1528,7 +1526,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
+                    "Doctrine\\Deprecations\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1539,9 +1537,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.4"
             },
-            "time": "2024-01-30T19:34:25+00:00"
+            "time": "2024-12-07T21:18:45+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1772,16 +1770,16 @@
         },
         {
             "name": "fakerphp/faker",
-            "version": "v1.23.1",
+            "version": "v1.24.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "bfb4fe148adbf78eff521199619b93a52ae3554b"
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/bfb4fe148adbf78eff521199619b93a52ae3554b",
-                "reference": "bfb4fe148adbf78eff521199619b93a52ae3554b",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
                 "shasum": ""
             },
             "require": {
@@ -1829,9 +1827,9 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.23.1"
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
             },
-            "time": "2024-01-02T13:46:09+00:00"
+            "time": "2024-11-21T13:46:39+00:00"
         },
         {
             "name": "gajus/dindent",
@@ -2662,12 +2660,12 @@
             "type": "laravel-package",
             "extra": {
                 "laravel": {
-                    "providers": [
-                        "MikeMcLin\\WpPassword\\WpPasswordProvider"
-                    ],
                     "aliases": {
                         "WpPassword": "MikeMcLin\\WpPassword\\Facades\\WpPassword"
-                    }
+                    },
+                    "providers": [
+                        "MikeMcLin\\WpPassword\\WpPasswordProvider"
+                    ]
                 }
             },
             "autoload": {
@@ -2752,16 +2750,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.0",
+            "version": "1.12.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
-                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
                 "shasum": ""
             },
             "require": {
@@ -2800,7 +2798,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
             },
             "funding": [
                 {
@@ -2808,7 +2806,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-12T14:39:25+00:00"
+            "time": "2024-11-08T17:47:46+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -3307,16 +3305,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.5.0",
+            "version": "5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "54e10d44fc1a84e2598d26f70d4f6f1f233e228a"
+                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/54e10d44fc1a84e2598d26f70d4f6f1f233e228a",
-                "reference": "54e10d44fc1a84e2598d26f70d4f6f1f233e228a",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
+                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
                 "shasum": ""
             },
             "require": {
@@ -3325,7 +3323,7 @@
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
                 "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
@@ -3365,29 +3363,29 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.5.0"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.1"
             },
-            "time": "2024-11-04T21:26:31+00:00"
+            "time": "2024-12-07T09:39:29+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.9.0",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "1fb5ba8d045f5dd984ebded5b1cc66f29459422d"
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/1fb5ba8d045f5dd984ebded5b1cc66f29459422d",
-                "reference": "1fb5ba8d045f5dd984ebded5b1cc66f29459422d",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
                 "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18"
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
@@ -3423,32 +3421,33 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.9.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
             },
-            "time": "2024-11-03T20:11:34+00:00"
+            "time": "2024-11-09T15:12:26+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.19.0",
+            "version": "v1.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "67a759e7d8746d501c41536ba40cd9c0a07d6a87"
+                "reference": "a0165c648cab6a80311c74ffc708a07bb53ecc93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/67a759e7d8746d501c41536ba40cd9c0a07d6a87",
-                "reference": "67a759e7d8746d501c41536ba40cd9c0a07d6a87",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/a0165c648cab6a80311c74ffc708a07bb53ecc93",
+                "reference": "a0165c648cab6a80311c74ffc708a07bb53ecc93",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2 || ^2.0",
-                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
+                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0"
             },
             "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.40",
                 "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpstan/phpstan": "^1.9",
                 "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0"
@@ -3492,9 +3491,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.19.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.20.0"
             },
-            "time": "2024-02-29T11:52:51+00:00"
+            "time": "2024-11-19T13:12:41+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -4783,16 +4782,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.19",
+            "version": "v2.11.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1"
+                "reference": "eb2b351927098c24860daa7484e290d3eed693be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
-                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/eb2b351927098c24860daa7484e290d3eed693be",
+                "reference": "eb2b351927098c24860daa7484e290d3eed693be",
                 "shasum": ""
             },
             "require": {
@@ -4803,9 +4802,9 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
                 "phpcsstandards/phpcsdevcs": "^1.1",
                 "phpstan/phpstan": "^1.7",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
                 "sirbrillig/phpcs-import-detection": "^1.1",
-                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -4837,7 +4836,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2024-06-26T20:08:34+00:00"
+            "time": "2024-12-02T16:37:49+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -4906,16 +4905,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.10.3",
+            "version": "3.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c"
+                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/62d32998e820bddc40f99f8251958aed187a5c9c",
-                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
+                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
                 "shasum": ""
             },
             "require": {
@@ -4982,7 +4981,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-09-18T10:38:58+00:00"
+            "time": "2024-11-16T12:02:36+00:00"
         },
         {
             "name": "stellarwp/coding-standards",
@@ -5269,16 +5268,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.3",
+            "version": "v2.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "80d075412b557d41002320b96a096ca65aa2c98d"
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/80d075412b557d41002320b96a096ca65aa2c98d",
-                "reference": "80d075412b557d41002320b96a096ca65aa2c98d",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
                 "shasum": ""
             },
             "require": {
@@ -5316,7 +5315,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.3"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
             },
             "funding": [
                 {
@@ -5332,7 +5331,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-01-24T14:02:46+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -5659,8 +5658,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5818,8 +5817,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -5976,8 +5975,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -6052,8 +6051,8 @@
             "type": "library",
             "extra": {
                 "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
                 }
             },
             "autoload": {
@@ -6176,16 +6175,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.3",
+            "version": "v2.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "a2329596ddc8fd568900e3fc76cba42489ecc7f3"
+                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a2329596ddc8fd568900e3fc76cba42489ecc7f3",
-                "reference": "a2329596ddc8fd568900e3fc76cba42489ecc7f3",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f37b419f7aea2e9abf10abd261832cace12e3300",
+                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300",
                 "shasum": ""
             },
             "require": {
@@ -6239,7 +6238,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.3"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.4"
             },
             "funding": [
                 {
@@ -6255,7 +6254,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-21T15:04:16+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/translation",
@@ -6354,16 +6353,16 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.5.3",
+            "version": "v2.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "b0073a77ac0b7ea55131020e87b1e3af540f4664"
+                "reference": "450d4172653f38818657022252f9d81be89ee9a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/b0073a77ac0b7ea55131020e87b1e3af540f4664",
-                "reference": "b0073a77ac0b7ea55131020e87b1e3af540f4664",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/450d4172653f38818657022252f9d81be89ee9a8",
+                "reference": "450d4172653f38818657022252f9d81be89ee9a8",
                 "shasum": ""
             },
             "require": {
@@ -6412,7 +6411,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.3"
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.4"
             },
             "funding": [
                 {
@@ -6428,7 +6427,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-01-23T13:51:25+00:00"
+            "time": "2024-09-25T14:11:13+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -7155,16 +7154,16 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "stellarwp/coding-standards": 20,
         "stellarwp/models": 20,
+        "stellarwp/coding-standards": 20,
         "the-events-calendar/tec-testing-facilities": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -782,16 +782,16 @@
         },
         {
             "name": "stellarwp/uplink",
-            "version": "v2.2.2",
+            "version": "v2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/uplink.git",
-                "reference": "5bc1f115efe629dd4244bff08809aea45ed9d8f1"
+                "reference": "57eb6264994662cb8da368cc3a9227ec716edc70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/uplink/zipball/5bc1f115efe629dd4244bff08809aea45ed9d8f1",
-                "reference": "5bc1f115efe629dd4244bff08809aea45ed9d8f1",
+                "url": "https://api.github.com/repos/stellarwp/uplink/zipball/57eb6264994662cb8da368cc3a9227ec716edc70",
+                "reference": "57eb6264994662cb8da368cc3a9227ec716edc70",
                 "shasum": ""
             },
             "require": {
@@ -843,9 +843,9 @@
             "description": "A library that integrates a WordPress product with the StellarWP Licensing system.",
             "support": {
                 "issues": "https://github.com/stellarwp/uplink/issues",
-                "source": "https://github.com/stellarwp/uplink/tree/v2.2.2"
+                "source": "https://github.com/stellarwp/uplink/tree/v2.2.1"
             },
-            "time": "2024-12-05T19:13:16+00:00"
+            "time": "2024-09-30T22:46:40+00:00"
         }
     ],
     "packages-dev": [
@@ -1498,27 +1498,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.4",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9"
+                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/31610dbb31faa98e6b5447b62340826f54fbc4e9",
-                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
+                "reference": "dfbaa3c2d2e9a9df1118213f3b8b0c597bb99fab",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12",
-                "phpstan/phpstan": "1.4.10 || 2.0.3",
-                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "doctrine/coding-standard": "^9",
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "psr/log": "^1 || ^2 || ^3"
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -1526,7 +1528,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Doctrine\\Deprecations\\": "src"
+                    "Doctrine\\Deprecations\\": "lib/Doctrine/Deprecations"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1537,9 +1539,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.4"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.3"
             },
-            "time": "2024-12-07T21:18:45+00:00"
+            "time": "2024-01-30T19:34:25+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1770,16 +1772,16 @@
         },
         {
             "name": "fakerphp/faker",
-            "version": "v1.24.1",
+            "version": "v1.23.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FakerPHP/Faker.git",
-                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5"
+                "reference": "bfb4fe148adbf78eff521199619b93a52ae3554b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
-                "reference": "e0ee18eb1e6dc3cda3ce9fd97e5a0689a88a64b5",
+                "url": "https://api.github.com/repos/FakerPHP/Faker/zipball/bfb4fe148adbf78eff521199619b93a52ae3554b",
+                "reference": "bfb4fe148adbf78eff521199619b93a52ae3554b",
                 "shasum": ""
             },
             "require": {
@@ -1827,9 +1829,9 @@
             ],
             "support": {
                 "issues": "https://github.com/FakerPHP/Faker/issues",
-                "source": "https://github.com/FakerPHP/Faker/tree/v1.24.1"
+                "source": "https://github.com/FakerPHP/Faker/tree/v1.23.1"
             },
-            "time": "2024-11-21T13:46:39+00:00"
+            "time": "2024-01-02T13:46:09+00:00"
         },
         {
             "name": "gajus/dindent",
@@ -2750,16 +2752,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.12.1",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845"
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/123267b2c49fbf30d78a7b2d333f6be754b94845",
-                "reference": "123267b2c49fbf30d78a7b2d333f6be754b94845",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
+                "reference": "3a6b9a42cd8f8771bd4295d13e1423fa7f3d942c",
                 "shasum": ""
             },
             "require": {
@@ -2798,7 +2800,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.12.0"
             },
             "funding": [
                 {
@@ -2806,7 +2808,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T17:47:46+00:00"
+            "time": "2024-06-12T14:39:25+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -3305,16 +3307,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.1",
+            "version": "5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8"
+                "reference": "54e10d44fc1a84e2598d26f70d4f6f1f233e228a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
-                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/54e10d44fc1a84e2598d26f70d4f6f1f233e228a",
+                "reference": "54e10d44fc1a84e2598d26f70d4f6f1f233e228a",
                 "shasum": ""
             },
             "require": {
@@ -3323,7 +3325,7 @@
                 "php": "^7.4 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.2",
                 "phpdocumentor/type-resolver": "^1.7",
-                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "phpstan/phpdoc-parser": "^1.7",
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
@@ -3363,29 +3365,29 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.5.0"
             },
-            "time": "2024-12-07T09:39:29+00:00"
+            "time": "2024-11-04T21:26:31+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.10.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
+                "reference": "1fb5ba8d045f5dd984ebded5b1cc66f29459422d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/1fb5ba8d045f5dd984ebded5b1cc66f29459422d",
+                "reference": "1fb5ba8d045f5dd984ebded5b1cc66f29459422d",
                 "shasum": ""
             },
             "require": {
                 "doctrine/deprecations": "^1.0",
                 "php": "^7.3 || ^8.0",
                 "phpdocumentor/reflection-common": "^2.0",
-                "phpstan/phpdoc-parser": "^1.18|^2.0"
+                "phpstan/phpdoc-parser": "^1.18"
             },
             "require-dev": {
                 "ext-tokenizer": "*",
@@ -3421,33 +3423,32 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.9.0"
             },
-            "time": "2024-11-09T15:12:26+00:00"
+            "time": "2024-11-03T20:11:34+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.20.0",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "a0165c648cab6a80311c74ffc708a07bb53ecc93"
+                "reference": "67a759e7d8746d501c41536ba40cd9c0a07d6a87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/a0165c648cab6a80311c74ffc708a07bb53ecc93",
-                "reference": "a0165c648cab6a80311c74ffc708a07bb53ecc93",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/67a759e7d8746d501c41536ba40cd9c0a07d6a87",
+                "reference": "67a759e7d8746d501c41536ba40cd9c0a07d6a87",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2 || ^2.0",
-                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.* || 8.4.*",
+                "php": "^7.2 || 8.0.* || 8.1.* || 8.2.* || 8.3.*",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0 || ^5.0 || ^6.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0 || ^5.0 || ^6.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.40",
                 "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpstan/phpstan": "^1.9",
                 "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0"
@@ -3491,9 +3492,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/v1.20.0"
+                "source": "https://github.com/phpspec/prophecy/tree/v1.19.0"
             },
-            "time": "2024-11-19T13:12:41+00:00"
+            "time": "2024-02-29T11:52:51+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -4782,16 +4783,16 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.21",
+            "version": "v2.11.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "eb2b351927098c24860daa7484e290d3eed693be"
+                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/eb2b351927098c24860daa7484e290d3eed693be",
-                "reference": "eb2b351927098c24860daa7484e290d3eed693be",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
+                "reference": "bc8d7e30e2005bce5c59018b7cdb08e9fb45c0d1",
                 "shasum": ""
             },
             "require": {
@@ -4802,9 +4803,9 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
                 "phpcsstandards/phpcsdevcs": "^1.1",
                 "phpstan/phpstan": "^1.7",
-                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0 || ^10.5.32 || ^11.3.3",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
                 "sirbrillig/phpcs-import-detection": "^1.1",
-                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0"
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -4836,7 +4837,7 @@
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2024-12-02T16:37:49+00:00"
+            "time": "2024-06-26T20:08:34+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -4905,16 +4906,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.1",
+            "version": "3.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87"
+                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
-                "reference": "19473c30efe4f7b3cd42522d0b2e6e7f243c6f87",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/62d32998e820bddc40f99f8251958aed187a5c9c",
+                "reference": "62d32998e820bddc40f99f8251958aed187a5c9c",
                 "shasum": ""
             },
             "require": {
@@ -4981,7 +4982,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-11-16T12:02:36+00:00"
+            "time": "2024-09-18T10:38:58+00:00"
         },
         {
             "name": "stellarwp/coding-standards",
@@ -5268,16 +5269,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v2.5.4",
+            "version": "v2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918"
+                "reference": "80d075412b557d41002320b96a096ca65aa2c98d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/605389f2a7e5625f273b53960dc46aeaf9c62918",
-                "reference": "605389f2a7e5625f273b53960dc46aeaf9c62918",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/80d075412b557d41002320b96a096ca65aa2c98d",
+                "reference": "80d075412b557d41002320b96a096ca65aa2c98d",
                 "shasum": ""
             },
             "require": {
@@ -5315,7 +5316,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.4"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.5.3"
             },
             "funding": [
                 {
@@ -5331,7 +5332,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2023-01-24T14:02:46+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -6175,16 +6176,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.5.4",
+            "version": "v2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300"
+                "reference": "a2329596ddc8fd568900e3fc76cba42489ecc7f3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f37b419f7aea2e9abf10abd261832cace12e3300",
-                "reference": "f37b419f7aea2e9abf10abd261832cace12e3300",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a2329596ddc8fd568900e3fc76cba42489ecc7f3",
+                "reference": "a2329596ddc8fd568900e3fc76cba42489ecc7f3",
                 "shasum": ""
             },
             "require": {
@@ -6238,7 +6239,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v2.5.4"
+                "source": "https://github.com/symfony/service-contracts/tree/v2.5.3"
             },
             "funding": [
                 {
@@ -6254,7 +6255,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2023-04-21T15:04:16+00:00"
         },
         {
             "name": "symfony/translation",
@@ -6353,16 +6354,16 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v2.5.4",
+            "version": "v2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "450d4172653f38818657022252f9d81be89ee9a8"
+                "reference": "b0073a77ac0b7ea55131020e87b1e3af540f4664"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/450d4172653f38818657022252f9d81be89ee9a8",
-                "reference": "450d4172653f38818657022252f9d81be89ee9a8",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/b0073a77ac0b7ea55131020e87b1e3af540f4664",
+                "reference": "b0073a77ac0b7ea55131020e87b1e3af540f4664",
                 "shasum": ""
             },
             "require": {
@@ -6411,7 +6412,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.4"
+                "source": "https://github.com/symfony/translation-contracts/tree/v2.5.3"
             },
             "funding": [
                 {
@@ -6427,7 +6428,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:11:13+00:00"
+            "time": "2024-01-23T13:51:25+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/composer.lock
+++ b/composer.lock
@@ -782,16 +782,16 @@
         },
         {
             "name": "stellarwp/uplink",
-            "version": "v2.2.1",
+            "version": "v2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/uplink.git",
-                "reference": "57eb6264994662cb8da368cc3a9227ec716edc70"
+                "reference": "5bc1f115efe629dd4244bff08809aea45ed9d8f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/uplink/zipball/57eb6264994662cb8da368cc3a9227ec716edc70",
-                "reference": "57eb6264994662cb8da368cc3a9227ec716edc70",
+                "url": "https://api.github.com/repos/stellarwp/uplink/zipball/5bc1f115efe629dd4244bff08809aea45ed9d8f1",
+                "reference": "5bc1f115efe629dd4244bff08809aea45ed9d8f1",
                 "shasum": ""
             },
             "require": {
@@ -843,9 +843,9 @@
             "description": "A library that integrates a WordPress product with the StellarWP Licensing system.",
             "support": {
                 "issues": "https://github.com/stellarwp/uplink/issues",
-                "source": "https://github.com/stellarwp/uplink/tree/v2.2.1"
+                "source": "https://github.com/stellarwp/uplink/tree/v2.2.2"
             },
-            "time": "2024-09-30T22:46:40+00:00"
+            "time": "2024-12-05T19:13:16+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -2098,7 +2098,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * Checks if a valid Uplink license exists.
 		 *
 		 * This method confirms if the 'stellarwp/uplink/{prefix}/connected' action
-		 * has been fired, which indicates a valid license.
+		 * has been fired, which indicates at least one valid license.
+		 *
+		 * @since TBD
 		 *
 		 * @return bool True if at least one license is valid, false otherwise.
 		 */

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -274,24 +274,21 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 
 			// Transient is missing or unexpected, revalidate licenses.
 			foreach ( self::$instances as $checker ) {
+				// First, check if the key is already valid.
 				if ( $checker->is_key_valid() ) {
 					// Found a valid license; update transient and return true.
 					set_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, $valid_slug, HOUR_IN_SECONDS );
 					return true;
 				}
-			}
 
-			// Revalidate if we haven't found a valid license yet.
-			foreach ( self::$instances as $checker ) {
+				// If not valid, attempt to revalidate the license.
 				$license  = get_option( $checker->get_license_option_key() );
 				$response = $checker->validate_key( $license );
-				// Is it valid?
 				if ( ! empty( $response['status'] ) ) {
 					set_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, $valid_slug, HOUR_IN_SECONDS );
 					return true;
 				}
 			}
-
 
 			// No valid licenses found; mark as invalid and return false.
 			set_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, $invalid_slug, HOUR_IN_SECONDS );

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -10,10 +10,9 @@
 
 use TEC\Common\StellarWP\Uplink\Resources\Plugin;
 use TEC\Common\StellarWP\Uplink\Config;
+use Tribe\Admin\Pages;
 
 use function TEC\Common\StellarWP\Uplink\get_resource;
-use function TEC\Common\StellarWP\Uplink\get_plugins as uplink_get_plugins;
-
 
 // Don't load directly.
 if ( ! defined( 'ABSPATH' ) ) {
@@ -404,7 +403,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			add_action( 'admin_enqueue_scripts', [ $this, 'maybe_display_json_error_on_plugins_page' ], 1 );
 			add_action( 'admin_init', [ $this, 'general_notifications' ] );
 
-			add_action( 'init', [ $this, 'monitor_uplink_actions' ], 1000 );
+			add_action( 'admin_init', [ $this, 'monitor_uplink_actions' ], 1000 );
 
 			// Package name.
 			add_filter( 'upgrader_pre_download', [ Tribe__PUE__Package_Handler::instance(), 'filter_upgrader_pre_download' ], 5, 3 );
@@ -2105,8 +2104,20 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		public function monitor_uplink_actions() {
 			static $has_run = false;
 
-			// Check if the method has already run.
 			if ( $has_run ) {
+				return;
+			}
+
+			if ( ! is_admin() ) {
+				return;
+			}
+
+			// Check that we are on an admin page.
+			/** @var Tribe\Admin\Pages */
+			$admin_pages = tribe( 'admin.pages' );
+			$admin_page  = $admin_pages->get_current_page();
+
+			if ( empty( $admin_page ) ) {
 				return;
 			}
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -270,6 +270,11 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		protected static function update_any_license_valid_transient( string $plugin_slug, bool $status ): void {
 			$transient_value = get_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY ) ?: [ 'plugins' => [] ];
 
+			// If the transient value is false or a string, initialize it as an empty array with the 'plugins' key.
+			if ( ! is_array( $transient_value ) ) {
+				$transient_value = [ 'plugins' => [] ];
+			}
+
 			$transient_value['plugins'][ $plugin_slug ] = $status;
 
 			set_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, $transient_value, HOUR_IN_SECONDS );
@@ -286,7 +291,12 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 */
 		public static function is_any_license_valid(): bool {
 			$transient_value = get_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY );
-			$transient_value = $transient_value !== false ? $transient_value : [];
+			$transient_value = false !== $transient_value ? $transient_value : [];
+
+			// If the transient value is a string, convert it to an empty array.
+			if ( ! is_array( $transient_value ) ) {
+				$transient_value = [];
+			}
 
 			// Check if the transient has a valid license.
 			if ( self::has_valid_license_in_transient( $transient_value ) ) {

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -358,6 +358,8 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 
 			if ( ! tribe_is_truthy( $valid ) ) {
 				delete_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY );
+			} else {
+				set_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, $status, HOUR_IN_SECONDS );
 			}
 		}
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -404,7 +404,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			add_action( 'admin_enqueue_scripts', [ $this, 'maybe_display_json_error_on_plugins_page' ], 1 );
 			add_action( 'admin_init', [ $this, 'general_notifications' ] );
 
-			add_action( 'wp_loaded', [ $this, 'monitor_uplink_actions' ] );
+			add_action( 'init', [ $this, 'monitor_uplink_actions' ], 1000 );
 
 			// Package name.
 			add_filter( 'upgrader_pre_download', [ Tribe__PUE__Package_Handler::instance(), 'filter_upgrader_pre_download' ], 5, 3 );
@@ -2109,26 +2109,16 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			if ( $has_run ) {
 				return;
 			}
-			$plugins = uplink_get_plugins();
 
-			// Loop through plugin resources and add actions.
-			foreach ( $plugins as $resource ) {
-				if ( ! $resource instanceof Plugin ) {
-					continue; // Skip non-Plugin resources.
-				}
-
-				$slug = $resource->get_slug();
-
-				// Hook into the existing 'connected' action for the specific plugin slug.
-				add_action(
-					'stellarwp/uplink/' . Config::get_hook_prefix() . '/' . $slug . '/connected',
-					function () use ( $slug ) {
-						set_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, 'valid', HOUR_IN_SECONDS );
-					},
-					10,
-					1
-				);
-			}
+			// Hook into the existing 'connected' action for the specific plugin slug.
+			add_action(
+				'stellarwp/uplink/' . Config::get_hook_prefix() . '/connected',
+				function () {
+					set_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, 'valid', HOUR_IN_SECONDS );
+				},
+				10,
+				1
+			);
 
 			$has_run = true;
 		}

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -2127,12 +2127,14 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		}
 
 		/**
-		 * Monitors Uplink and hooks into the plugin connected action.
+		 * Hooks into the Uplink plugin's 'connected' action for the current plugin.
 		 *
-		 * This method loops through the registered Uplink plugins and hooks into the
-		 * 'stellarwp/uplink/{slug}/connected' action for each plugin resource.
+		 * This method registers a callback for the 'stellarwp/uplink/{slug}/connected' action.
+		 * When the action is triggered, it updates the license validity transient for the plugin.
 		 *
 		 * @since TBD
+		 *
+		 * @return void
 		 */
 		public static function monitor_uplink_actions(): void {
 			// Hook into the existing 'connected' action for the specific plugin slug.

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -8,9 +8,7 @@
  * @todo switch all plugins over to use the PUE utilities here in Commons
  */
 
-use TEC\Common\StellarWP\Uplink\Resources\Plugin;
 use TEC\Common\StellarWP\Uplink\Config;
-use Tribe\Admin\Pages;
 
 use function TEC\Common\StellarWP\Uplink\get_resource;
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -351,7 +351,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			// @todo remove transient in a major feature release where we release all plugins.
 			set_transient( $this->pue_key_status_transient_name, $status, $this->check_period * HOUR_IN_SECONDS );
 
-			delete_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY );
+			if ( ! tribe_is_truthy( $valid ) ) {
+				delete_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY );
+			}
 		}
 
 		/**

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -251,7 +251,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 *
 		 * @return bool True if a valid license is found, otherwise false.
 		 */
-		protected static function has_valid_license_in_transient( ?array $transient_value ): bool {
+		protected static function transient_contains_valid_license( ?array $transient_value ): bool {
 			if ( ! is_array( $transient_value ) || ! isset( $transient_value['plugins'] ) ) {
 				return false;
 			}
@@ -299,7 +299,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			}
 
 			// Check if the transient has a valid license.
-			if ( self::has_valid_license_in_transient( $transient_value ) ) {
+			if ( self::transient_contains_valid_license( $transient_value ) ) {
 				return true;
 			}
 
@@ -410,7 +410,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		/**
 		 * Install the hooks required to run periodic update checks and inject update info
 		 * into WP data structures.
-		 * Also other hooks related to the automatic updates (such as checking agains API and what not (@from Darren)
+		 * Also other hooks related to the automatic updates (such as checking against API and what not (@from Darren)
 		 */
 		public function hooks() {
 			// Override requests for plugin information.
@@ -2138,12 +2138,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			// Hook into the existing 'connected' action for the specific plugin slug.
 			add_action(
 				'stellarwp/uplink/' . Config::get_hook_prefix() . '/connected',
-				function ($plugin) {
-					//set_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, 'valid', HOUR_IN_SECONDS );
+				function ( $plugin ) {
 					self::update_any_license_valid_transient( $plugin->get_slug(), true );
 				},
-				10,
-				1
 			);
 		}
 	}

--- a/tests/integration/Tribe/PUE/Checker_Test.php
+++ b/tests/integration/Tribe/PUE/Checker_Test.php
@@ -2,17 +2,26 @@
 
 namespace Tribe\PUE;
 
-use TEC\Common\Tests\Licensing\PUE_Service_Mock;
-use Tribe__PUE__Checker as PUE_Checker;
-use Tribe__Main;
+use Closure;
+use Codeception\TestCase\WPTestCase;
+use Generator;
 use TEC\Common\StellarWP\Uplink\Register;
+use TEC\Common\Tests\Licensing\PUE_Service_Mock;
+use Tribe__Main;
+use Tribe__PUE__Checker as PUE_Checker;
+
 use function TEC\Common\StellarWP\Uplink\get_resource;
 
-class Checker_Test extends \Codeception\TestCase\WPTestCase {
+class Checker_Test extends WPTestCase {
 	/**
 	 * @var PUE_Service_Mock
 	 */
 	private $pue_service_mock;
+
+	/**
+	 * @var array
+	 */
+	protected $temp_pue_plugin = [];
 
 	/**
 	 * @before
@@ -28,9 +37,9 @@ class Checker_Test extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function should_not_update_license_key_if_replacement_key_not_provided(): void {
 		// Ensure there is no key set.
-		delete_option( 'pue_install_key_test_plugin');
+		delete_option( 'pue_install_key_test_plugin' );
 		$validated_key = md5( microtime() );
-		$body = $this->pue_service_mock->get_validate_key_success_body();
+		$body          = $this->pue_service_mock->get_validate_key_success_body();
 		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
 		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
 
@@ -47,12 +56,12 @@ class Checker_Test extends \Codeception\TestCase\WPTestCase {
 	 */
 	public function should_not_update_license_key_if_replacement_key_is_empty(): void {
 		// Ensure there is no key set.
-		delete_option( 'pue_install_key_test_plugin');
+		delete_option( 'pue_install_key_test_plugin' );
 		$validated_key = md5( microtime() );
-		$body = $this->pue_service_mock->get_validate_key_success_body();
+		$body          = $this->pue_service_mock->get_validate_key_success_body();
 		// Add an empty replacement key to the response body.
 		$body['results'][0]['replacement_key'] = '';
-		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$mock_response                         = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
 		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
 
 		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
@@ -69,13 +78,13 @@ class Checker_Test extends \Codeception\TestCase\WPTestCase {
 	public function should_update_license_key_if_replacement_key_provided_and_key_not_previously_set(): void {
 		$validated_key = md5( microtime() );
 		// Ensure there is no key set.
-		delete_option( 'pue_install_key_test_plugin');
+		delete_option( 'pue_install_key_test_plugin' );
 		// Set the response mock to provide a replacement key.
 		$replacement_key = '2222222222222222222222222222222222222222';
-		$body = $this->pue_service_mock->get_validate_key_success_body();
+		$body            = $this->pue_service_mock->get_validate_key_success_body();
 		// Add a replacement key to the response body.
 		$body['results'][0]['replacement_key'] = $replacement_key;
-		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$mock_response                         = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
 		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
 
 		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
@@ -95,10 +104,10 @@ class Checker_Test extends \Codeception\TestCase\WPTestCase {
 		update_option( 'pue_install_key_test_plugin', $original_key );
 		// Set the response mock to provide a replacement key.
 		$replacement_key = '2222222222222222222222222222222222222222';
-		$body = $this->pue_service_mock->get_validate_key_success_body();
+		$body            = $this->pue_service_mock->get_validate_key_success_body();
 		// Add a replacement key to the response body.
 		$body['results'][0]['replacement_key'] = $replacement_key;
-		$mock_response = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
+		$mock_response                         = $this->pue_service_mock->make_response( 200, $body, 'application/json' );
 		$this->pue_service_mock->will_reply_to_request( 'POST', '/plugins/v2/license/validate', $mock_response );
 
 		$pue_instance = new PUE_Checker( 'deprecated', 'test-plugin', [], 'test-plugin/test-plugin.php' );
@@ -129,126 +138,119 @@ class Checker_Test extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $key, $pue_instance->get_key() );
 	}
 
-	public function test_replacemnt_key_update_in_multisite_context(): void {
+	public function test_replacemnt_key_update_in_multisite_context(): void {}
 
+	/**
+	 * It should validate licenses correctly across various scenarios.
+	 *
+	 * @test
+	 * @dataProvider license_validation_data_provider
+	 */
+	public function should_is_any_license_valid_return_correctly( Closure $setup_closure, $expected_result, $message ): void {
+		// Clean up before each scenario.
+		$this->clean_up_test_options();
+
+		// Run the setup closure to configure the test scenario.
+		$setup_closure();
+
+		// Assert the expected outcome.
+		$this->assertEquals( $expected_result, PUE_Checker::is_any_license_valid(), $message );
 	}
 
 	/**
-	 * It should correctly determine license validity across different scenarios.
-	 *
-	 * @test
+	 * Cleans up transient and options dynamically based on plugins in $temp_pue_plugin.
 	 */
-	public function should_correctly_determine_is_any_license_valid_across_scenarios(): void {
-		// Clean up before starting.
+	private function clean_up_test_options(): void {
+		// Clear transient.
 		delete_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY );
-		delete_option( 'pue_install_key_test_plugin_1' );
-		delete_option( 'pue_install_key_test_plugin_2' );
 
-		// Scenario 1: Initially unlicensed.
-		$this->assertFalse( PUE_Checker::is_any_license_valid(), 'Initially unlicensed should return invalid.' );
+		// Clear dynamic options based on the plugins.
+		foreach ( $this->temp_pue_plugin as $plugin_name ) {
+			delete_option( "pue_install_key_{$plugin_name}" );
+		}
 
-		// Scenario 2: Initially unlicensed, then license a plugin.
-		$validated_key_1 = md5( microtime() );
-		update_option( 'pue_install_key_test_plugin_1', $validated_key_1 );
-		$pue_instance_1 = new PUE_Checker( 'deprecated', 'test-plugin-1', [], 'test-plugin-1/test-plugin.php' );
-		$pue_instance_1->set_key_status( 1 ); // Set valid status.
-		$this->assertTrue( PUE_Checker::is_any_license_valid(), 'Licensing a plugin should make is_any_license_valid return valid.' );
-
-		// Scenario 3: Initially licensed.
-		delete_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY ); // Reset transient.
-		$this->assertTrue( PUE_Checker::is_any_license_valid(), 'Initially licensed should return valid.' );
-
-		// Scenario 4: Initially unlicensed, license a plugin, then unlicense.
-		delete_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY ); // Reset transient.
-		delete_option( 'pue_install_key_test_plugin_1' );
-		$pue_instance_1->set_key_status( 0 ); // Set invalid status.
-		$this->assertFalse( PUE_Checker::is_any_license_valid(), 'Initially unlicensed should return invalid.' );
-
-		// Re-license the plugin.
-		update_option( 'pue_install_key_test_plugin_1', $validated_key_1 );
-		$pue_instance_1->set_key_status( 1 ); // Set valid status.
-		$this->assertTrue( PUE_Checker::is_any_license_valid(), 'Licensing the plugin again should make is_any_license_valid return valid.' );
-
-		// Unlicense the plugin.
-		$pue_instance_1->set_key_status( 0 ); // Set invalid status.
-		$this->assertFalse( PUE_Checker::is_any_license_valid(), 'Unlicensing the only valid plugin should make is_any_license_valid return invalid.' );
+		// Reset the array to ensure no carryover between tests.
+		$this->temp_pue_plugin = [];
 	}
 
 	/**
-	 * It should handle edge cases for multiple licenses and transient behavior.
+	 * Data provider for license validation test scenarios.
 	 *
-	 * @test
+	 * @return Generator
 	 */
-	public function should_handle_edge_cases_for_is_any_license_valid_and_transient_behavior(): void {
-		// Clean up before starting.
-		delete_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY );
-		delete_option( 'pue_install_key_test_plugin_1' );
-		delete_option( 'pue_install_key_test_plugin_2' );
+	public function license_validation_data_provider(): Generator {
+		yield 'initially_unlicensed' => [
+			function () {
+				// No setup needed, all licenses are invalid initially.
+			},
+			false,
+			'Initially unlicensed should return invalid.',
+		];
 
-		// Scenario 1: Multiple plugins, one licensed, one unlicensed.
-		$validated_key_1 = md5( microtime() );
-		update_option( 'pue_install_key_test_plugin_1', $validated_key_1 );
-		$pue_instance_1 = new PUE_Checker( 'deprecated', 'test-plugin-1', [], 'test-plugin-1/test-plugin.php' );
-		$pue_instance_1->set_key_status( 1 ); // Set valid status for first plugin.
+		yield 'license_a_plugin' => [
+			function () {
+				$validated_key           = md5( microtime() );
+				$plugin_name             = 'test-plugin-1';
+				$this->temp_pue_plugin[] = $plugin_name;
+				update_option( "pue_install_key_{$plugin_name}", $validated_key );
+				$pue_instance = new PUE_Checker( 'deprecated', $plugin_name, [], "{$plugin_name}/{$plugin_name}.php" );
+				$pue_instance->set_key_status( 1 ); // Set valid status.
+			},
+			true,
+			'Licensing a plugin should make is_any_license_valid return valid.',
+		];
 
-		$validated_key_2 = md5( microtime() );
-		update_option( 'pue_install_key_test_plugin_2', $validated_key_2 );
-		$pue_instance_2 = new PUE_Checker( 'deprecated', 'test-plugin-2', [], 'test-plugin-2/test-plugin.php' );
-		$pue_instance_2->set_key_status( 0 ); // Set invalid status for second plugin.
+		yield 'transient_deleted' => [
+			function () {
+				$validated_key           = md5( microtime() );
+				$plugin_name             = 'test-plugin-1';
+				$this->temp_pue_plugin[] = $plugin_name;
+				update_option( "pue_install_key_{$plugin_name}", $validated_key );
+				$pue_instance = new PUE_Checker( 'deprecated', $plugin_name, [], "{$plugin_name}/{$plugin_name}.php" );
+				$pue_instance->set_key_status( 1 ); // Set valid status.
+				delete_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY ); // Simulate transient deletion.
+			},
+			true,
+			'Deleting transient should trigger revalidation and return valid if at least one license is valid.',
+		];
 
-		$this->assertTrue( PUE_Checker::is_any_license_valid(), 'At least one valid license should make is_any_license_valid return valid.' );
+		yield 'multiple_plugins_with_even_valid' => [
+			function () {
+				for ( $i = 1; $i <= 10; $i++ ) {
+					$validated_key           = md5( microtime() . $i );
+					$plugin_name             = "test-plugin-{$i}";
+					$this->temp_pue_plugin[] = $plugin_name;
+					update_option( "pue_install_key_{$plugin_name}", $validated_key );
 
-		// Scenario 2: All plugins unlicensed.
-		$pue_instance_1->set_key_status( 0 ); // Unlicense first plugin.
-		$this->assertFalse( PUE_Checker::is_any_license_valid(), 'When all plugins are unlicensed, is_any_license_valid should return invalid.' );
+					$pue_instance = new PUE_Checker( 'deprecated', $plugin_name, [], "{$plugin_name}/{$plugin_name}.php" );
+					if ( 0 === $i % 2 ) {
+						// Even plugins are valid.
+						$pue_instance->set_key_status( 1 );
+					} else {
+						// Odd plugins are invalid.
+						$pue_instance->set_key_status( 0 );
+					}
+				}
+			},
+			true,
+			'At least one valid license (even-numbered plugins) should make is_any_license_valid return valid.',
+		];
 
-		// Scenario 3: Transient manually deleted.
-		delete_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY );
-		$this->assertFalse( PUE_Checker::is_any_license_valid(), 'Deleting transient should trigger revalidation and return invalid if all plugins are unlicensed.' );
+		yield 'all_plugins_invalid' => [
+			function () {
+				for ( $i = 1; $i <= 10; $i++ ) {
+					$validated_key           = md5( microtime() . $i );
+					$plugin_name             = "test-plugin-{$i}";
+					$this->temp_pue_plugin[] = $plugin_name;
+					update_option( "pue_install_key_{$plugin_name}", $validated_key );
 
-		// Scenario 4: Invalid transient value.
-		set_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, 'unknown', HOUR_IN_SECONDS );
-		$this->assertFalse( PUE_Checker::is_any_license_valid(), 'An invalid transient value should trigger revalidation and return invalid if no licenses are valid.' );
-
-		// Scenario 5: Revalidate licenses after invalid transient.
-		$pue_instance_1->set_key_status( 1 ); // License the first plugin.
-		$this->assertTrue( PUE_Checker::is_any_license_valid(), 'Revalidating after an invalid transient should return valid if at least one license is valid.' );
+					$pue_instance = new PUE_Checker( 'deprecated', $plugin_name, [], "{$plugin_name}/{$plugin_name}.php" );
+					// All plugins are set as invalid.
+					$pue_instance->set_key_status( 0 );
+				}
+			},
+			false,
+			'When all plugins are invalid, is_any_license_valid should return false.',
+		];
 	}
-
-	/**
-	 * It should validate licenses correctly across multiple plugins
-	 *
-	 * @test
-	 */
-	public function should_validate_is_any_license_valid_across_multiple_plugins(): void {
-		// Clean up any existing transient or options.
-		delete_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY );
-		delete_option( 'pue_install_key_test_plugin_1' );
-		delete_option( 'pue_install_key_test_plugin_2' );
-
-		// Step 1: No license, validate `is_any_license_valid` is false.
-		$is_valid = PUE_Checker::is_any_license_valid();
-		$this->assertFalse( $is_valid, 'Initially, no licenses should be valid.' );
-
-		// Step 2: Install a plugin with a valid license.
-		$validated_key_1 = md5( microtime() );
-		update_option( 'pue_install_key_test_plugin_1', $validated_key_1 );
-		$pue_instance_1 = new PUE_Checker( 'deprecated', 'test-plugin-1', [], 'test-plugin-1/test-plugin.php' );
-		$pue_instance_1->set_key_status( 1 ); // Set valid status.
-
-		// Validate that `is_any_license_valid` is true.
-		$is_valid = PUE_Checker::is_any_license_valid();
-		$this->assertTrue( $is_valid, 'After licensing one plugin, `is_any_license_valid` should return true.' );
-
-		// Step 3: Install another plugin with an invalid license.
-		$validated_key_2 = md5( microtime() );
-		update_option( 'pue_install_key_test_plugin_2', $validated_key_2 );
-		$pue_instance_2 = new PUE_Checker( 'deprecated', 'test-plugin-2', [], 'test-plugin-2/test-plugin.php' );
-		$pue_instance_2->set_key_status( 0 ); // Set invalid status.
-
-		// Validate that `is_any_license_valid` is still true.
-		$is_valid = PUE_Checker::is_any_license_valid();
-		$this->assertTrue( $is_valid, 'After adding a plugin with an invalid license, `is_any_license_valid` should still return true as one plugin is valid.' );
-	}
-
 }

--- a/tests/integration/Tribe/PUE/Checker_Test.php
+++ b/tests/integration/Tribe/PUE/Checker_Test.php
@@ -9,6 +9,9 @@ use TEC\Common\StellarWP\Uplink\Register;
 use TEC\Common\Tests\Licensing\PUE_Service_Mock;
 use Tribe__Main;
 use Tribe__PUE__Checker as PUE_Checker;
+use TEC\Common\StellarWP\Uplink\Auth\Token\Contracts\Token_Manager;
+use TEC\Common\StellarWP\Uplink\Resources\Collection;
+use TEC\Common\StellarWP\Uplink\Storage\Contracts\Storage;
 
 use function TEC\Common\StellarWP\Uplink\get_resource;
 
@@ -251,6 +254,25 @@ class Checker_Test extends WPTestCase {
 			},
 			false,
 			'When all plugins are invalid, is_any_license_valid should return false.',
+		];
+
+		yield 'Testing Uplink' => [
+			function () {
+				$key = 'license-key-for-test-plugin';
+				$collection    = tribe( Collection::class );
+				$resource      = $collection->get( 'test-plugin' );
+				$token_manager = tribe( Token_Manager::class );
+				$storage       = tribe( Storage::class );
+				$resource->set_license_key( $key );
+				$this->assertEquals( $key, $resource->get_license_key() );
+				$storage->set(
+					'stellarwp_auth_url_tec_seating',
+					'https://my.theeventscalendar.com/account-auth/?uplink_callback=aHR0cHM6Ly90ZWNkZXYubG5kby5zaXRlL3dwLWFkbWluL2FkbWluLnBocD9wYWdlPXRlYy10aWNrZXRzLXNldHRpbmdzJnRhYj1saWNlbnNlcyZ1cGxpbmtfc2x1Zz10ZWMtc2VhdGluZyZfdXBsaW5rX25vbmNlPU1zb3ptQlZJVUp4aFh6c0Q%3D'
+				);
+				$token_manager->store( $key, $resource );
+			},
+			true,
+			'Testing uplink',
 		];
 	}
 }

--- a/tests/integration/Tribe/PUE/Checker_Test.php
+++ b/tests/integration/Tribe/PUE/Checker_Test.php
@@ -222,6 +222,38 @@ class Checker_Test extends WPTestCase {
 			'Licensing a plugin should make is_any_license_valid return valid.',
 		];
 
+		yield 'license_a_plugin_old_transient_valid' => [
+			function () {
+				$plugin_names   = [];
+				$validated_key  = md5( microtime() );
+				$plugin_name    = 'test-plugin-1';
+				$plugin_names[] = $plugin_name;
+				update_option( "pue_install_key_{$plugin_name}", $validated_key );
+				$pue_instance = new PUE_Checker( 'deprecated', $plugin_name, [], "{$plugin_name}/{$plugin_name}.php" );
+				$pue_instance->set_key_status( 1 ); // Set valid status.
+				set_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, 'valid', HOUR_IN_SECONDS );
+				return $plugin_names;
+			},
+			true,
+			'Licensing a plugin should make is_any_license_valid return valid.',
+		];
+
+		yield 'invalid_license_old_transient' => [
+			function () {
+				$plugin_names   = [];
+				$validated_key  = md5( microtime() );
+				$plugin_name    = 'test-plugin-1';
+				$plugin_names[] = $plugin_name;
+				update_option( "pue_install_key_{$plugin_name}", $validated_key );
+				$pue_instance = new PUE_Checker( 'deprecated', $plugin_name, [], "{$plugin_name}/{$plugin_name}.php" );
+				$pue_instance->set_key_status( 0 ); // Set valid status.
+				set_transient( PUE_Checker::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, 'invalid', HOUR_IN_SECONDS );
+				return $plugin_names;
+			},
+			false,
+			'Licensing a plugin should make is_any_license_valid return valid.',
+		];
+
 		yield 'transient_deleted' => [
 			function () use ( &$plugin_names ) {
 				$plugin_names   = [];

--- a/tests/integration/Tribe/PUE/Checker_Test.php
+++ b/tests/integration/Tribe/PUE/Checker_Test.php
@@ -384,7 +384,7 @@ class Checker_Test extends WPTestCase {
 		$this->assertSame( $token, $this->token_manager->get( $plugin ) );
 
 		// Verify that the general 'connected' action fires.
-		$this->assertEquals( 1, did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/connected' ) );
+		$this->assertEquals( 1, did_action( 'stellarwp/uplink/' . Config::get_hook_prefix() . '/connected' ) ,'Hook should only run once');
 
 		return $token;
 	}

--- a/tests/integration/Tribe/PUE/Checker_Test.php
+++ b/tests/integration/Tribe/PUE/Checker_Test.php
@@ -146,8 +146,6 @@ class Checker_Test extends WPTestCase {
 		$this->assertEquals( $key, $pue_instance->get_key() );
 	}
 
-	public function test_replacemnt_key_update_in_multisite_context(): void {}
-
 	/**
 	 * It should validate licenses correctly across various scenarios.
 	 *


### PR DESCRIPTION
### 🎫 Ticket

[TECTRIA-549]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

When installing a free plugin and going to Help Hub `is_any_license_valid` would cache that there were no valid licenses. Once installing a valid license `is_any_license_valid` would continue to return false.

By deleting the transient when we check a plugins status we can confirm that `is_any_license_valid` always gives us the most up to date value.

We also took into account Uplink, Dimi introduced a new hook that will fire when a plugin is licensed.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.

[TECTRIA-549]: https://stellarwp.atlassian.net/browse/TECTRIA-549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ