### PR TITLE
Country List with Stripe info

### DIFF
--- a/src/Common/Lists/Country.php
+++ b/src/Common/Lists/Country.php
@@ -380,13 +380,13 @@ class Country {
 			$api_countries[ $country['id'] ] = $country;
 		}
 
-		// Process all countries from the base list.
+		// Process all countries from the base list and add the Payment Gateways support information.
 		foreach ( $base_countries as $continent => $countries ) {
 			foreach ( $countries as $code => $name ) {
 				$result[ $code ] = [
-					'name'       => __( $name ),
+					'name'       => $name,
 					'group'      => $continent,
-					'has_paypal' => false,
+					'has_paypal' => $api_countries[ $code ]['paypal']['is_active'] ?? false,
 					'has_stripe' => $api_countries[ $code ]['stripe']['is_active'] ?? false,
 					'has_square' => false,
 				];

--- a/src/Common/Lists/Country.php
+++ b/src/Common/Lists/Country.php
@@ -384,15 +384,9 @@ class Country {
 					'name'       => __( $name ),
 					'group'      => $continent,
 					'has_paypal' => true,
-					'has_stripe' => false,
+					'has_stripe' => $stripe_data['countries'][ $code ]['is_active'] ?? false,
 					'has_square' => true,
 				];
-
-				// Check if this country exists in Stripe data and is active.
-				if ( isset( $stripe_data['countries'][ $code ] ) &&
-					! empty( $stripe_data['countries'][ $code ]['is_active'] ) {
-					$result[ $code ]['has_stripe'] = true;
-				}
 			}
 		}
 

--- a/src/Common/Lists/Country.php
+++ b/src/Common/Lists/Country.php
@@ -364,9 +364,9 @@ class Country {
 					$result[ $code ] = [
 						'name'       => $name,
 						'group'      => $continent,
-						'has_paypal' => true,
-						'has_stripe' => true,
-						'has_square' => true,
+						'has_paypal' => false,
+						'has_stripe' => false,
+						'has_square' => false,
 					];
 				}
 			}
@@ -375,7 +375,7 @@ class Country {
 			return $result;
 		}
 
-		// TODO: Check for other payment gateways, Square/PayPal/etc.
+		// TODO: Check for other payment gateways, Square and PayPal.
 		// TODO: Load translations for countries. What textdomain?
 		// Process all countries from the base list.
 		foreach ( $base_countries as $continent => $countries ) {
@@ -383,9 +383,9 @@ class Country {
 				$result[ $code ] = [
 					'name'       => __( $name ),
 					'group'      => $continent,
-					'has_paypal' => true,
+					'has_paypal' => false,
 					'has_stripe' => $stripe_data['countries'][ $code ]['is_active'] ?? false,
-					'has_square' => true,
+					'has_square' => false,
 				];
 			}
 		}

--- a/src/Common/Lists/Country.php
+++ b/src/Common/Lists/Country.php
@@ -390,8 +390,7 @@ class Country {
 
 				// Check if this country exists in Stripe data and is active.
 				if ( isset( $stripe_data['countries'][ $code ] ) &&
-					isset( $stripe_data['countries'][ $code ]['is_active'] ) &&
-					$stripe_data['countries'][ $code ]['is_active'] === true ) {
+					! empty( $stripe_data['countries'][ $code ]['is_active'] ) {
 					$result[ $code ]['has_stripe'] = true;
 				}
 			}

--- a/src/Common/Lists/Currency.php
+++ b/src/Common/Lists/Currency.php
@@ -46,6 +46,12 @@ class Currency {
 				'symbol' => '£',
 				'entity' => '&pound;',
 			],
+			'bgn'     => [
+				'code'   => 'BGN',
+				'name'   => __( 'Bulgarian Lev', 'event-tickets' ),
+				'symbol' => 'лв',
+				'entity' => '&#1083;&#1074;',
+			],
 			'cad'     => [
 				'code'   => 'CAD',
 				'name'   => __( 'Canadian Dollar', 'event-tickets' ),
@@ -63,6 +69,12 @@ class Currency {
 				'name'   => __( 'Chinese Yuan (元)', 'event-tickets' ),
 				'symbol' => '元',
 				'entity' => '&#20803;',
+			],
+			'hrk'     => [
+				'code'   => 'HRK',
+				'name'   => __( 'Croatian Kuna', 'event-tickets' ),
+				'symbol' => 'kn',
+				'entity' => 'kn',
 			],
 			'czk'     => [
 				'code'   => 'CZK',
@@ -136,17 +148,17 @@ class Currency {
 				'symbol' => '$',
 				'entity' => '&#36;',
 			],
-			'ngn'     => [
-				'code'   => 'NGN',
-				'name'   => __( 'Nigerian Naira', 'event-tickets' ),
-				'symbol' => '₦',
-				'entity' => '&#8358;',
-			],
 			'nzd'     => [
 				'code'   => 'NZD',
 				'name'   => __( 'New Zealand Dollar', 'event-tickets' ),
 				'symbol' => '$',
 				'entity' => '&#36;',
+			],
+			'ngn'     => [
+				'code'   => 'NGN',
+				'name'   => __( 'Nigerian Naira', 'event-tickets' ),
+				'symbol' => '₦',
+				'entity' => '&#8358;',
 			],
 			'nok'     => [
 				'code'   => 'NOK',
@@ -166,17 +178,23 @@ class Currency {
 				'symbol' => 'zł',
 				'entity' => 'z&#x142;',
 			],
+			'ron'     => [
+				'code'   => 'RON',
+				'name'   => __( 'Romanian Leu', 'event-tickets' ),
+				'symbol' => 'lei',
+				'entity' => 'lei',
+			],
 			'rub'     => [
 				'code'   => 'RUB',
 				'name'   => __( 'Russian Ruble', 'event-tickets' ),
 				'symbol' => '₽',
 				'entity' => '&#8381;',
 			],
-			'sek'     => [
-				'code'   => 'SEK',
-				'name'   => __( 'Swedish Krona', 'event-tickets' ),
-				'symbol' => 'kr',
-				'entity' => 'kr',
+			'sar'     => [
+				'code'   => 'SAR',
+				'name'   => __( 'Saudi Riyal', 'event-tickets' ),
+				'symbol' => 'ر.س',
+				'entity' => '&#x631;.&#x633;',
 			],
 			'sgd'     => [
 				'code'   => 'SGD',
@@ -189,6 +207,12 @@ class Currency {
 				'name'   => __( 'South African Rand', 'event-tickets' ),
 				'symbol' => 'R',
 				'entity' => 'R',
+			],
+			'sek'     => [
+				'code'   => 'SEK',
+				'name'   => __( 'Swedish Krona', 'event-tickets' ),
+				'symbol' => 'kr',
+				'entity' => 'kr',
 			],
 			'chf'     => [
 				'code'   => 'CHF',
@@ -213,6 +237,12 @@ class Currency {
 				'name'   => __( 'Turkish Lira', 'event-tickets' ),
 				'symbol' => '₺',
 				'entity' => '&#8378;',
+			],
+			'aed'     => [
+				'code'   => 'AED',
+				'name'   => __( 'United Arab Emirates Dirham', 'event-tickets' ),
+				'symbol' => 'د.إ',
+				'entity' => '&#x62f;.&#x625;',
 			],
 			'usd'     => [
 				'code'   => 'USD',


### PR DESCRIPTION
### 🎫 Ticket

[ET-2339]

### 🗒️ Description

Under the ET Onboarding Wizard work, we centralize our Currency and Country lists in Common. We also use the [whodat Stripe API](https://whodatdev.theeventscalendar.com/commerce/v1/stripe/countries) endpoint to pull info about the payment gateway. These methods will also be used by TEC Onboarding Wizard, to centralize our data.

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[ET-2339]: https://stellarwp.atlassian.net/browse/ET-2339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ