### PR TITLE
FBAR-330 Allow tabbing through select2 elements

### DIFF
--- a/changelog/fix-FBAR-330-tabindex-results
+++ b/changelog/fix-FBAR-330-tabindex-results
@@ -1,0 +1,4 @@
+Significance: minor
+Type: accessibility
+
+Improve accessibility of select2 component, allowing tabbing into elements. [FBAR-330]

--- a/vendor/tribe-selectWoo/dist/js/selectWoo.full.js
+++ b/vendor/tribe-selectWoo/dist/js/selectWoo.full.js
@@ -1928,7 +1928,7 @@ S2.define('select2/selection/search',[
   Search.prototype.render = function (decorated) {
     var $search = $(
       '<li class="select2-search select2-search--inline">' +
-        '<input class="select2-search__field" type="text"' +
+        '<input class="select2-search__field" type="text" tabindex="-1"' +
         ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
         ' spellcheck="false" role="textbox" aria-autocomplete="list" />' +
       '</li>'
@@ -4000,7 +4000,7 @@ S2.define('select2/dropdown/search',[
 
     var $search = $(
       '<span class="select2-search select2-search--dropdown">' +
-        '<input class="select2-search__field" type="text"' +
+        '<input class="select2-search__field" type="text" tabindex="-1"' +
         ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
         ' spellcheck="false" role="combobox" aria-autocomplete="list" aria-expanded="true" />' +
       '</span>'

--- a/vendor/tribe-selectWoo/dist/js/selectWoo.full.js
+++ b/vendor/tribe-selectWoo/dist/js/selectWoo.full.js
@@ -799,7 +799,7 @@ S2.define('select2/results',[
 
   Results.prototype.render = function () {
     var $results = $(
-      '<ul class="select2-results__options" role="listbox" tabindex="-1"></ul>'
+      '<ul class="select2-results__options" role="listbox" tabindex="0"></ul>'
     );
 
     if (this.options.get('multiple')) {
@@ -958,7 +958,7 @@ S2.define('select2/results',[
     var attrs = {
       'role': 'option',
       'data-selected': 'false',
-      'tabindex': -1
+      'tabindex': '0'
     };
 
     if (data.disabled) {
@@ -1928,7 +1928,7 @@ S2.define('select2/selection/search',[
   Search.prototype.render = function (decorated) {
     var $search = $(
       '<li class="select2-search select2-search--inline">' +
-        '<input class="select2-search__field" type="text" tabindex="-1"' +
+        '<input class="select2-search__field" type="text"' +
         ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
         ' spellcheck="false" role="textbox" aria-autocomplete="list" />' +
       '</li>'
@@ -4000,7 +4000,7 @@ S2.define('select2/dropdown/search',[
 
     var $search = $(
       '<span class="select2-search select2-search--dropdown">' +
-        '<input class="select2-search__field" type="text" tabindex="-1"' +
+        '<input class="select2-search__field" type="text"' +
         ' autocomplete="off" autocorrect="off" autocapitalize="none"' +
         ' spellcheck="false" role="combobox" aria-autocomplete="list" aria-expanded="true" />' +
       '</span>'


### PR DESCRIPTION
### 🎫 Ticket

[FBAR-330]

### 🗒️ Description

The elements in any FilterBar section that has a multichoice dropdown (Tags, Categories, Series, etc) are not included in the keyboard navigational sequence because they have `tabindex='-1'` assigned, breaking the expected keyboard navigation for the web page.

This change is in the tribe-selectWoo vendor to tweak this value from '-1' to '0' for the `results` dropdown elements

### 🎥 Artifacts 

https://github.com/user-attachments/assets/9c651acf-3987-4efb-bc61-16edbcaff6fd



### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[FBAR-330]: https://stellarwp.atlassian.net/browse/FBAR-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ