### PR TITLE
[TEC-5385] Ignore checking empty licenses

### DIFF
--- a/changelog/fix-TEC-5385_dont_check_empty_license_keys
+++ b/changelog/fix-TEC-5385_dont_check_empty_license_keys
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Update the license checker to ignore empty licenses. [TEC-5385]

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1213,6 +1213,8 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		/**
 		 * Checks for the license key status with MT servers.
 		 *
+		 * @since 6.5.1.1 Bail early if no license key is found.
+		 *
 		 * @param string $key     The license key to check.
 		 * @param bool   $network Whether the key to check for is a network one or not.
 		 *
@@ -1221,6 +1223,10 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		public function validate_key( string $key, bool $network = false ): array {
 			$response           = [];
 			$response['status'] = 0;
+
+			if ( empty( $key ) ) {
+				return [];
+			}
 
 			$uplink_resource = $this->get_uplink_resource( $this->get_slug() );
 
@@ -1565,7 +1571,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			$install_key = $this->get_key();
 
 			// Check for expired keys.
-			if ( ! empty( $plugin_info->api_expired ) ) {
+			if ( empty( $install_key ) ) {
+				return $plugin_info;
+			} elseif ( ! empty( $plugin_info->api_expired ) ) {
 				$pue_notices->add_notice( Tribe__PUE__Notices::EXPIRED_KEY, $plugin_name );
 			} elseif ( ! empty( $plugin_info->api_upgrade ) ) {
 				// Check for keys that are out of installs (*must* happen before the api_invalid test).
@@ -1847,8 +1855,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 
 		/**
 		 * Check for plugin updates.
-		 *
 		 * The results are stored in the DB option specified in $pue_option_name.
+		 *
+		 * @since 6.5.1.1 Bail early if no license key is found.
 		 *
 		 * @param array|object $updates       Existing updates.
 		 * @param boolean      $force_recheck Whether to force a recheck of the update status.
@@ -1856,6 +1865,9 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		 * @return array|object
 		 */
 		public function check_for_updates( $updates = [], bool $force_recheck = false ) {
+			if ( empty( $this->get_key() ) ) {
+				return $updates;
+			}
 			$state = $this->get_state( $force_recheck );
 
 			$state->lastCheck      = time();
@@ -2320,6 +2332,8 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 		/**
 		 * Initializes a license check during PUE Checker initialization.
 		 *
+		 * @since 6.5.1.1 Bail early if no license key is found.
+		 *
 		 * @param Tribe__PUE__Checker $checker An instance of the PUE Checker.
 		 */
 		public function initialize_license_check( Tribe__PUE__Checker $checker ): void {
@@ -2345,9 +2359,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			// Retrieve the license.
 			$license = get_option( $checker->get_license_option_key() );
 			if ( empty( $license ) ) {
-				// Set transient for invalid status to avoid repeated checks.
-				set_transient( $this->pue_key_status_transient_name, 'invalid', HOUR_IN_SECONDS );
-
+				// An empty license doesn't mean an invalid plugin. So skip it.
 				return;
 			}
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1868,6 +1868,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			if ( empty( $this->get_key() ) ) {
 				return $updates;
 			}
+
 			$state = $this->get_state( $force_recheck );
 
 			$state->lastCheck      = time();
@@ -2359,7 +2360,7 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 			// Retrieve the license.
 			$license = get_option( $checker->get_license_option_key() );
 			if ( empty( $license ) ) {
-				// An empty license doesn't mean an invalid plugin. So skip it.
+				// An empty license doesn't always mean an invalid plugin. So skip it.
 				return;
 			}
 

--- a/src/Tribe/PUE/Checker.php
+++ b/src/Tribe/PUE/Checker.php
@@ -1572,7 +1572,8 @@ if ( ! class_exists( 'Tribe__PUE__Checker' ) ) {
 
 			// Check for expired keys.
 			if ( empty( $install_key ) ) {
-				return $plugin_info;
+				// Return null on empty license keys.
+				return null;
 			} elseif ( ! empty( $plugin_info->api_expired ) ) {
 				$pue_notices->add_notice( Tribe__PUE__Notices::EXPIRED_KEY, $plugin_name );
 			} elseif ( ! empty( $plugin_info->api_upgrade ) ) {


### PR DESCRIPTION
### 🎫 Ticket
[TEC-5385] 
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

When users had Event Aggregator, or paid products without a license (empty) the PUE checker would still check if there were any updates.

We changed the logic to bail early if no license key is found.

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->
[Screencast from 02-11-2025 02:50:11 PM.webm](https://github.com/user-attachments/assets/4a8cf1fa-edac-4aca-8a70-9082952f86f4)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5385]: https://stellarwp.atlassian.net/browse/TEC-5385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ