### PR TITLE
Fix the load order fatalling

### DIFF
--- a/changelog/fix-load-order-fatal
+++ b/changelog/fix-load-order-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Tweak load order to prevent Promoter fatal. Ensure PUE gets loaded first.

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -188,13 +188,13 @@ class Tribe__Main {
 	 */
 	public function init_early_libraries() {
 		require_once $this->plugin_path . 'src/functions/editor.php';
-		require_once $this->plugin_path . 'src/functions/utils.php';
 	}
 
 	/**
 	 * initializes all required libraries
 	 */
 	public function init_libraries() {
+		require_once $this->plugin_path . 'src/functions/utils.php';
 		require_once $this->plugin_path . 'src/functions/conditionals.php';
 		require_once $this->plugin_path . 'src/functions/transient.php';
 		require_once $this->plugin_path . 'src/functions/url.php';
@@ -772,16 +772,16 @@ class Tribe__Main {
 		tribe_singleton( Translations_Loader::class, Translations_Loader::class );
 
 		tribe_register_provider( Tribe__Editor__Provider::class );
-		tribe_register_provider( Tribe\Service_Providers\PUE::class );
-		tribe_register_provider( Tribe\Admin\Notice\Service_Provider::class );
 		tribe_register_provider( Tribe__Service_Providers__Debug_Bar::class );
-		tribe_register_provider( Tribe__Service_Providers__Promoter::class );
 		tribe_register_provider( Tribe\Service_Providers\Tooltip::class );
 		tribe_register_provider( Tribe\Service_Providers\Dialog::class );
+		tribe_register_provider( Tribe\Service_Providers\PUE::class );
 		tribe_register_provider( Tribe\Service_Providers\Shortcodes::class );
 		tribe_register_provider( Tribe\Service_Providers\Body_Classes::class );
 		tribe_register_provider( Tribe\Log\Service_Provider::class );
 		tribe_register_provider( Tribe\Service_Providers\Crons::class );
+		tribe_register_provider( Tribe\Admin\Notice\Service_Provider::class );
+		tribe_register_provider( Tribe__Service_Providers__Promoter::class );
 		tribe_register_provider( Tribe\Service_Providers\Widgets::class );
 		tribe_register_provider( Tribe\Service_Providers\Onboarding::class );
 		tribe_register_provider( \TEC\Common\Admin\Conditional_Content\Controller::class );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -188,13 +188,13 @@ class Tribe__Main {
 	 */
 	public function init_early_libraries() {
 		require_once $this->plugin_path . 'src/functions/editor.php';
+		require_once $this->plugin_path . 'src/functions/utils.php';
 	}
 
 	/**
 	 * initializes all required libraries
 	 */
 	public function init_libraries() {
-		require_once $this->plugin_path . 'src/functions/utils.php';
 		require_once $this->plugin_path . 'src/functions/conditionals.php';
 		require_once $this->plugin_path . 'src/functions/transient.php';
 		require_once $this->plugin_path . 'src/functions/url.php';
@@ -772,18 +772,18 @@ class Tribe__Main {
 		tribe_singleton( Translations_Loader::class, Translations_Loader::class );
 
 		tribe_register_provider( Tribe__Editor__Provider::class );
+		tribe_register_provider( Tribe\Service_Providers\PUE::class );
+		tribe_register_provider( Tribe\Admin\Notice\Service_Provider::class );
 		tribe_register_provider( Tribe__Service_Providers__Debug_Bar::class );
 		tribe_register_provider( Tribe__Service_Providers__Promoter::class );
 		tribe_register_provider( Tribe\Service_Providers\Tooltip::class );
 		tribe_register_provider( Tribe\Service_Providers\Dialog::class );
-		tribe_register_provider( Tribe\Service_Providers\PUE::class );
 		tribe_register_provider( Tribe\Service_Providers\Shortcodes::class );
 		tribe_register_provider( Tribe\Service_Providers\Body_Classes::class );
 		tribe_register_provider( Tribe\Log\Service_Provider::class );
 		tribe_register_provider( Tribe\Service_Providers\Crons::class );
 		tribe_register_provider( Tribe\Service_Providers\Widgets::class );
 		tribe_register_provider( Tribe\Service_Providers\Onboarding::class );
-		tribe_register_provider( Tribe\Admin\Notice\Service_Provider::class );
 		tribe_register_provider( \TEC\Common\Admin\Conditional_Content\Controller::class );
 		tribe_register_provider( \TEC\Common\Notifications\Controller::class );
 		tribe_register_provider( Libraries\Provider::class );


### PR DESCRIPTION
### 🎫 Ticket

No ticket yet.

### 🗒️ Description

Tweak load order to prevent Promoter fatal. Ensure PUE and notices get loaded before they are used.

### 🎥 Artifacts <!-- if applicable-->
No fatal when Promoter is active.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
