### PR TITLE
[TEC-5384] Fix tribe_is_truthy() undefined error.

### DIFF
--- a/changelog/fix-TEC-5384_move_pue_hooks_to_admin_init
+++ b/changelog/fix-TEC-5384_move_pue_hooks_to_admin_init
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Adjustments were made to prevent a fatal error when tec_pue_checker_init was triggered too early, attempting to call tribe_is_truthy() before it was available. The license check and active plugin monitoring now run on admin_init to ensure proper loading. [TEC-5384]

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -416,6 +416,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * Also, other hooks related to the automatic updates (such as checking against API and what not (@from Darren)
 		 *
 		 * @since 6.5.1 Added `initialize_license_check` action.
+		 * @since TBD Moved `monitor_active_plugins` and `initialize_license_check` to `admin_init`.
 		 */
 		public function hooks(): void {
 			// Override requests for plugin information.
@@ -445,11 +446,21 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			add_filter( 'upgrader_pre_download', [ Tribe__PUE__Package_Handler::instance(), 'filter_upgrader_pre_download' ], 5, 3 );
 
 			add_action( 'admin_init', [ $this, 'monitor_uplink_actions' ], 1000 );
+			add_action( 'tribe_common_loaded', [ $this, 'setup_pue_license_hooks' ] );
+		}
+
+		/**
+		 * Registers hooks to initialize the PUE license check and monitor active plugins.
+		 * This method adds actions to handle the PUE license check
+		 * and monitor active plugins when the `tec_pue_checker_init` action is triggered.
+		 *
+		 * @since TBD
+		 * @return void
+		 */
+		public function setup_pue_license_hooks() {
 			add_action( 'tec_pue_checker_init', [ __CLASS__, 'monitor_active_plugins' ] );
 			add_action( 'tec_pue_checker_init', [ $this, 'initialize_license_check' ] );
 		}
-
-
 
 		/********************** Getter / Setter Functions **********************/
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -440,26 +440,25 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			add_action( 'wp_ajax_pue-validate-key_' . $this->get_slug(), [ $this, 'ajax_validate_key' ] );
 			add_filter( 'tribe-pue-install-keys', [ $this, 'return_install_key' ] );
 			add_action( 'admin_enqueue_scripts', [ $this, 'maybe_display_json_error_on_plugins_page' ], 1 );
-			add_action( 'admin_init', [ $this, 'general_notifications' ] );
 
 			// Package name.
 			add_filter( 'upgrader_pre_download', [ Tribe__PUE__Package_Handler::instance(), 'filter_upgrader_pre_download' ], 5, 3 );
 
-			add_action( 'admin_init', [ $this, 'monitor_uplink_actions' ], 1000 );
 			add_action( 'admin_init', [ $this, 'setup_admin_init_pue_license_hooks' ] );
 		}
 
 		/**
 		 * Initializes and registers the PUE license check and active plugin monitoring.
-		 * This method is triggered on `admin_init`, ensuring that the PUE license check
-		 * and active plugin monitoring occur only when the admin environment is ready.
+		 * This method is triggered on `admin_init`.
 		 *
 		 * @since TBD
 		 * @return void
 		 */
 		public function setup_admin_init_pue_license_hooks() {
 			self::monitor_active_plugins( $this );
+			$this->general_notifications();
 			$this->initialize_license_check( $this );
+			$this->monitor_uplink_actions( $this );
 		}
 
 		/********************** Getter / Setter Functions **********************/

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -416,7 +416,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * Also, other hooks related to the automatic updates (such as checking against API and what not (@from Darren)
 		 *
 		 * @since 6.5.1 Added `initialize_license_check` action.
-		 * @since TBD Moved `monitor_active_plugins` and `initialize_license_check` to `admin_init`.
+		 * @since TBD Moved `monitor_active_plugins` and `initialize_license_check` to `setup_pue_license_hooks`, and run on `tribe_common_loaded`.
 		 */
 		public function hooks(): void {
 			// Override requests for plugin information.

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -416,7 +416,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * Also, other hooks related to the automatic updates (such as checking against API and what not (@from Darren)
 		 *
 		 * @since 6.5.1 Added `initialize_license_check` action.
-		 * @since 6.5.2.1 Moved `monitor_active_plugins` and `initialize_license_check` to `setup_pue_license_hooks`, and run on `admin_init`.
+		 * @since 6.5.1.1 Moved `monitor_active_plugins` and `initialize_license_check` to `setup_pue_license_hooks`, and run on `admin_init`.
 		 */
 		public function hooks(): void {
 			// Override requests for plugin information.
@@ -451,7 +451,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * Initializes and registers the PUE license check and active plugin monitoring.
 		 * This method is triggered on `admin_init`.
 		 *
-		 * @since 6.5.2.1
+		 * @since 6.5.1.1
 		 * @return void
 		 */
 		public function setup_admin_init_pue_license_hooks() {

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -416,7 +416,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * Also, other hooks related to the automatic updates (such as checking against API and what not (@from Darren)
 		 *
 		 * @since 6.5.1 Added `initialize_license_check` action.
-		 * @since TBD Moved `monitor_active_plugins` and `initialize_license_check` to `setup_pue_license_hooks`, and run on `tribe_common_loaded`.
+		 * @since TBD Moved `monitor_active_plugins` and `initialize_license_check` to `setup_pue_license_hooks`, and run on `admin_init`.
 		 */
 		public function hooks(): void {
 			// Override requests for plugin information.

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -458,7 +458,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			self::monitor_active_plugins( $this );
 			$this->general_notifications();
 			$this->initialize_license_check( $this );
-			$this->monitor_uplink_actions( $this );
+			$this->monitor_uplink_actions();
 		}
 
 		/********************** Getter / Setter Functions **********************/

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -446,20 +446,20 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			add_filter( 'upgrader_pre_download', [ Tribe__PUE__Package_Handler::instance(), 'filter_upgrader_pre_download' ], 5, 3 );
 
 			add_action( 'admin_init', [ $this, 'monitor_uplink_actions' ], 1000 );
-			add_action( 'tribe_common_loaded', [ $this, 'setup_pue_license_hooks' ] );
+			add_action( 'admin_init', [ $this, 'setup_admin_init_pue_license_hooks' ] );
 		}
 
 		/**
-		 * Registers hooks to initialize the PUE license check and monitor active plugins.
-		 * This method adds actions to handle the PUE license check
-		 * and monitor active plugins when the `tec_pue_checker_init` action is triggered.
+		 * Initializes and registers the PUE license check and active plugin monitoring.
+		 * This method is triggered on `admin_init`, ensuring that the PUE license check
+		 * and active plugin monitoring occur only when the admin environment is ready.
 		 *
 		 * @since TBD
 		 * @return void
 		 */
-		public function setup_pue_license_hooks() {
-			add_action( 'tec_pue_checker_init', [ __CLASS__, 'monitor_active_plugins' ] );
-			add_action( 'tec_pue_checker_init', [ $this, 'initialize_license_check' ] );
+		public function setup_admin_init_pue_license_hooks() {
+			self::monitor_active_plugins( $this );
+			$this->initialize_license_check( $this );
 		}
 
 		/********************** Getter / Setter Functions **********************/

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -416,7 +416,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * Also, other hooks related to the automatic updates (such as checking against API and what not (@from Darren)
 		 *
 		 * @since 6.5.1 Added `initialize_license_check` action.
-		 * @since TBD Moved `monitor_active_plugins` and `initialize_license_check` to `setup_pue_license_hooks`, and run on `admin_init`.
+		 * @since 6.5.2.1 Moved `monitor_active_plugins` and `initialize_license_check` to `setup_pue_license_hooks`, and run on `admin_init`.
 		 */
 		public function hooks(): void {
 			// Override requests for plugin information.
@@ -451,7 +451,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * Initializes and registers the PUE license check and active plugin monitoring.
 		 * This method is triggered on `admin_init`.
 		 *
-		 * @since TBD
+		 * @since 6.5.2.1
 		 * @return void
 		 */
 		public function setup_admin_init_pue_license_hooks() {

--- a/src/Tribe/Service_Providers/Promoter.php
+++ b/src/Tribe/Service_Providers/Promoter.php
@@ -30,21 +30,37 @@ class Tribe__Service_Providers__Promoter extends Service_Provider {
 	private function hook() {
 		add_action( 'template_redirect', tribe_callback( 'promoter.view', 'display_auth_check_view' ), 10, 0 );
 		add_action( 'init', tribe_callback( 'promoter.view', 'add_rewrites' ) );
+		add_action( 'tribe_common_loaded', [ $this, 'add_auth_setting' ] );
 
+		// The usage of a high priority so we can push the icon to the end.
+		add_action( 'admin_bar_menu', [ $this, 'add_promoter_logo_on_admin_bar' ], 1000 );
+		add_action( 'tribe_common_loaded', [ $this, 'add_promoter_assets' ] );
+	}
+
+	/**
+	 * Adds the Promoter authentication setting if a valid license key is present.
+	 *
+	 * This method checks if the Promoter PUE has a valid
+	 * license key. If a key is found, it registers the authentication setting
+	 * via the 'init' action.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function add_auth_setting() {
 		/** @var Tribe__Promoter__PUE $pue */
 		$pue = tribe( 'promoter.pue' );
 
-		// Only add the setting if a promoter key is present.
-		if ( $pue->has_license_key() ) {
-			add_action(
-				'init',
-				tribe_callback( 'promoter.auth', 'register_setting' )
-			);
+		if ( ! $pue->has_license_key() ) {
+			return;
 		}
 
-		// The usage of a high priority so we can push the icon to the end
-		add_action( 'admin_bar_menu', [ $this, 'add_promoter_logo_on_admin_bar' ], 1000 );
-		add_action( 'tribe_common_loaded', [ $this, 'add_promoter_assets' ] );
+		// Only add the setting if a promoter key is present.
+		add_action(
+			'init',
+			tribe_callback( 'promoter.auth', 'register_setting' )
+		);
 	}
 
 	/**

--- a/src/Tribe/Service_Providers/Promoter.php
+++ b/src/Tribe/Service_Providers/Promoter.php
@@ -44,7 +44,7 @@ class Tribe__Service_Providers__Promoter extends Service_Provider {
 	 * license key. If a key is found, it registers the authentication setting
 	 * via the 'init' action.
 	 *
-	 * @since TBD
+	 * @since 6.5.1.1
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5384](https://stellarwp.atlassian.net/browse/TEC-5384)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

This PR focuses on fixing the error `An error of type E_ERROR was caused in line 28 of the file /var/www/wp-content/plugins/event-tickets/common/src/Common/Contracts/Container.php. Error message: Uncaught TEC\Common\Exceptions\Not_Bound_Exception: Error while making pue.notices: call to undefined function tribe_is_truthy(). in /var/www/wp-content/plugins/event-tickets/common/src/Common/Contracts/Container.php:28
Stack trace:`

This fix focuses on two things - 

1. Move the logic for checking Promoter license key into a hook that runs on `tribe_common_loaded`. This is so that we know that PUE is loaded already.
2. Move `monitor_active_plugins` and `initialize_license_check` into `admin_init` instead of `tec_pue_checker_init`. This is done so we know that certain methods like `tribe_is_truthy()` is already defined.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5384]: https://stellarwp.atlassian.net/browse/TEC-5384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ