### PR TITLE
Fix warning about deprecated ability

### DIFF
--- a/changelog/fix-TEC-5086_deprecated_notice
+++ b/changelog/fix-TEC-5086_deprecated_notice
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolve warning about deprecation of passing null to version_compare function.

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1641,6 +1641,8 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				$all_plugins = get_plugins();
 				if ( array_key_exists( $this->get_plugin_file(), $all_plugins ) && array_key_exists( 'Version', $all_plugins[ $this->get_plugin_file() ] ) ) {
 					return $all_plugins[ $this->get_plugin_file() ]['Version'];
+				} else {
+					return '';
 				}
 			}
 		}


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5086]

### 🗒️ Description

As explained by one of [our users here](https://wordpress.org/support/topic/version_compare-passing-null-to-parameter-2/), our `Tribe__PUE__Checker::get_installed_version()` function was returning `null` because it was looking for `event-aggregator/event-aggregator.php`. EA is not standalone plugin, it comes bundled with TEC. Passing null to version_compare() in PHP >8.1 caused this warning:

`Deprecated: version_compare(): Passing null to parameter #2 ($version2) of type string is deprecated in ..\the-events-calendar\common\src\Tribe\PUE\Checker.php on line 1710`

The fix is to pass an empty string in this case.

### 🎥 Artifacts

![Screenshot_1](https://github.com/user-attachments/assets/5f32a597-9ef8-4f08-b8d8-196bd82e583a)


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5086]: https://stellarwp.atlassian.net/browse/TEC-5086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ