### PR TITLE
Consider group path in tec_asset function

### DIFF
--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -972,7 +972,7 @@ if ( ! function_exists( 'tec_asset' ) ) {
 		/** @var Asset $asset */
 		$asset = Tribe__Assets::instance()->register( $origin, $slug, $file, $dependencies, $action, $arguments );
 
-		$prefix_asset_directory = $arguments['prefix_asset_directory'] ?? true;
+		$prefix_asset_directory = $arguments['prefix_asset_directory'] ?? ( empty( $arguments['group_path'] ) || ! str_ends_with( $arguments['group_path'], '-packages' ) );
 		$asset->prefix_asset_directory( $prefix_asset_directory );
 
 		$asset->get_url();


### PR DESCRIPTION
### 🗒️ Description

Also consider to which group_path the asset belongs to (if any) before deciding if it should use prefix or not!

If the asset was added to the `-packages` group path but without specifying the param for asset group prefix, the asset group prefix would be forced as true, making the group path `-packages` redundant 