### PR TITLE
FBAR-332 Add accessibility tags to No Events result icon

### DIFF
--- a/changelog/bucket-filterbar-maintenance
+++ b/changelog/bucket-filterbar-maintenance
@@ -1,0 +1,4 @@
+Significance: minor
+Type: accessibility
+
+Add empty alt tag to no events icon so screen readers will skip. [FBAR-332]

--- a/changelog/bucket-filterbar-maintenance
+++ b/changelog/bucket-filterbar-maintenance
@@ -1,4 +1,0 @@
-Significance: minor
-Type: accessibility
-
-Add empty alt tag to no events icon so screen readers will skip. [FBAR-332]

--- a/changelog/fix-add-accessibility-attr-to-icon
+++ b/changelog/fix-add-accessibility-attr-to-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: accessibility
+
+Added proper accessibility attributes to the no results icon to ensure screen readers skip over it. [FBAR-332]

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "stellarwp/assets": "1.4.2",
     "stellarwp/admin-notices": "^1.1",
     "stellarwp/uplink": "2.2.2",
-    "woocommerce/action-scheduler": "3.9.0"
+    "woocommerce/action-scheduler": "3.9.2"
   },
   "require-dev": {
     "automattic/vipwpcs": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9edc7eaf3ea1058acb5a0271a3dba910",
+    "content-hash": "f6dcf9ba26c9424458a3601a871c03b4",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -849,16 +849,16 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.9.0",
+            "version": "3.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "90b98e6fe97d455679b1d288f050cad8f6f79771"
+                "reference": "efbb7953f72a433086335b249292f280dd43ddfe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/90b98e6fe97d455679b1d288f050cad8f6f79771",
-                "reference": "90b98e6fe97d455679b1d288f050cad8f6f79771",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/efbb7953f72a433086335b249292f280dd43ddfe",
+                "reference": "efbb7953f72a433086335b249292f280dd43ddfe",
                 "shasum": ""
             },
             "require": {
@@ -886,9 +886,9 @@
             "homepage": "https://actionscheduler.org/",
             "support": {
                 "issues": "https://github.com/woocommerce/action-scheduler/issues",
-                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.0"
+                "source": "https://github.com/woocommerce/action-scheduler/tree/3.9.2"
             },
-            "time": "2024-11-15T00:11:39+00:00"
+            "time": "2025-02-03T09:09:30+00:00"
         }
     ],
     "packages-dev": [

--- a/src/views/v2/components/icons/messages-not-found.php
+++ b/src/views/v2/components/icons/messages-not-found.php
@@ -12,7 +12,7 @@
  * @var array<string> $classes Additional classes to add to the svg icon.
  *
  * @version 4.12.14
- * @since TBD Added empty alt attribute for accessibility.
+ * @since TBD Added accessibility attributes to make icon decorative.
  *
  */
 $svg_classes = [ 'tribe-common-c-svgicon', 'tribe-common-c-svgicon--messages-not-found' ];
@@ -21,4 +21,4 @@ if ( ! empty( $classes ) ) {
 	$svg_classes = array_merge( $svg_classes, $classes );
 }
 ?>
-<svg <?php tribe_classes( $svg_classes ); ?> viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg" alt=""><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
+<svg <?php tribe_classes( $svg_classes ); ?> viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="img" focusable="false"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>

--- a/src/views/v2/components/icons/messages-not-found.php
+++ b/src/views/v2/components/icons/messages-not-found.php
@@ -12,6 +12,7 @@
  * @var array<string> $classes Additional classes to add to the svg icon.
  *
  * @version 4.12.14
+ * @since TBD Added empty alt attribute for accessibility.
  *
  */
 $svg_classes = [ 'tribe-common-c-svgicon', 'tribe-common-c-svgicon--messages-not-found' ];
@@ -20,4 +21,4 @@ if ( ! empty( $classes ) ) {
 	$svg_classes = array_merge( $svg_classes, $classes );
 }
 ?>
-<svg <?php tribe_classes( $svg_classes ); ?> viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
+<svg <?php tribe_classes( $svg_classes ); ?> viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg" alt=""><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>

--- a/src/views/v2/components/icons/messages-not-found.php
+++ b/src/views/v2/components/icons/messages-not-found.php
@@ -21,4 +21,11 @@ if ( ! empty( $classes ) ) {
 	$svg_classes = array_merge( $svg_classes, $classes );
 }
 ?>
-<svg <?php tribe_classes( $svg_classes ); ?> viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="img" focusable="false"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
+<svg <?php tribe_classes( $svg_classes ); ?> viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="presentation" tabindex="-1">
+	<g fill-rule="evenodd">
+		<path d="M.5 2.5h20v20H.5z"/>
+		<path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/>
+		<path stroke-linecap="round" d="M4.5.5v4m12-4v4"/>
+		<path stroke-linecap="square" d="M.5 7.5h20"/>
+	</g>
+</svg>

--- a/tests/as_integration/Ensure_Latest_AS_Test.php
+++ b/tests/as_integration/Ensure_Latest_AS_Test.php
@@ -7,7 +7,7 @@ use ActionScheduler_Versions;
 
 class Ensure_Latest_AS_Test extends WPTestCase {
 	public function test_latest_as() {
-		$current_version = '3.9.0';
+		$current_version = '3.9.2';
 
 		$as_versions = ActionScheduler_Versions::instance();
 		$loaded_version = $as_versions->latest_version();

--- a/tests/eva_integration/Views/V2/Components/Icons/__snapshots__/Messages_Not_FoundTest__test_render_with_classes__0.snapshot.html
+++ b/tests/eva_integration/Views/V2/Components/Icons/__snapshots__/Messages_Not_FoundTest__test_render_with_classes__0.snapshot.html
@@ -1,1 +1,8 @@
-<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found test-class-1 test-class-2"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
+<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found test-class-1 test-class-2"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="presentation" tabindex="-1">
+	<g fill-rule="evenodd">
+		<path d="M.5 2.5h20v20H.5z"/>
+		<path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/>
+		<path stroke-linecap="round" d="M4.5.5v4m12-4v4"/>
+		<path stroke-linecap="square" d="M.5 7.5h20"/>
+	</g>
+</svg>

--- a/tests/eva_integration/Views/V2/Components/Icons/__snapshots__/Messages_Not_FoundTest__test_render_without_classes__0.snapshot.html
+++ b/tests/eva_integration/Views/V2/Components/Icons/__snapshots__/Messages_Not_FoundTest__test_render_without_classes__0.snapshot.html
@@ -1,1 +1,8 @@
-<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd"><path d="M.5 2.5h20v20H.5z"/><path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/><path stroke-linecap="round" d="M4.5.5v4m12-4v4"/><path stroke-linecap="square" d="M.5 7.5h20"/></g></svg>
+<svg  class="tribe-common-c-svgicon tribe-common-c-svgicon--messages-not-found"  viewBox="0 0 21 23" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" role="presentation" tabindex="-1">
+	<g fill-rule="evenodd">
+		<path d="M.5 2.5h20v20H.5z"/>
+		<path stroke-linecap="round" d="M7.583 11.583l5.834 5.834m0-5.834l-5.834 5.834" class="tribe-common-c-svgicon__svg-stroke"/>
+		<path stroke-linecap="round" d="M4.5.5v4m12-4v4"/>
+		<path stroke-linecap="square" d="M.5 7.5h20"/>
+	</g>
+</svg>


### PR DESCRIPTION
### 🎫 Ticket

[FBAR-332]

### 🗒️ Description

This came up in [this PR](https://github.com/the-events-calendar/the-events-calendar/pull/5045) - the icon for the 'No Events Found' results is being read by screen readers, which is unnecessary. This adds more accessibility attributes to avoid reading out the icon if the focus is shifted to the results to keep the focus on the 'No Events Found' alert message. 

### 🎥 Artifacts 

https://github.com/user-attachments/assets/09af976c-2f55-46a0-af6f-bf256c584c39


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[FBAR-332]: https://stellarwp.atlassian.net/browse/FBAR-332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ