### PR TITLE
Update schema version to latest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "stellarwp/db": "^1.0.3",
     "stellarwp/installer": "^1.1.0",
     "stellarwp/models": "dev-main",
-    "stellarwp/schema": "^1.1.3",
+    "stellarwp/schema": "^1.1.8",
     "stellarwp/telemetry": "^2.3.1",
     "stellarwp/assets": "1.4.2",
     "stellarwp/admin-notices": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d34ed5899218cfb511d9033c2f1a48ce",
+    "content-hash": "956b3e8feda4b5c337d3b015c1ab5f1c",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -674,16 +674,16 @@
         },
         {
             "name": "stellarwp/schema",
-            "version": "1.1.7",
+            "version": "1.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/schema.git",
-                "reference": "4dc49390f9c9babedb85f70574603c8a3971edd7"
+                "reference": "979344c46d9c54a7891a27e7399fd391fa51b755"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/schema/zipball/4dc49390f9c9babedb85f70574603c8a3971edd7",
-                "reference": "4dc49390f9c9babedb85f70574603c8a3971edd7",
+                "url": "https://api.github.com/repos/stellarwp/schema/zipball/979344c46d9c54a7891a27e7399fd391fa51b755",
+                "reference": "979344c46d9c54a7891a27e7399fd391fa51b755",
                 "shasum": ""
             },
             "require": {
@@ -727,9 +727,9 @@
             "description": "A library for simplifying the creation and updates of custom tables within WordPress.",
             "support": {
                 "issues": "https://github.com/stellarwp/schema/issues",
-                "source": "https://github.com/stellarwp/schema/tree/1.1.7"
+                "source": "https://github.com/stellarwp/schema/tree/1.1.8"
             },
-            "time": "2024-06-06T17:01:03+00:00"
+            "time": "2025-01-10T19:40:08+00:00"
         },
         {
             "name": "stellarwp/telemetry",

--- a/src/Common/Integrations/Custom_Table_Abstract.php
+++ b/src/Common/Integrations/Custom_Table_Abstract.php
@@ -69,28 +69,4 @@ abstract class Custom_Table_Abstract extends Table {
 
 		return $results;
 	}
-
-	/**
-	 * Empties the custom table in a way that is not causing an implicit commit.
-	 *
-	 * Even though the method is called truncate it doesn't use TRUNCATE.
-	 * Thats because we want to avoid implicit commits in the DB making this method suitable for using during a testcase.
-	 * If you want to use TRUNCATE you can use the `empty_table` method instead.
-	 *
-	 * @since TBD
-	 *
-	 * @return bool|int Whether it was emptied or not.
-	 */
-	public function truncate() {
-		DB::query( 'SET FOREIGN_KEY_CHECKS = 0;' );
-		$deleted = DB::query(
-			DB::prepare(
-				'DELETE FROM %i',
-				static::table_name( true )
-			)
-		);
-		DB::query( 'SET FOREIGN_KEY_CHECKS = 1;' );
-
-		return is_numeric( $deleted );
-	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[ETP-974]
<!-- Ticket ID, if there's any put it between brackets -->

Updates stellarwp/schema version to 1.1.8 which includes the `truncate()` function so we can remove it.

[ETP-974]: https://stellarwp.atlassian.net/browse/ETP-974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ