### PR TITLE
TCMN-177 Correction to docblocks for `where` and `all` methods

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -44,4 +44,4 @@ jobs:
       # Run phpstan
       # ------------------------------------------------------------------------------
       - name: Run phpstan
-        run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist --memory-limit=1024M --error-format=table
+        run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist --memory-limit=512M --error-format=table

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,0 +1,47 @@
+name: 'PHPStan Tests'
+on:
+  pull_request:
+    paths:
+      - '.github/**/*'
+      - '*.php'
+      - 'src/**.php'
+jobs:
+  phpstan:
+    strategy:
+      matrix:
+        phpVersion: [
+            "7.4",
+            # ----------------------------------------
+            # Disabled until we get all of 7.4 passing
+            # "8.0",
+            # "8.1",
+            # "8.2",
+            # "8.3",
+            # ----------------------------------------
+        ]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v4
+      # ------------------------------------------------------------------------------
+      # Set up PHP and run phpstan
+      # ------------------------------------------------------------------------------
+      - name: Configure PHP environment to run phpstan
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.phpVersion }}
+      # ------------------------------------------------------------------------------
+      # Override composer php version
+      # ------------------------------------------------------------------------------
+      - name: Set php version ${{ matrix.phpVersion }} in composer
+        run: composer config platform.php ${{ matrix.phpVersion }}
+      # ------------------------------------------------------------------------------
+      # Install dependencies - ignoring php requirements
+      # ------------------------------------------------------------------------------
+      - name: Install dependencies
+        run: composer i --ignore-platform-req=php+
+      # ------------------------------------------------------------------------------
+      # Run phpstan
+      # ------------------------------------------------------------------------------
+      - name: Run phpstan
+        run: ./vendor/bin/phpstan analyse -c phpstan.neon.dist --memory-limit=1024M --error-format=table

--- a/changelog/fix-TCMN-177-correct-ORM-docblocks
+++ b/changelog/fix-TCMN-177-correct-ORM-docblocks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added more details to `Core_Read_Interface` methods' docblocks to avoid errors in PHPStan. [TCMN-177]

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,9 @@
     "wp-cli/checksum-command": "2.0.0",
     "wp-coding-standards/wpcs": "^3.0.0",
     "automattic/jetpack-changelogger": "^4.2",
-    "codeception/module-rest": "^2.0"
+    "codeception/module-rest": "^2.0",
+    "phpstan/phpstan": "^2.1",
+    "php-stubs/wordpress-stubs": "^6.7"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,8 @@
     "wp-coding-standards/wpcs": "^3.0.0",
     "automattic/jetpack-changelogger": "^4.2",
     "codeception/module-rest": "^2.0",
-    "phpstan/phpstan": "^2.1",
-    "php-stubs/wordpress-stubs": "^6.7"
+    "php-stubs/wordpress-stubs": "^6.7",
+    "szepeviktor/phpstan-wordpress": "^1.1"
   },
   "autoload": {
     "psr-4": {
@@ -93,6 +93,9 @@
     "pup": [
       "test -f ./bin/pup.phar || curl -o ./bin/pup.phar -L -C - https://github.com/stellarwp/pup/releases/download/1.3.7/pup.phar",
       "@php bin/pup.phar"
+    ],
+    "analyze": [
+      "phpstan analyse -c phpstan.neon.dist --memory-limit=1024M"
     ]
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,7 @@
       "@php bin/pup.phar"
     ],
     "analyze": [
-      "phpstan analyse -c phpstan.neon.dist --memory-limit=1024M"
+      "phpstan analyse -c phpstan.neon.dist --memory-limit=512M"
     ]
   },
   "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a552a38d268739c81a09042f37ae6405",
+    "content-hash": "d971476cb8d7a607bd2c7951c56e9a77",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -3046,6 +3046,54 @@
             "time": "2018-07-08T19:19:57+00:00"
         },
         {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "83448e918bf06d1ed3d67ceb6a985fc266a02fd1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/83448e918bf06d1ed3d67ceb6a985fc266a02fd1",
+                "reference": "83448e918bf06d1ed3d67ceb6a985fc266a02fd1",
+                "shasum": ""
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^4.13",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.3",
+                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "phpstan/phpstan": "^1.11",
+                "phpunit/phpunit": "^9.5",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.7.1"
+            },
+            "time": "2024-11-24T03:57:09+00:00"
+        },
+        {
             "name": "php-webdriver/webdriver",
             "version": "1.13.1",
             "source": {
@@ -3642,6 +3690,64 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/1.33.0"
             },
             "time": "2024-10-13T11:25:22+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7d08f569e582ade182a375c366cbd896eccadd3a",
+                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-21T14:54:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -7022,16 +7128,16 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "stellarwp/coding-standards": 20,
         "stellarwp/models": 20,
+        "stellarwp/coding-standards": 20,
         "the-events-calendar/tec-testing-facilities": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d971476cb8d7a607bd2c7951c56e9a77",
+    "content-hash": "d34ed5899218cfb511d9033c2f1a48ce",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -3693,20 +3693,20 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.2",
+            "version": "1.12.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a"
+                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7d08f569e582ade182a375c366cbd896eccadd3a",
-                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e0bb5cb78545aae631220735aa706eac633a6be9",
+                "reference": "e0bb5cb78545aae631220735aa706eac633a6be9",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4|^8.0"
+                "php": "^7.2|^8.0"
             },
             "conflict": {
                 "phpstan/phpstan-shim": "*"
@@ -3747,7 +3747,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-21T14:54:06+00:00"
+            "time": "2025-01-21T14:50:05+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -6572,6 +6572,69 @@
             "time": "2022-08-02T15:47:23+00:00"
         },
         {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "reference": "7f8cfe992faa96b6a33bbd75c7bace98864161e7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "php-stubs/wordpress-stubs": "^4.7 || ^5.0 || ^6.0",
+                "phpstan/phpstan": "^1.10.31",
+                "symfony/polyfill-php73": "^1.12.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.2",
+                "phpunit/phpunit": "^8.0 || ^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v1.3.5"
+            },
+            "time": "2024-06-28T22:27:19+00:00"
+        },
+        {
             "name": "the-events-calendar/tec-testing-facilities",
             "version": "dev-master",
             "source": {
@@ -7128,16 +7191,16 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "stellarwp/models": 20,
         "stellarwp/coding-standards": 20,
+        "stellarwp/models": 20,
         "the-events-calendar/tec-testing-facilities": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": [],
-    "platform-dev": [],
+    "platform": {},
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,9 @@
+parameters:
+  bootstrapFiles:
+    - %currentWorkingDirectory%/tests/_bootstrap.php
+  level: 0
+  paths:
+    - src
+    - tribe-common.php
+    - tests
+

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,0 @@
-parameters:
-  bootstrapFiles:
-    - %currentWorkingDirectory%/tests/_bootstrap.php
-  level: 0
-  paths:
-    - src
-    - tribe-common.php
-    - tests
-

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,7 +10,7 @@ includes:
 parameters:
 	parallel:
 		jobSize: 10
-		maximumNumberOfProcesses: 32
+		maximumNumberOfProcesses: 8
 		minimumNumberOfJobsPerProcess: 2
 	level: 5
 	inferPrivatePropertyTypeFromConstructor: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,12 +10,11 @@ includes:
 parameters:
 	parallel:
 		jobSize: 10
-		maximumNumberOfProcesses: 4
+		maximumNumberOfProcesses: 2
 		minimumNumberOfJobsPerProcess: 2
 	level: 5
 	inferPrivatePropertyTypeFromConstructor: true
 	reportUnmatchedIgnoredErrors: false
-	checkGenericClassInNonGenericObjectType: false
 	treatPhpDocTypesAsCertain: false
 
 	# Paths to be analyzed.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,7 +10,7 @@ includes:
 parameters:
 	parallel:
 		jobSize: 10
-		maximumNumberOfProcesses: 8
+		maximumNumberOfProcesses: 4
 		minimumNumberOfJobsPerProcess: 2
 	level: 5
 	inferPrivatePropertyTypeFromConstructor: true

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,34 @@
+# Configuration for PHPStan
+# https://phpstan.org/config-reference
+
+includes:
+	# @see https://github.com/phpstan/phpstan-src/blob/master/conf/bleedingEdge.neon
+	- phar://phpstan.phar/conf/bleedingEdge.neon
+	# Include this extension
+	- vendor/szepeviktor/phpstan-wordpress/extension.neon
+
+parameters:
+	parallel:
+		jobSize: 10
+		maximumNumberOfProcesses: 32
+		minimumNumberOfJobsPerProcess: 2
+	level: 5
+	inferPrivatePropertyTypeFromConstructor: true
+	reportUnmatchedIgnoredErrors: false
+	checkGenericClassInNonGenericObjectType: false
+	treatPhpDocTypesAsCertain: false
+
+	# Paths to be analyzed.
+	paths:
+		- %currentWorkingDirectory%/src
+
+	ignoreErrors:
+		# Uses func_get_args()
+		- '#^Function add_query_arg invoked with [123] parameters?, 0 required\.$#'
+		# Uses func_get_args()
+		- '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
+		- '#^Constant WP_CONTENT_DIR not found\.$#'
+		- '#^Constant WP_CONTENT_URL not found\.$#'
+		- '#^Constant WPMU_PLUGIN_URL not found\.$#'
+		- '#^Constant WP_PLUGIN_DIR not found\.$#'
+		- '#^Constant WP_PLUGIN_URL not found\.$#'

--- a/src/Tribe/Repository/Core_Read_Interface.php
+++ b/src/Tribe/Repository/Core_Read_Interface.php
@@ -54,13 +54,14 @@ interface Core_Read_Interface {
 	/**
 	 * Just an alias of the `by` method to allow for easier reading.
 	 *
-	 * @since 4.7.19
-	 * @since TBD Added optional param of comma separated args that can be passed to the schema.
+	 * This method can accept additional arguments as individual, comma-separated
+	 * parameters, which will be passed to the schema.
 	 *
-	 * @param string $key
-	 * @param mixed  $value
-	 * @param mixed  ...$args Additional, optional, call arguments that will be passed to
-	 *                         the schema.
+	 * @since 4.7.19
+	 * @since TBD Added clarification about format for optional additional arguments.
+	 *
+	 * @param string $key   The key to query by.
+	 * @param mixed  $value The value associated with the key.
 	 *
 	 * @return Tribe__Repository__Read_Interface
 	 */

--- a/src/Tribe/Repository/Core_Read_Interface.php
+++ b/src/Tribe/Repository/Core_Read_Interface.php
@@ -13,6 +13,7 @@ namespace Tribe\Repository;
 
 use Tribe__Repository__Read_Interface;
 use WP_Post;
+use Generator;
 
 /**
  * Class Core_Read_Interface
@@ -119,7 +120,7 @@ interface Core_Read_Interface {
 	 * @param int  $batch_size       The number of post IDs to fetch at a time when using a generator; ignored
 	 *                               if `$return_generator` is false.
 	 *
-	 * @return array<int|WP_Post|object>|\Generator<int|WP_Post|object> An array of all the matching post IDs, or a generator of them
+	 * @return array<int|WP_Post|object>|Generator<int|WP_Post|object> An array of all the matching post IDs, or a generator of them
 	 *                                                                 if `$return_generator` is true.
 	 */
 	public function all( $return_generator = false, int $batch_size = 50 );
@@ -416,7 +417,7 @@ interface Core_Read_Interface {
 	 * @param int  $batch_size       The number of post IDs to fetch at a time when using a generator; ignored
 	 *                               if `$return_generator` is false.
 	 *
-	 * @return array<int>|\Generator<int> An array of all the matching post IDs, or a generator of them
+	 * @return array<int>|Generator<int> An array of all the matching post IDs, or a generator of them
 	 *                                   if `$return_generator` is true.
 	 */
 	public function get_ids( $return_generator = false, int $batch_size = 50 );

--- a/src/Tribe/Repository/Core_Read_Interface.php
+++ b/src/Tribe/Repository/Core_Read_Interface.php
@@ -38,14 +38,14 @@ interface Core_Read_Interface {
 	 * Applies a filter to the query.
 	 *
 	 * While the signature only shows 2 arguments additional arguments will be passed
-	 * to the schema filters.
+	 * to the schema filters. These additional arguments can be passed as individual, comma-separated
+	 * parameters, which will be passed to the schema.
 	 *
 	 * @since 4.7.19
+	 * @since TBD Moved optional `$args` param to an explanation in the description.
 	 *
 	 * @param string $key
 	 * @param mixed  $value
-	 * @param mixed  ...$args Additional, optional, call arguments that will be passed to
-	 *                        the schema.
 	 *
 	 * @return Tribe__Repository__Read_Interface
 	 */
@@ -119,7 +119,7 @@ interface Core_Read_Interface {
 	 * @param int  $batch_size       The number of post IDs to fetch at a time when using a generator; ignored
 	 *                               if `$return_generator` is false.
 	 *
-	 * @return array<int|WP_Post|object>|Generator<int|WP_Post|object> An array of all the matching post IDs, or a generator of them
+	 * @return array<int|WP_Post|object>|\Generator<int|WP_Post|object> An array of all the matching post IDs, or a generator of them
 	 *                                                                 if `$return_generator` is true.
 	 */
 	public function all( $return_generator = false, int $batch_size = 50 );
@@ -416,7 +416,7 @@ interface Core_Read_Interface {
 	 * @param int  $batch_size       The number of post IDs to fetch at a time when using a generator; ignored
 	 *                               if `$return_generator` is false.
 	 *
-	 * @return array<int>|Generator<int> An array of all the matching post IDs, or a generator of them
+	 * @return array<int>|\Generator<int> An array of all the matching post IDs, or a generator of them
 	 *                                   if `$return_generator` is true.
 	 */
 	public function get_ids( $return_generator = false, int $batch_size = 50 );

--- a/src/Tribe/Repository/Core_Read_Interface.php
+++ b/src/Tribe/Repository/Core_Read_Interface.php
@@ -55,9 +55,12 @@ interface Core_Read_Interface {
 	 * Just an alias of the `by` method to allow for easier reading.
 	 *
 	 * @since 4.7.19
+	 * @since TBD Added optional param of comma separated args that can be passed to the schema.
 	 *
 	 * @param string $key
 	 * @param mixed  $value
+	 * @param mixed  ...$args Additional, optional, call arguments that will be passed to
+	 *                         the schema.
 	 *
 	 * @return Tribe__Repository__Read_Interface
 	 */
@@ -109,13 +112,14 @@ interface Core_Read_Interface {
 	 *
 	 * @since 4.1.3
 	 * @since 5.2.0 Added the `$return_generator` and `$batch_size` parameters.
+	 * @since TBD Updated `return` to more accurately reflect what can be returned.
 	 *
 	 * @param bool $return_generator Whether to return a generator of post IDs instead of an array of post IDs.
 	 * @param int  $batch_size       The number of post IDs to fetch at a time when using a generator; ignored
 	 *                               if `$return_generator` is false.
 	 *
-	 * @return array<int>|Generator<int> An array of all the matching post IDs, or a generator of them
-	 *                                   if `$return_generator` is true.
+	 * @return array<int|WP_Post|object>|Generator<int|WP_Post|object> An array of all the matching post IDs, or a generator of them
+	 *                                                                 if `$return_generator` is true.
 	 */
 	public function all( $return_generator = false, int $batch_size = 50 );
 

--- a/src/Tribe/Repository/Core_Read_Interface.php
+++ b/src/Tribe/Repository/Core_Read_Interface.php
@@ -113,7 +113,7 @@ interface Core_Read_Interface {
 	 *
 	 * @since 4.1.3
 	 * @since 5.2.0 Added the `$return_generator` and `$batch_size` parameters.
-	 * @since TBD Updated `return` to more accurately reflect what can be returned.
+	 * @since TBD   Updated `return` to more accurately reflect what can be returned.
 	 *
 	 * @param bool $return_generator Whether to return a generator of post IDs instead of an array of post IDs.
 	 * @param int  $batch_size       The number of post IDs to fetch at a time when using a generator; ignored


### PR DESCRIPTION
### 🎫 Ticket

[TCMN-177]

### 🗒️ Description

A user reported that they were seeing errors in PHPStan when trying to use the ORM and in reviewing our doc blocks for some methods, it seems like some updates are needed to more accurately reflect what is returned (`all`) or how many arguments are accepted (`where`). 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
After changes: 
![CleanShot 2025-01-24 at 13 17 13](https://github.com/user-attachments/assets/fb6595d1-93f7-42c7-95e2-29a75a191f83)


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TCMN-177]: https://stellarwp.atlassian.net/browse/TCMN-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ