### PR TITLE
Fix a bug in Tribe__Template, rename a constant.

### DIFF
--- a/src/Common/Admin/Abstract_Admin_Page.php
+++ b/src/Common/Admin/Abstract_Admin_Page.php
@@ -191,7 +191,7 @@ abstract class Abstract_Admin_Page {
 			return false;
 		}
 
-		return static::$is_dismissed;
+		return (bool) tribe_get_option( static::DISMISS_PAGE_OPTION, false );
 	}
 
 	/**

--- a/src/Tribe/Template.php
+++ b/src/Tribe/Template.php
@@ -137,7 +137,7 @@ class Tribe__Template {
 		if (
 			empty( $origin->plugin_path )
 			&& empty( $origin->pluginPath )
-			&& ! is_dir( $origin )
+			&& ( is_string( $origin ) && ! is_dir( $origin ) )
 		) {
 			throw new InvalidArgumentException( 'Invalid Origin Class for Template Instance' );
 		}


### PR DESCRIPTION
### 🎫 Ticket

[ET_2380]

### 🗒️ Description

Discovered that somewhere along the way `set_template_origin()` decided that `$origin` can be an object AND a string at the same time.

Also tweaked the  `Abstract_Admin_Page` `is_dismissed` function to return the saved option value. We were overriding this function in TEC for no reason.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
