### PR TITLE
[TEC-5332] Help Hub transient newly installed plugin issue

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -2201,20 +2201,14 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			$transient_data            = get_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY ) ?: [ 'plugins' => [] ];
 			$transient_data['plugins'] = is_array( $transient_data['plugins'] ) ? $transient_data['plugins'] : [];
 
-			// Add missing plugins and update transient data.
-			$changes_detected = false;
+			// Check if the msising plugins are valid, which adds the transients automatically.
 			foreach ( $current_plugin_list as $plugin_slug ) {
 				if ( ! isset( $transient_data['plugins'][ $plugin_slug ] ) ) {
 					$transient_data['plugins'][ $plugin_slug ] = $checker->is_key_valid();
-					$changes_detected                          = true;
 				}
 			}
 
-			if ( ! $changes_detected ) {
-				return;
-			}
 
-			set_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY, $transient_data );
 		}
 
 		/**

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -2201,13 +2201,12 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			$transient_data            = get_transient( self::IS_ANY_LICENSE_VALID_TRANSIENT_KEY ) ?: [ 'plugins' => [] ];
 			$transient_data['plugins'] = is_array( $transient_data['plugins'] ) ? $transient_data['plugins'] : [];
 
-			// Check if the msising plugins are valid, which adds the transients automatically.
+			// Check if the missing plugins are valid, which adds the transients automatically.
 			foreach ( $current_plugin_list as $plugin_slug ) {
 				if ( ! isset( $transient_data['plugins'][ $plugin_slug ] ) ) {
 					$transient_data['plugins'][ $plugin_slug ] = $checker->is_key_valid();
 				}
 			}
-
 
 		}
 


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5332]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Going back and forth with Romine today we still had a pain point where a plugin becomes active it wasn't updating the transient properly unless you went directly to the licenses page. This is due to the way PUE works. By adding this check we can update the transient without directly going to the licenses page.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[Screencast from 01-09-2025 03:40:01 PM.webm](https://github.com/user-attachments/assets/c75c46a3-d333-4d71-99c2-17687bb711af)

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5332]: https://stellarwp.atlassian.net/browse/TEC-5332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ