### PR TITLE
There is no need to store callbacks

### DIFF
--- a/src/Tribe/Context.php
+++ b/src/Tribe/Context.php
@@ -458,10 +458,7 @@ class Tribe__Context {
 
 		static::$locations = array_merge( static::$locations, $this->override_locations );
 
-		if ( has_filter( 'tribe_context_locations' ) && $this->prepopulate_locations ) {
-			// Store a local cache of the hooks.
-			$this->save_location_hooks();
-
+		if ( $this->prepopulate_locations ) {
 			/**
 			 * Filters the locations registered in the Context.
 			 *
@@ -474,49 +471,10 @@ class Tribe__Context {
 			static::$locations = apply_filters( 'tribe_context_locations', static::$locations, $this );
 
 			// Remove all filters everytime it runs.
-			remove_all_filters( 'tribe_context_locations' );
+			$this->prepopulate_locations = false;
 		}
 
 		return static::$locations;
-	}
-
-	/**
-	 * Stores the hooks in the cache.
-	 *
-	 * @since TBD
-	 */
-	protected function save_location_hooks(): void {
-		global $wp_filter;
-		if ( ! isset( $wp_filter['tribe_context_locations'] ) ) {
-			return;
-		}
-
-		foreach ( $wp_filter['tribe_context_locations']->callbacks as $priority => $callbacks ) {
-			foreach ( $callbacks as $idx => $callback ) {
-				$this->locations_callbacks[] = [
-					'priority'      => $priority,
-					'accepted_args' => $callback['accepted_args'],
-					'function'      => $callback['function'],
-					'idx'           => $idx,
-				];
-			}
-		}
-	}
-
-	/**
-	 * Re-hooks the locations callbacks.
-	 *
-	 * @since TBD
-	 */
-	public function hook_locations_callbacks() {
-		foreach ( $this->locations_callbacks as $hook ) {
-			// Ignore back hooks.
-			if ( ! isset( $hook['function'], $hook['priority'], $hook['accepted_args'] ) ) {
-				continue;
-			}
-
-			add_filter( 'tribe_context_locations', $hook['function'], $hook['priority'], $hook['accepted_args'] );
-		}
 	}
 
 	/**

--- a/tests/wpunit/Tribe/ContextTest.php
+++ b/tests/wpunit/Tribe/ContextTest.php
@@ -1736,6 +1736,8 @@ class ContextTest extends \Codeception\TestCase\WPTestCase {
 		// Both are diff context instances, locations are one and the same.
 		$this->assertNotSame( $context, tribe_context() );
 
+		$context->dangerously_repopulate_locations();
+
 		$value_overwrite_before_reset = $context->get( $context_key( '__closure_overwrite__' ) );
 		$value_before_reset = $context->get( $context_key( '__closure__' ) );
 


### PR DESCRIPTION
### 🎫 Ticket

No specific ticket

### 🗒️ Description

Prevents introducing method just for the sake of test environment. It uses the hook system normally.

If we have an issue where our hooks get applied multiple times over and over we should prevent that and not blindly remove our hooks

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
