### PR TITLE
Fix/uplink translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,12 +77,12 @@
       "@clean-strauss-static-function-autoload"
     ],
     "post-install-cmd": [
-      "@strauss",
-      "@stellar-uplink"
+      "@stellar-uplink",
+      "@strauss"
     ],
     "post-update-cmd": [
-      "@strauss",
-      "@stellar-uplink"
+      "@stellar-uplink",
+      "@strauss"
     ],
     "stellar-uplink": [
       "vendor/bin/stellar-uplink domain=tribe-common"


### PR DESCRIPTION
Fixes the order of strauss and uplink set domain for translations.

First we should have uplink do its domain replacement and then strauss move it to vendor-prefixed.

![image](https://github.com/user-attachments/assets/ecacaf65-a82d-4306-9c22-b46ad5bd388d)
