### PR TITLE
 [TEC-5351] PUE Checker - Fix get_installed_version() not returning a value.

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -141,11 +141,11 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		public $plugin_info;
 
 		/**
-		 * Storing the `plugin_notice` message.
+		 * Storing the `plugin_notice` messages.
 		 *
-		 * @var string
+		 * @var array
 		 */
-		public string $plugin_notice;
+		public array $plugin_notice;
 
 		/**
 		 * Stats
@@ -1767,17 +1767,33 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		/**
 		 * Get the currently installed version of the plugin.
 		 *
+		 * @since TBD Refactored logic to better catch different scenarios.
+		 *
 		 * @return string Version number.
 		 */
 		public function get_installed_version(): string {
-			if ( function_exists( 'get_plugins' ) ) {
-				$all_plugins = get_plugins();
-				if ( array_key_exists( $this->get_plugin_file(), $all_plugins ) && array_key_exists( 'Version', $all_plugins[ $this->get_plugin_file() ] ) ) {
-					return $all_plugins[ $this->get_plugin_file() ]['Version'];
-				} else {
-					return '';
-				}
+			if ( ! function_exists( 'get_plugins' ) ) {
+				include_once ABSPATH . 'wp-admin/includes/plugin.php';
 			}
+
+			if ( ! function_exists( 'get_plugins' ) ) {
+				return '';
+			}
+
+			$all_plugins = get_plugins();
+			$plugin_file = $this->get_plugin_file();
+
+			if ( ! array_key_exists( $plugin_file, $all_plugins ) ) {
+				return '';
+			}
+
+			$plugin_data = $all_plugins[ $plugin_file ];
+
+			if ( ! array_key_exists( 'Version', $plugin_data ) ) {
+				return '';
+			}
+
+			return $plugin_data['Version'];
 		}
 
 		/**

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -2308,6 +2308,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * @param Tribe__PUE__Checker $checker An instance of the PUE Checker.
 		 */
 		public function initialize_license_check( Tribe__PUE__Checker $checker ): void {
+			if ( ! is_admin() ) {
+				return;
+			}
 			// Check Transient.
 			$pue_transient_status = get_transient( $this->pue_key_status_transient_name );
 			if ( ! empty( $pue_transient_status ) ) {

--- a/src/Tribe/PUE/Plugin_Info.php
+++ b/src/Tribe/PUE/Plugin_Info.php
@@ -79,49 +79,48 @@ if ( ! class_exists( 'Tribe__PUE__Plugin_Info' ) ) {
 		 * @return Tribe__PUE__Plugin_Info New instance of Tribe__PUE__Plugin_Info, or NULL on error.
 		 */
 		public static function from_json( $json ) {
-			// phpcs:disable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
-			$apiResponse = json_decode( $json );
+			// Decode the JSON response.
+			$api_response = json_decode( $json );
 
-			// Get first item of the response array.
-			if ( $apiResponse && ! empty( $apiResponse->results ) ) {
-				$apiResponse = current( $apiResponse->results );
+			// Get the first item of the response array.
+			if ( $api_response && ! empty( $api_response->results ) ) {
+				$api_response = current( $api_response->results );
 			}
 
-			if ( empty( $apiResponse ) || ! is_object( $apiResponse ) ) {
+			if ( empty( $api_response ) || ! is_object( $api_response ) ) {
 				return null;
 			}
 
-			// Normalize keys by stripping "plugin_" prefix.
-			$normalizedResponse = [];
-			foreach ( get_object_vars( $apiResponse ) as $key => $value ) {
+			// Normalize keys by stripping the "plugin_" prefix.
+			$normalized_response = [];
+			foreach ( get_object_vars( $api_response ) as $key => $value ) {
 				if ( strpos( $key, 'plugin_' ) === 0 ) {
-					$normalizedKey = substr( $key, strlen( 'plugin_' ) );
+					$normalized_key = substr( $key, strlen( 'plugin_' ) );
 				} else {
-					$normalizedKey = $key;
+					$normalized_key = $key;
 				}
-				$normalizedResponse[ $normalizedKey ] = $value;
+				$normalized_response[ $normalized_key ] = $value;
 			}
 
 			// Basic validation after normalization.
-			$valid = ( ! empty( $normalizedResponse['name'] )
-					&& ! empty( $normalizedResponse['version'] ) )
-					|| ( isset( $normalizedResponse['api_invalid'] )
-					|| isset( $normalizedResponse['no_api'] )
-					);
-			if ( ! $valid ) {
+			$is_valid = ( ! empty( $normalized_response['name'] )
+						&& ! empty( $normalized_response['version'] ) )
+						|| ( isset( $normalized_response['api_invalid'] )
+						|| isset( $normalized_response['no_api'] )
+						);
+			if ( ! $is_valid ) {
 				return null;
 			}
 
 			// Populate the object.
-			$info = new self();
-			foreach ( $normalizedResponse as $key => $value ) {
-				if ( $info->check_whitelisted_keys( $key ) ) {
-					$info->$key = $value;
+			$plugin_info = new self();
+			foreach ( $normalized_response as $key => $value ) {
+				if ( $plugin_info->check_whitelisted_keys( $key ) ) {
+					$plugin_info->$key = $value;
 				}
 			}
 
-			return $info;
-			// phpcs:enable WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			return $plugin_info;
 		}
 
 		/**

--- a/src/Tribe/PUE/Plugin_Info.php
+++ b/src/Tribe/PUE/Plugin_Info.php
@@ -94,7 +94,7 @@ if ( ! class_exists( 'Tribe__PUE__Plugin_Info' ) ) {
 			// Normalize keys by stripping "plugin_" prefix.
 			$normalizedResponse = [];
 			foreach ( get_object_vars( $apiResponse ) as $key => $value ) {
-				$normalizedKey = preg_replace('/\bplugin_/', '', $key);
+				$normalizedKey                        = preg_replace( '/\bplugin_/', '', $key );
 				$normalizedResponse[ $normalizedKey ] = $value;
 			}
 

--- a/src/Tribe/PUE/Plugin_Info.php
+++ b/src/Tribe/PUE/Plugin_Info.php
@@ -94,7 +94,7 @@ if ( ! class_exists( 'Tribe__PUE__Plugin_Info' ) ) {
 			// Normalize keys by stripping "plugin_" prefix.
 			$normalizedResponse = [];
 			foreach ( get_object_vars( $apiResponse ) as $key => $value ) {
-				$normalizedKey                        = str_replace( 'plugin_', '', $key );
+				$normalizedKey = preg_replace('/\bplugin_/', '', $key);
 				$normalizedResponse[ $normalizedKey ] = $value;
 			}
 

--- a/src/Tribe/PUE/Plugin_Info.php
+++ b/src/Tribe/PUE/Plugin_Info.php
@@ -94,7 +94,11 @@ if ( ! class_exists( 'Tribe__PUE__Plugin_Info' ) ) {
 			// Normalize keys by stripping "plugin_" prefix.
 			$normalizedResponse = [];
 			foreach ( get_object_vars( $apiResponse ) as $key => $value ) {
-				$normalizedKey                        = preg_replace( '/\bplugin_/', '', $key );
+				if ( strpos( $key, 'plugin_' ) === 0 ) {
+					$normalizedKey = substr( $key, strlen( 'plugin_' ) );
+				} else {
+					$normalizedKey = $key;
+				}
 				$normalizedResponse[ $normalizedKey ] = $value;
 			}
 

--- a/tests/integration/Tribe/PUE/Checker_Test.php
+++ b/tests/integration/Tribe/PUE/Checker_Test.php
@@ -940,4 +940,33 @@ class Checker_Test extends WPTestCase {
 		// Assert the plugin name remains null.
 		$this->assertEmpty( $pue_checker->get_plugin_name(), 'It should use the plugin slug when the file name is missing.' );
 	}
+
+	/**
+	 * @test
+	 * @return void
+	 */
+	public function it_should_get_the_installed_version() {
+		$validated_key = md5( microtime() );
+		$plugin_name   = 'the-events-calendar';
+		update_option( "pue_install_key_{$plugin_name}", $validated_key );
+		$pue_instance   = new PUE_Checker( 'deprecated', $plugin_name, [], "{$plugin_name}/{$plugin_name}.php" );
+		$version_number = $pue_instance->get_installed_version();
+
+		$this->assertNotEmpty( $version_number, 'Version should come back for the-events-calendar' );
+	}
+
+	/**
+	 * @test
+	 * @return void
+	 */
+	public function it_should_not_get_the_installed_version() {
+		$validated_key = md5( microtime() );
+		$plugin_name   = 'fake-plugin-not-installed';
+		update_option( "pue_install_key_{$plugin_name}", $validated_key );
+		$pue_instance = new PUE_Checker( 'deprecated', $plugin_name, [], "{$plugin_name}/{$plugin_name}.php" );
+
+		$version_number = $pue_instance->get_installed_version();
+
+		$this->assertEmpty( $version_number, 'Version number should be empty for fake plugin.' );
+	}
 }

--- a/tests/integration/Tribe/PUE/Plugin_Info_Test.php
+++ b/tests/integration/Tribe/PUE/Plugin_Info_Test.php
@@ -171,6 +171,7 @@ class Plugin_Info_Test extends WPTestCase {
 			[
 				'plugin_name'    => 'Valid Plugin',
 				'plugin_version' => '1.2.3',
+				'tec_plugin_version' => '1.2.3',
 			]
 		);
 
@@ -179,6 +180,7 @@ class Plugin_Info_Test extends WPTestCase {
 		$this->assertInstanceOf( Tribe__PUE__Plugin_Info::class, $plugin_info, 'from_json should create an instance when `name` and `version` are set.' );
 		$this->assertEquals( 'Valid Plugin', $plugin_info->name, 'Property "name" was not set correctly.' );
 		$this->assertEquals( '1.2.3', $plugin_info->version, 'Property "version" was not set correctly.' );
+		$this->assertObjectNotHasAttribute( 'tec_plugin_version', $plugin_info, 'Non-whitelisted prefixed key should not be added to the object.' );
 	}
 
 	/**

--- a/tests/integration/Tribe/PUE/Plugin_Info_Test.php
+++ b/tests/integration/Tribe/PUE/Plugin_Info_Test.php
@@ -1,0 +1,194 @@
+<?php
+
+namespace Tribe\PUE;
+
+use Codeception\TestCase\WPTestCase;
+use Tribe\Tests\Traits\With_Uopz;
+use Tribe__PUE__Plugin_Info;
+
+class Plugin_Info_Test extends WPTestCase {
+	use With_Uopz;
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_all_whitelisted_keys() {
+		$plugin_info   = new Tribe__PUE__Plugin_Info();
+		$expected_keys = array_keys( get_class_vars( Tribe__PUE__Plugin_Info::class ) );
+
+		$this->assertEquals( $expected_keys, $plugin_info->get_whitelisted_keys(), 'Whitelist keys do not match expected properties.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_validate_keys_against_whitelist_correctly() {
+		$plugin_info = new Tribe__PUE__Plugin_Info();
+		$valid_key   = 'name'; // An existing property of the class.
+		$invalid_key = 'non_existent_key'; // A key not defined in the class.
+
+		$this->assertTrue( $plugin_info->check_whitelisted_keys( $valid_key ), "'$valid_key' should be a valid whitelist key." );
+		$this->assertFalse( $plugin_info->check_whitelisted_keys( $invalid_key ), "'$invalid_key' should not be a valid whitelist key." );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_populate_only_whitelisted_properties_from_json() {
+		$json = wp_json_encode(
+			[
+				'name'                => 'Sample Plugin',
+				'version'             => '1.0.0',
+				'non_whitelisted_key' => 'Should not be added',
+				'plugin_homepage'     => 'https://example.com', // Plugin prefix to be stripped.
+			]
+		);
+
+		$plugin_info = Tribe__PUE__Plugin_Info::from_json( $json );
+
+		$this->assertInstanceOf( Tribe__PUE__Plugin_Info::class, $plugin_info, 'from_json did not return an instance of Tribe__PUE__Plugin_Info.' );
+		$this->assertEquals( 'Sample Plugin', $plugin_info->name, 'Property "name" was not set correctly.' );
+		$this->assertEquals( '1.0.0', $plugin_info->version, 'Property "version" was not set correctly.' );
+		$this->assertEquals( 'https://example.com', $plugin_info->homepage, 'Property "homepage" was not set correctly after prefix removal.' );
+		$this->assertObjectNotHasAttribute( 'non_whitelisted_key', $plugin_info, 'Non-whitelisted key should not be added to the object.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_null_for_invalid_json_input() {
+		$invalid_json = 'invalid json string';
+		$plugin_info  = Tribe__PUE__Plugin_Info::from_json( $invalid_json );
+
+		$this->assertNull( $plugin_info, 'from_json should return null for invalid JSON input.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_null_when_required_fields_are_missing() {
+		$json = wp_json_encode(
+			[
+				'non_whitelisted_key' => 'This should be ignored',
+			]
+		);
+
+		$plugin_info = Tribe__PUE__Plugin_Info::from_json( $json );
+
+		$this->assertNull( $plugin_info, 'from_json should return null when required fields are missing.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_handle_empty_json() {
+		$empty_json  = '{}';
+		$plugin_info = Tribe__PUE__Plugin_Info::from_json( $empty_json );
+
+		$this->assertNull( $plugin_info, 'from_json should return null for empty JSON.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_handle_nested_json_with_valid_and_invalid_keys() {
+		$json = wp_json_encode(
+			[
+				'results' => [
+					[
+						'name'                => 'Nested Plugin',
+						'version'             => '2.0.0',
+						'non_whitelisted_key' => 'Ignored',
+					],
+				],
+			]
+		);
+
+		$plugin_info = Tribe__PUE__Plugin_Info::from_json( $json );
+
+		$this->assertInstanceOf( Tribe__PUE__Plugin_Info::class, $plugin_info, 'from_json did not return an instance for nested JSON.' );
+		$this->assertEquals( 'Nested Plugin', $plugin_info->name, 'Property "name" in nested JSON was not set correctly.' );
+		$this->assertEquals( '2.0.0', $plugin_info->version, 'Property "version" in nested JSON was not set correctly.' );
+		$this->assertObjectNotHasAttribute( 'non_whitelisted_key', $plugin_info, 'Non-whitelisted key in nested JSON should not be added.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_ignore_plugin_prefix_in_json_keys() {
+		$json = wp_json_encode(
+			[
+				'plugin_name'    => 'Prefixed Plugin',
+				'plugin_version' => '3.1.4',
+				'plugin_extra'   => 'Ignored',
+			]
+		);
+
+		$plugin_info = Tribe__PUE__Plugin_Info::from_json( $json );
+
+		$this->assertInstanceOf( Tribe__PUE__Plugin_Info::class, $plugin_info, 'from_json did not return an instance for prefixed JSON keys.' );
+		$this->assertEquals( 'Prefixed Plugin', $plugin_info->name, 'Property "name" was not set correctly from prefixed JSON key.' );
+		$this->assertEquals( '3.1.4', $plugin_info->version, 'Property "version" was not set correctly from prefixed JSON key.' );
+		$this->assertObjectNotHasAttribute( 'plugin_extra', $plugin_info, 'Non-whitelisted prefixed key should not be added to the object.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_null_for_json_missing_required_fields() {
+		$json = json_encode(
+			[
+				'plugin_author' => 'Test Author', // No 'name' or 'version'.
+			]
+		);
+
+		$plugin_info = Tribe__PUE__Plugin_Info::from_json( $json );
+
+		$this->assertNull( $plugin_info, 'from_json should return null when required fields are missing.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_create_instance_for_json_with_api_invalid_or_no_api() {
+		$json = wp_json_encode(
+			[
+				'plugin_api_invalid' => true, // Valid because `api_invalid` is set.
+			]
+		);
+
+		$plugin_info = Tribe__PUE__Plugin_Info::from_json( $json );
+
+		$this->assertInstanceOf( Tribe__PUE__Plugin_Info::class, $plugin_info, 'from_json should create an instance when `api_invalid` is set.' );
+		$this->assertTrue( $plugin_info->api_invalid, 'Property "api_invalid" was not set correctly.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_create_instance_with_name_and_version() {
+		$json = wp_json_encode(
+			[
+				'plugin_name'    => 'Valid Plugin',
+				'plugin_version' => '1.2.3',
+			]
+		);
+
+		$plugin_info = Tribe__PUE__Plugin_Info::from_json( $json );
+
+		$this->assertInstanceOf( Tribe__PUE__Plugin_Info::class, $plugin_info, 'from_json should create an instance when `name` and `version` are set.' );
+		$this->assertEquals( 'Valid Plugin', $plugin_info->name, 'Property "name" was not set correctly.' );
+		$this->assertEquals( '1.2.3', $plugin_info->version, 'Property "version" was not set correctly.' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_null_for_empty_json() {
+		$json = '{}';
+
+		$plugin_info = Tribe__PUE__Plugin_Info::from_json( $json );
+
+		$this->assertNull( $plugin_info, 'from_json should return null for empty JSON.' );
+	}
+}


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5351](https://stellarwp.atlassian.net/browse/TEC-5351)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

There was an issue in certain scenarios where `get_installed_version()` would not return a value and cause a fatal. I refactored the method to add an early bail, as well as try to load `get_plugins`. 

This PR is a continuation of one that was already merged and doesn't need a changelog entry.

--

This PR also fixes an issue in the `Tribe__PUE__Plugin_Info` class. Under certain circumstances it was possible to create dynamic class parameters when using `from_json()`. To fix the issue, I implemented a whitelist of current class parameters. As I was writing tests, I also found an issue with the original logic of checking is_set() variables because the `plugin_` string replacement was happening AFTER the check, it should of been happening before.


---

Testing Instructions - 
The big part of this change involves making sure we have the proper license checks ran upon plugin activation. That includes the transient and the option. If neither exist, they will populate.

- Activate a licensed plugin for the first time
- Go to Help Hub
- Help Hub should not display any messages about not having licensed plugins

To test the `Plugin_Info` code -
- Validate a license key
- No errors should occur and no deprications should appear.


### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[init_license_checker_plugin_info-2025-01-28_14.32.51.webm](https://github.com/user-attachments/assets/1ce1fa27-4204-4d42-8343-21927d6a5d98)

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5351]: https://stellarwp.atlassian.net/browse/TEC-5351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ