### PR TITLE
Fix slic/driver issues in EVA tests

### DIFF
--- a/.github/workflows/tests-php-eva.yml
+++ b/.github/workflows/tests-php-eva.yml
@@ -42,7 +42,7 @@ jobs:
         if: steps.skip.outputs.value != 1
         with:
           repository: stellarwp/slic
-          ref: main
+          ref: 1.9.2
           path: slic
           fetch-depth: 1
       # ------------------------------------------------------------------------------


### PR DESCRIPTION
This tests version `1.9.2` of `slic` to find out whether it fixes the `end2end` suite driver/Chromedriver image issues.
