### PR TITLE
Prevent fatal on integration page of ET when ECP without ETP

### DIFF
--- a/changelog/fix-fatal-when-ecp-without-etp-on-integrations-tab
+++ b/changelog/fix-fatal-when-ecp-without-etp-on-integrations-tab
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Prevent fatal on ET integration page when used with Events Pro but without Event Tickets Plus. [n/a]

--- a/changelog/fix-fatal-when-ecp-without-etp-on-integrations-tab
+++ b/changelog/fix-fatal-when-ecp-without-etp-on-integrations-tab
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Prevent fatal on ET integration page when used with Events Pro but without Event Tickets Plus. [n/a]
+Prevent fatal on ET integration page when used with Events Pro but without Event Tickets Plus. [TCMN-174]

--- a/changelog/fix-fatal-when-ecp-without-etp-on-integrations-tab-2
+++ b/changelog/fix-fatal-when-ecp-without-etp-on-integrations-tab-2
@@ -1,0 +1,4 @@
+Significance: minor
+Type: deprecated
+
+Integrations Tab registration in Event Ticket Settings from common. These will be registered from Event Tickets Plus only instead. [TCMN-174]

--- a/src/Common/Event_Automator/Admin/Tabs/Integrations.php
+++ b/src/Common/Event_Automator/Admin/Tabs/Integrations.php
@@ -2,13 +2,13 @@
 
 namespace TEC\Event_Automator\Admin\Tabs;
 
-use Tribe\Tickets\Admin\Settings as Plugin_Settings;
-
 /**
  * Class Integrations
  *
  * @since 6.0.0 Migrated to Common from Event Automator
  * @package TEC\Event_Automator\Admin\Tabs
+ *
+ * @deprecated TBD
  *
  */
 class Integrations {
@@ -17,6 +17,8 @@ class Integrations {
 	 * Slug for the tab.
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
+	 *
+	 * @deprecated TBD
 	 *
 	 * @var string
 	 */
@@ -27,29 +29,12 @@ class Integrations {
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
 	 *
+	 * @deprecated TBD
+	 *
 	 * @param string Admin page id.
 	 */
 	public function register_tab( $admin_page ) {
-		if ( ! empty( $admin_page ) && Plugin_Settings::$settings_page_id !== $admin_page ) {
-			return;
-		}
-
-		$tab_settings = [
-			'priority'  => 35,
-			'fields'    => $this->get_fields(),
-			'show_save' => true,
-		];
-
-		/**
-		 * Filter the tab settings options.
-		 *
-		 * @since 6.0.0 Migrated to Common from Event Automator
-		 *
-		 * @param array<string,mixed> Key value pairs of setting options.
-		 */
-		$tab_settings = apply_filters( 'tec_event_automator_integrations_tab_settings', $tab_settings );
-
-		new \Tribe__Settings_Tab( static::$slug, esc_html__( 'Integrations', 'tribe-common' ), $tab_settings );
+		_deprecated_function( __METHOD__, 'TBD' );
 	}
 
 	/**
@@ -57,12 +42,14 @@ class Integrations {
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
 	 *
+	 * @deprecated TBD
+	 *
 	 * @param array<string> $tabs Array of tabs IDs for the Events settings page.
 	 *
 	 * @return array<string> The filtered list of tab ids.
 	 */
 	public function register_tab_id( array $tabs ): array {
-		$tabs[] = static::$slug;
+		_deprecated_function( __METHOD__, 'TBD' );
 
 		return $tabs;
 	}
@@ -72,35 +59,13 @@ class Integrations {
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
 	 *
+	 * @deprecated TBD
+	 *
 	 * @return array<string,mixed> Key value pair for setting options.
 	 */
 	public function get_fields(): array {
-		$settings_start = [
-			'info-start' => [
-				'type' => 'html',
-				'html' => '<div class="tribe-settings-form-wrap">',
-			]
-		];
+		_deprecated_function( __METHOD__, 'TBD' );
 
-		$settings_end = [
-			'info-end' => [
-				'type' => 'html',
-				'html' => '</div>',
-			]
-		];
-
-		/**
-		 * Filters the fields in the Tickets > Settings > Integrations tab.
-		 * Utilizes the name from Event Tickets Plus as this is a replacement if that plugin is deactivated.
-		 *
-		 * @since 6.0.0 Migrated to Common from Event Automator
-		 *
-		 * @param array<string,array> $fields The current fields.
-		 *
-		 * @return array<string,array> The fields, as updated by the settings.
-		 */
-		$fields = apply_filters( 'tec_tickets_plus_integrations_tab_fields', [] );
-
-		return array_merge( $settings_start, $fields, $settings_end );
+		return [];
 	}
 }

--- a/src/Common/Event_Automator/Admin/Tabs/Tabs_Provider.php
+++ b/src/Common/Event_Automator/Admin/Tabs/Tabs_Provider.php
@@ -26,7 +26,7 @@ class Tabs_Provider extends Service_Provider {
 		}
 
 		// If Event Tickets Plus is Active, do not add the Integrations tab as it will do it.
-		if ( ! class_exists('TEC\Tickets_Plus\Admin\Tabs\Provider', false ) ) {
+		if ( ! class_exists( 'TEC\Tickets_Plus\Admin\Tabs\Provider', false ) ) {
 			return;
 		}
 

--- a/src/Common/Event_Automator/Admin/Tabs/Tabs_Provider.php
+++ b/src/Common/Event_Automator/Admin/Tabs/Tabs_Provider.php
@@ -10,6 +10,8 @@ use TEC\Common\Contracts\Service_Provider;
  * @package TEC\Event_Automator\Admin\Tabs
  *
  * @since 6.0.0 Migrated to Common from Event Automator
+ *
+ * @deprecated TBD
  */
 class Tabs_Provider extends Service_Provider {
 
@@ -17,40 +19,33 @@ class Tabs_Provider extends Service_Provider {
 	 * Register the provider.
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
+	 *
+	 * @deprecated TBD
 	 */
 	public function register() {
-
-		// If Plugin Settings does not exist, return as there is no settings tab to add.
-		if ( ! class_exists('Tribe\Tickets\Admin\Settings', false ) ) {
-			return;
-		}
-
-		// If Event Tickets Plus is Active, do not add the Integrations tab as it will do it.
-		if ( ! class_exists( 'TEC\Tickets_Plus\Admin\Tabs\Provider', false ) ) {
-			return;
-		}
-
-		// Hook actions and filters.
-		$this->add_actions();
-		$this->add_filters();
+		_deprecated_function( __METHOD__, 'TBD' );
 	}
 
 	/**
 	 * Add the action hooks.
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
+	 *
+	 * @deprecated TBD
 	 */
 	public function add_actions() {
-		add_action( 'tribe_settings_do_tabs', [ $this, 'add_tabs' ] );
+		_deprecated_function( __METHOD__, 'TBD' );
 	}
 
 	/**
 	 * Add fhe filter hooks.
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
+	 *
+	 * @deprecated TBD
 	 */
 	public function add_filters() {
-		add_filter( 'tec_tickets_settings_tabs_ids', [ $this, 'filter_include_integrations_tab_id' ] );
+		_deprecated_function( __METHOD__, 'TBD' );
 	}
 
 	/**
@@ -58,12 +53,14 @@ class Tabs_Provider extends Service_Provider {
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
 	 *
+	 * @deprecated TBD
+	 *
 	 * @param string Admin page id.
 	 *
 	 * @return void
 	 */
 	public function add_tabs( $admin_page ) {
-		$this->container->make( Integrations::class )->register_tab( $admin_page );
+		_deprecated_function( __METHOD__, 'TBD' );
 	}
 
 	/**
@@ -71,11 +68,14 @@ class Tabs_Provider extends Service_Provider {
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
 	 *
+	 * @deprecated TBD
+	 *
 	 * @param array<string> $tabs Array of tabs IDs for the Events settings page.
 	 *
 	 * @return array<string> The filtered list of tab ids.
 	 */
 	public function filter_include_integrations_tab_id( array $tabs ): array {
-		return $this->container->make( Integrations::class )->register_tab_id( $tabs );
+		_deprecated_function( __METHOD__, 'TBD' );
+		return [];
 	}
 }

--- a/src/Common/Event_Automator/Admin/Tabs/Tabs_Provider.php
+++ b/src/Common/Event_Automator/Admin/Tabs/Tabs_Provider.php
@@ -26,7 +26,7 @@ class Tabs_Provider extends Service_Provider {
 		}
 
 		// If Event Tickets Plus is Active, do not add the Integrations tab as it will do it.
-		if ( class_exists('TEC\Tickets_Plus\Admin\Tabs\Provider', false ) ) {
+		if ( ! class_exists('TEC\Tickets_Plus\Admin\Tabs\Provider', false ) ) {
 			return;
 		}
 

--- a/src/Common/Event_Automator/Hooks.php
+++ b/src/Common/Event_Automator/Hooks.php
@@ -41,7 +41,6 @@ class Hooks extends Service_Provider {
 		$this->container->singleton( 'event-automator.hooks', $this );
 
 		add_action( 'admin_init', [ $this, 'run_updates' ], 10, 0 );
-		add_action( 'admin_init', [ $this, 'admin_register' ], 0 );
 	}
 
 	/**
@@ -62,8 +61,9 @@ class Hooks extends Service_Provider {
 	 * Register providers at admin_init, so dependencies are loaded.
 	 *
 	 * @since 6.0.0 Migrated to Common from Event Automator
+	 * @deprecated TBD
 	 */
 	public function admin_register() {
-		$this->container->register( Tabs_Provider::class );
+		_deprecated_function( __METHOD__, 'TBD' );
 	}
 }

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -699,7 +699,7 @@ class Tribe__Settings {
 		$is_event_settings = $this->is_event_settings( $admin_page );
 		$form_classes      = [ "tec-settings-form__{$current_tab}-tab--active" ];
 
-		if ( $this->get_tab( $current_tab )->has_parent() ) {
+		if ( is_object( $current_tab ) && $current_tab->has_parent() ) {
 			$form_classes[] = 'tec-settings-form__subnav-active';
 		}
 

--- a/src/Tribe/Settings.php
+++ b/src/Tribe/Settings.php
@@ -690,6 +690,7 @@ class Tribe__Settings {
 	 * Includes the view file.
 	 *
 	 * @since 6.1.0
+	 * @since TBD Avoid Fatal error when the current tab is not an object.
 	 */
 	public function generate_page(): void {
 		$admin_pages       = tribe( 'admin.pages' );

--- a/tests/end2end/Events_Automator/Zapier/Event_Tickets_Plus/SettingsCest.php
+++ b/tests/end2end/Events_Automator/Zapier/Event_Tickets_Plus/SettingsCest.php
@@ -104,6 +104,6 @@ class SettingsCest {
 		$I->amOnAdminPage('/admin.php?page=tec-tickets-settings&tab=integrations');
 		$I->dontSeeInPageSource( 'Zapier' );
 		$I->dontSeeInPageSource( 'Power Automate' );
-		$I->canSeeInPageSource("<p>You've requested a non-existent tab.</p>");
+		$I->canSeeInPageSource("You've requested a non-existent tab.");
 	}
 }

--- a/tests/end2end/Events_Automator/Zapier/Event_Tickets_Plus/SettingsCest.php
+++ b/tests/end2end/Events_Automator/Zapier/Event_Tickets_Plus/SettingsCest.php
@@ -97,6 +97,7 @@ class SettingsCest {
 				'event-tickets-plus',
 			]
 		);
+
 		$I->amOnPluginsPage();
 		$I->seePluginActivated( 'event-tickets' );
 		$I->seePluginDeactivated( 'event-tickets-plus' );

--- a/tests/end2end/Events_Automator/Zapier/Event_Tickets_Plus/SettingsCest.php
+++ b/tests/end2end/Events_Automator/Zapier/Event_Tickets_Plus/SettingsCest.php
@@ -104,6 +104,6 @@ class SettingsCest {
 		$I->amOnAdminPage('/admin.php?page=tec-tickets-settings&tab=integrations');
 		$I->dontSeeInPageSource( 'Zapier' );
 		$I->dontSeeInPageSource( 'Power Automate' );
-		$I->canSeeInPageSource("You've requested a non-existent tab.");
+		$I->canSeeInPageSource('You\'ve requested a non-existent tab.');
 	}
 }

--- a/tests/end2end/Events_Automator/Zapier/Event_Tickets_Plus/SettingsCest.php
+++ b/tests/end2end/Events_Automator/Zapier/Event_Tickets_Plus/SettingsCest.php
@@ -86,4 +86,24 @@ class SettingsCest {
 		// 25 instances of dashboard rows with 11 for PA and 14 for Zapier, includes the header.
 		$I->canSeeNumberOfElementsInDOM('//div[contains(@class, "tec-automator-grid-row")]', 25);
 	}
+
+	/**
+	 * @test
+	 */
+	public function should_see_warning_when_etp_is_inactive_and_on_integrations_page( End2endTester $I ) {
+		$I->amOnPluginsPage();
+		$I->deactivatePlugin(
+			[
+				'event-tickets-plus',
+			]
+		);
+		$I->amOnPluginsPage();
+		$I->seePluginActivated( 'event-tickets' );
+		$I->seePluginDeactivated( 'event-tickets-plus' );
+
+		$I->amOnAdminPage('/admin.php?page=tec-tickets-settings&tab=integrations');
+		$I->dontSeeInPageSource( 'Zapier' );
+		$I->dontSeeInPageSource( 'Power Automate' );
+		$I->canSeeInPageSource("<p>You've requested a non-existent tab.</p>");
+	}
 }


### PR DESCRIPTION
[TCMN-174]

The integration tab for ET should not be registering when ETP is not present. Avoiding a fatal as a result

https://www.loom.com/share/5195f40f6698449ca76a6055c96e6ac8

[TCMN-174]: https://stellarwp.atlassian.net/browse/TCMN-174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ