### PR TITLE
More specific event triggers

### DIFF
--- a/src/resources/js/dependency.js
+++ b/src/resources/js/dependency.js
@@ -335,6 +335,6 @@
 	$window.on( 'load', obj.setup );
 
 	// Re-run the setup when the widgets are toggled
-	$( document.body ).on( 'click.widgets-toggle', obj.setup );
+	$(document).on('widget-updated widget-added', obj.setup);
 
 }( jQuery, window.underscore || window._, {} ) );


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5396]

### 🗒️ Description

Fixing [QA reported issues](https://docs.google.com/spreadsheets/d/1NzXAjMpzE7Cum9rOix2ctIjEsdpR_YgFLLMKvnGtzkk/edit?gid=2103530230#gid=2103530230). This PR fixes:
- Dependent dropdowns were being initialized twice, because of a `dependency.js` eventListener that was added for the QR Code Widget

[TEC-5396]: https://stellarwp.atlassian.net/browse/TEC-5396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ