### PR TITLE
Prevents loading prior common is loaded

### DIFF
--- a/changelog/fix-prevent-logging-if-common-is-not-loaded
+++ b/changelog/fix-prevent-logging-if-common-is-not-loaded
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevents logging while common hasn't fully loaded yet.

--- a/src/Tribe/Log/Service_Provider.php
+++ b/src/Tribe/Log/Service_Provider.php
@@ -153,6 +153,10 @@ class Service_Provider extends Provider_Contract {
 	 * @see   \TEC\Common\Monolog\Logger for the log level constants and names.
 	 */
 	public function dispatch_log( $level = 'debug', $message = '', array $context = [] ) {
+		if ( ! did_action( 'tribe_common_loaded' ) ) {
+			return;
+		}
+
 		// Goes from something like `debug` to `100`.
 		$level = is_numeric( $level ) ? $level : Logger::toMonologLevel( $level );
 


### PR DESCRIPTION
Prevent logging anything prior common is loaded - and as a result Monolog is not bound to the container yet