### PR TITLE
Update Strauss to 0.20.1 to avoid permissions issues.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
   "scripts": {
     "clean-strauss-static-function-autoload": "bash bin/clean-composer.sh",
     "strauss": [
-      "test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.19.4/strauss.phar",
+      "test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.20.1/strauss.phar",
       "vendor/stellarwp/installer/bin/set-domain domain=tribe-common",
       "@php -d display_errors=on bin/strauss.phar",
       "@composer dump-autoload"


### PR DESCRIPTION
### 🎫 Ticket

No ticket. Internal task.

### 🗒️ Description

Update to latest Strauss to avoid permissions issues on vendor-prefixed folder(s)