### PR TITLE
Make sure we flush permalinks on updates

### DIFF
--- a/changelog/fix-flush-permalinkson-update
+++ b/changelog/fix-flush-permalinkson-update
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Make sure update callbacks are executed prior `wp_loaded` action.
+Make sure update callbacks are executed prior `wp_loaded` action. [TEC-5436]

--- a/changelog/fix-flush-permalinkson-update
+++ b/changelog/fix-flush-permalinkson-update
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Make sure update callbacks are executed prior `wp_loaded` action.

--- a/src/Common/Updater.php
+++ b/src/Common/Updater.php
@@ -90,6 +90,10 @@ class Updater extends Tribe__Updater {
 			return;
 		}
 
+		if ( ! is_admin() ) {
+			return;
+		}
+
 		// Dom't run on AJAX requests.
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 			return;
@@ -100,7 +104,11 @@ class Updater extends Tribe__Updater {
 			return;
 		}
 
-		add_action( 'admin_init', [ $this, 'do_updates' ] );
+		if ( ! $this->update_required() ) {
+			return;
+		}
+
+		$this->do_updates();
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5436]
Issue 17 from [gsheet](https://docs.google.com/spreadsheets/d/1NzXAjMpzE7Cum9rOix2ctIjEsdpR_YgFLLMKvnGtzkk/edit?gid=439778935#gid=439778935)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The method `do_updates` from the Updates instance must run before wp_loaded for the flush_permalinks to happen! admin_init is taking place after wp_loaded.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5436]: https://stellarwp.atlassian.net/browse/TEC-5436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ