### PR TITLE
Try to keep a fatal from happening due to a filter change.

### DIFF
--- a/src/Tribe/Container.php
+++ b/src/Tribe/Container.php
@@ -298,7 +298,7 @@ if ( ! function_exists( 'tribe_register_provider' ) ) {
 			 */
 			add_action(
 				'tec_tickets_fully_loaded',
-				static function() use ( $container, &$tec_common_et_registered ) {
+				static function () use ( $container, &$tec_common_et_registered ) {
 					if ( ! empty( $tec_common_et_registered ) ) {
 						return;
 					}
@@ -309,7 +309,7 @@ if ( ! function_exists( 'tribe_register_provider' ) ) {
 
 			add_action(
 				'tribe_tickets_plugin_loaded',
-				static function() use ( $container, &$tec_common_et_registered ) {
+				static function () use ( $container, &$tec_common_et_registered ) {
 					if ( ! empty( $tec_common_et_registered ) ) {
 						return;
 					}

--- a/src/Tribe/Container.php
+++ b/src/Tribe/Container.php
@@ -289,6 +289,7 @@ if ( ! function_exists( 'tribe_register_provider' ) ) {
 		$container = Tribe__Container::init();
 
 		if ( $provider_class === 'Tribe\Tickets\Admin\Home\Service_Provider' ) {
+			static $tec_common_et_registered = false;
 			/**
 			 * Prevent binding a poorly located service provider registration in ET pre 5.6.0
 			 * and places it after ET Main::bind_implementations().
@@ -297,8 +298,23 @@ if ( ! function_exists( 'tribe_register_provider' ) ) {
 			 */
 			add_action(
 				'tec_tickets_fully_loaded',
-				static function() use ( $container ) {
+				static function() use ( $container, &$tec_common_et_registered ) {
+					if ( ! empty( $tec_common_et_registered ) ) {
+						return;
+					}
 					$container->register( Tribe\Tickets\Admin\Home\Service_Provider::class );
+					$tec_common_et_registered = true;
+				}
+			);
+
+			add_action(
+				'tribe_tickets_plugin_loaded',
+				static function() use ( $container, &$tec_common_et_registered ) {
+					if ( ! empty( $tec_common_et_registered ) ) {
+						return;
+					}
+					$container->register( Tribe\Tickets\Admin\Home\Service_Provider::class );
+					$tec_common_et_registered = true;
 				}
 			);
 		} else {


### PR DESCRIPTION
Discovered during regression testing.

The change of the filter name in common causes a fatal if TEC is updated before ET is updated, as the required provider does not get loaded before it gets called.

By using the static variable and putting the old filter second, we prevent an extra call to register() if it's already registered and we seem to prevent a deprecation notice as well.