### PR TITLE
Fix php 8.1 deprecation warning.

### DIFF
--- a/src/Common/Admin/Abstract_Admin_Page.php
+++ b/src/Common/Admin/Abstract_Admin_Page.php
@@ -273,8 +273,12 @@ abstract class Abstract_Admin_Page {
 	 * Get the menu position of the page.
 	 *
 	 * @since 6.4.1
+	 *
+	 * @since TBD Updated the return type to be null|int|float, to avoid php 8+ deprecation warnings.
+	 *
+	 * @return null|int|float The menu position of the page.
 	 */
-	public function get_position(): ?int {
+	public function get_position() {
 		return $this->menu_position ?? null;
 	}
 


### PR DESCRIPTION
Issue:

```
Implicit conversion from float 1.2 to int loses precision       wp-content/plugins/event-tickets/src/Tickets/Admin/Tickets/Page.php:337
 ```
 
 Fix: 
 The `add_submenu_page` method accepts both `int|float` as position. So, we had to update the method signature to allow both and get rid of the warning when `float` was used.
 