### PR TITLE
Fix datatypes for check_for_api_key_error()

### DIFF
--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1916,7 +1916,6 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 *
 		 * @param string|null $field_id        The ID of the field.
 		 * @param mixed       $value           The value of the option.
-		 * @param object      $validated_field The validated field.
 		 *
 		 * @return void
 		 * @internal

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1945,15 +1945,14 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		/**
 		 * Clears out the site external site option and re-checks the license key
 		 *
-		 * @since TBD Updated to be passthrough method to `check_for_api_key_error_on_action`.
-		 *
 		 * @param mixed  $value           The value of the option.
 		 * @param string $field_id        The ID of the field.
 		 * @param object $validated_field The validated field.
 		 *
 		 * @return mixed returns $value
+		 * @deprecated TBD Updated to be passthrough method to `check_for_api_key_error_on_action`.
+		 *
 		 * @internal
-		 * @deprecated
 		 */
 		public function check_for_api_key_error( $value, string $field_id, object $validated_field ) {
 			_deprecated_function( __METHOD__, 'TBD', 'check_for_api_key_error_on_action' );

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -435,7 +435,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			add_action( 'load-plugins.php', [ $this, 'remove_default_inline_update_msg' ], 50 );
 
 			// Key validation.
-			add_action( 'tribe_settings_save_field', [ $this, 'check_for_api_key_error_on_action' ], 10, 3 );
+			add_action( 'tribe_settings_save_field', [ $this, 'check_for_api_key_error_on_action' ], 10, 2 );
 			add_action( 'wp_ajax_pue-validate-key_' . $this->get_slug(), [ $this, 'ajax_validate_key' ] );
 			add_filter( 'tribe-pue-install-keys', [ $this, 'return_install_key' ] );
 			add_action( 'admin_enqueue_scripts', [ $this, 'maybe_display_json_error_on_plugins_page' ], 1 );
@@ -1921,7 +1921,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * @return void
 		 * @internal
 		 */
-		public function check_for_api_key_error_on_action( ?string $field_id, $value, object $validated_field ): void {
+		public function check_for_api_key_error_on_action( ?string $field_id, $value ): void {
 			// Only hook into our option.
 			if ( $this->pue_install_key !== $field_id ) {
 				return;
@@ -1953,10 +1953,11 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 *
 		 * @return mixed returns $value
 		 * @internal
+		 * @deprecated
 		 */
 		public function check_for_api_key_error( $value, string $field_id, object $validated_field ) {
 			_deprecated_function( __METHOD__, 'TBD', 'check_for_api_key_error_on_action' );
-			$this->check_for_api_key_error_on_action( $field_id, $value, $validated_field );
+			$this->check_for_api_key_error_on_action( $field_id, $value );
 
 			return $value;
 		}

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1927,27 +1927,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 				return;
 			}
 
-			if ( empty( $value ) ) {
-				return;
-			}
-
 			if ( 'service' !== $this->context ) {
 				$this->check_for_updates( [], true );
 			}
-
-			$network_option = false;
-
-			if ( ! empty( $validated_field->field['network_option'] ) ) {
-				$network_option = (bool) $validated_field->field['network_option'];
-			}
-
-			$key_type = 'local';
-
-			if ( $network_option ) {
-				$key_type = 'network';
-			}
-
-			$current_key = $this->get_key( $key_type );
 
 			// if we are saving this PUE key, we need to make sure we update the license key notices
 			// appropriately. Otherwise, we could have an invalid license key in place but the notices

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1912,13 +1912,13 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		/**
 		 * Clears out the site external site option and re-checks the license key
 		 *
-		 * @param string $value           The value of the option.
+		 * @param mixed  $value           The value of the option.
 		 * @param string $field_id        The ID of the field.
 		 * @param object $validated_field The validated field.
 		 *
-		 * @return string
+		 * @return mixed returns $value
 		 */
-		public function check_for_api_key_error( string $value, string $field_id, object $validated_field ): string {
+		public function check_for_api_key_error( $value, string $field_id, object $validated_field ) {
 			// Only hook into our option.
 			if ( $this->pue_install_key !== $field_id ) {
 				return $value;

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1914,13 +1914,12 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 *
 		 * @since TBD
 		 *
-		 * @param string $field_id        The ID of the field.
-		 * @param mixed  $value           The value of the option.
-		 * @param object $validated_field The validated field.
+		 * @param string|null $field_id        The ID of the field.
+		 * @param mixed       $value           The value of the option.
+		 * @param object      $validated_field The validated field.
 		 *
 		 * @return void
 		 * @internal
-		 *
 		 */
 		public function check_for_api_key_error_on_action( ?string $field_id, $value, object $validated_field ): void {
 			// Only hook into our option.
@@ -1964,7 +1963,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		/**
 		 * Clears out the site external site option and re-checks the license key
 		 *
-		 * @since TBD Updated to be pass through method to `check_for_api_key_error_on_action`.
+		 * @since TBD Updated to be passthrough method to `check_for_api_key_error_on_action`.
 		 *
 		 * @param mixed  $value           The value of the option.
 		 * @param string $field_id        The ID of the field.
@@ -1972,7 +1971,6 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 *
 		 * @return mixed returns $value
 		 * @internal
-		 *
 		 */
 		public function check_for_api_key_error( $value, string $field_id, object $validated_field ) {
 			_deprecated_function( __METHOD__, 'TBD', 'check_for_api_key_error_on_action' );

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -435,7 +435,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			add_action( 'load-plugins.php', [ $this, 'remove_default_inline_update_msg' ], 50 );
 
 			// Key validation.
-			add_filter( 'tribe_settings_save_field_value', [ $this, 'check_for_api_key_error' ], 10, 3 );
+			add_action( 'tribe_settings_save_field', [ $this, 'check_for_api_key_error_on_action' ], 10, 3 );
 			add_action( 'wp_ajax_pue-validate-key_' . $this->get_slug(), [ $this, 'ajax_validate_key' ] );
 			add_filter( 'tribe-pue-install-keys', [ $this, 'return_install_key' ] );
 			add_action( 'admin_enqueue_scripts', [ $this, 'maybe_display_json_error_on_plugins_page' ], 1 );
@@ -1912,16 +1912,24 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		/**
 		 * Clears out the site external site option and re-checks the license key
 		 *
-		 * @param mixed  $value           The value of the option.
+		 * @since TBD
+		 *
 		 * @param string $field_id        The ID of the field.
+		 * @param mixed  $value           The value of the option.
 		 * @param object $validated_field The validated field.
 		 *
-		 * @return mixed returns $value
+		 * @return void
+		 * @internal
+		 *
 		 */
-		public function check_for_api_key_error( $value, string $field_id, object $validated_field ) {
+		public function check_for_api_key_error_on_action( ?string $field_id, $value, object $validated_field ): void {
 			// Only hook into our option.
 			if ( $this->pue_install_key !== $field_id ) {
-				return $value;
+				return;
+			}
+
+			if ( empty( $value ) ) {
+				return;
 			}
 
 			if ( 'service' !== $this->context ) {
@@ -1951,6 +1959,24 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			$query_args['key'] = sanitize_text_field( $value );
 
 			$this->license_key_status( $query_args );
+		}
+
+		/**
+		 * Clears out the site external site option and re-checks the license key
+		 *
+		 * @since TBD Updated to be pass through method to `check_for_api_key_error_on_action`.
+		 *
+		 * @param mixed  $value           The value of the option.
+		 * @param string $field_id        The ID of the field.
+		 * @param object $validated_field The validated field.
+		 *
+		 * @return mixed returns $value
+		 * @internal
+		 *
+		 */
+		public function check_for_api_key_error( $value, string $field_id, object $validated_field ) {
+			_deprecated_function( __METHOD__, 'TBD', 'check_for_api_key_error_on_action' );
+			$this->check_for_api_key_error_on_action( $field_id, $value, $validated_field );
 
 			return $value;
 		}


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

When saving the tickets settings page `check_for_api_key_error` is being ran. The function expects `$value` to be mixed, as well as return back the mixed `$value`. Removed the datatype for `$value` on the function.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
