### PR TITLE
Hide Install Event Tickets button if step has been completed

### DIFF
--- a/changelog/fix-TEC-5410-hide-install-ET-button
+++ b/changelog/fix-TEC-5410-hide-install-ET-button
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Added CSS that will hide the Install Event Tickets button following completing the Onboarding Wizard. [TEC_5410]

--- a/changelog/fix-TEC-5410-hide-install-ET-button
+++ b/changelog/fix-TEC-5410-hide-install-ET-button
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fix
 
-Added CSS that will hide the Install Event Tickets button following completing the Onboarding Wizard. [TEC_5410]
+Added CSS that will hide the Install Event Tickets button following completing the Onboarding Wizard. [TEC-5410]

--- a/src/resources/postcss/tribe-common-admin/tec_baseline_admin/_step-list.pcss
+++ b/src/resources/postcss/tribe-common-admin/tec_baseline_admin/_step-list.pcss
@@ -60,5 +60,9 @@
 			border: 0;
 			margin: 1px var(--tec-spacer-1) 1px 1px;
 		}
+
+		&#tec-events-onboarding-wizard-tickets-item .step-list__item-right {
+			display: none;
+		}
 	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5410]

### 🗒️ Description

On completely fresh WP installs, if the Onboarding Wizard step 5 was completed to install and activate ET, when the Wizard closed, the green check mark would successfully show, but the 'Install Event Tickets' button would still show incorrectly and cause a console error if clicked.

This PR adds some logic to remove the 'Install Event Tickets' button if the Onboarding Wizard has been completed.

### 🎥 Artifacts 
Before:
![image](https://github.com/user-attachments/assets/773c5ff0-9ef8-4ec2-b687-7deb1f94f244)

After:
![CleanShot 2025-03-04 at 14 37 39@2x](https://github.com/user-attachments/assets/a4847cbb-0223-46a2-8d4f-59b89d57ed64)


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5410]: https://stellarwp.atlassian.net/browse/TEC-5410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ