### PR TITLE
Prevent a PHP 8.3 Fatal error when cache warming yields non-Array

### DIFF
--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -493,6 +493,11 @@ class Tribe__Rewrite {
 				$wp_canonical = $canonical_url;
 			}
 
+			// Prevent a Fatal error if warming yielded non-Array data
+			if ( ! is_array( $this->canonical_url_cache ) ) {
+				$this->canonical_url_cache = [];
+			}
+
 			$this->canonical_url_cache[ $url ] = $wp_canonical;
 
 			return $wp_canonical;
@@ -511,6 +516,12 @@ class Tribe__Rewrite {
 		if ( empty( $matched_vars ) ) {
 			// The URL does contain query vars, but none we handle.
 			$wp_canonical                      = trailingslashit( redirect_canonical( $url, false ) );
+
+			// Prevent a Fatal error if warming yielded non-Array data
+			if ( ! is_array( $this->canonical_url_cache ) ) {
+				$this->canonical_url_cache = [];
+			}
+
 			$this->canonical_url_cache[ $url ] = $wp_canonical;
 
 			return $wp_canonical;
@@ -1164,6 +1175,11 @@ class Tribe__Rewrite {
 		}
 
 		$clean = $this->get_canonical_url( add_query_arg( $parsed_vars, home_url( '/' ) ), $force );
+
+		// Prevent a Fatal error if warming yielded non-Array data
+		if ( ! is_array( $this->clean_url_cache ) ) {
+			$this->clean_url_cache = [];
+		}
 
 		$this->clean_url_cache[ $url ] = $clean;
 


### PR DESCRIPTION
### 🗒️ Description

Prevent a PHP 8.3 Fatal error when cache warming yields non-Array. Sometimes due to cache eviction, persistent object cache corruption, or other unexpected factors, the `canonical_url_cache` and `clean_url_cache` can get populated with data other than an Array upon cache warming. When this happens, an unrecoverable Fatal error is thrown. This change prevents the Fatal error and applies a sane state of an empty Array to prevent crashing the site. 
- Bug fix
- Resolve a Fatal error in PHP 8.3
- Full backwards compatibility expected
- Error thrown on TEC plugin release version 6.13.2.1

Stack trace of PHP Fatal error this resolves:
```
[10-Jun-2025 12:11:07 UTC] PHP Fatal error:  Uncaught TypeError: Cannot access offset of type string on string in /home/wordpress/public_html/wp-content/plugins/the-events
-calendar/common/src/Tribe/Rewrite.php:1168
Stack trace:
#0 /home/wordpress/public_html/wp-content/plugins/the-events-calendar/src/Tribe/Views/V2/View.php(978): Tribe__Rewrite->get_clean_url('https://www.exa...', false)
#1 /home/wordpress/public_html/wp-content/plugins/the-events-calendar/src/Tribe/Views/V2/View.php(1708): Tribe\Events\Views\V2\View->get_url(true)
#2 /home/wordpress/public_html/wp-content/plugins/the-events-calendar/src/Tribe/Views/V2/Views/Widgets/Widget_View.php(102): Tribe\Events\Views\V2\View->setup_template_var
s()
#3 /home/wordpress/public_html/wp-content/plugins/the-events-calendar/src/Tribe/Views/V2/Views/Widgets/Widget_List_View.php(67): Tribe\Events\Views\V2\Views\Widgets\Widget
_View->setup_template_vars()
#4 /home/wordpress/public_html/wp-content/plugins/the-events-calendar/src/Tribe/Views/V2/View.php(731): Tribe\Events\Views\V2\Views\Widgets\Widget_List_View->setup_templat
e_vars()
#5 /home/wordpress/public_html/wp-content/plugins/the-events-calendar/src/Tribe/Views/V2/Widgets/Widget_Abstract.php(134): Tribe\Events\Views\V2\View->get_html()
#6 /home/wordpress/public_html/wp-content/plugins/the-events-calendar/common/src/Tribe/Widget/Widget_Abstract.php(307): Tribe\Events\Views\V2\Widgets\Widget_Abstract->get_
html()
#7 /home/wordpress/public_html/wp-includes/widgets.php(1269): Tribe\Widget\Widget_Abstract->widget(Array, Array)
#8 /home/wordpress/public_html/wp-includes/blocks/legacy-widget.php(55): the_widget('Tribe\\Events\\Vi...', Array, Array)
#9 /home/wordpress/public_html/wp-includes/class-wp-block.php(586): render_block_core_legacy_widget(Array, '', Object(WP_Block))
#10 /home/wordpress/public_html/wp-includes/class-wp-block.php(566): WP_Block->render()
#11 /home/wordpress/public_html/wp-includes/class-wp-block.php(566): WP_Block->render()
#12 /home/wordpress/public_html/wp-includes/class-wp-block.php(566): WP_Block->render()
#13 /home/wordpress/public_html/wp-includes/class-wp-block.php(566): WP_Block->render()
#14 /home/wordpress/public_html/wp-includes/class-wp-block.php(566): WP_Block->render()
#15 /home/wordpress/public_html/wp-includes/blocks.php(2358): WP_Block->render()
#16 /home/wordpress/public_html/wp-includes/blocks.php(2410): render_block(Array)
#17 /home/wordpress/public_html/wp-includes/class-wp-hook.php(324): do_blocks('<!-- wp:bytesco...')
#18 /home/wordpress/public_html/wp-includes/plugin.php(205): WP_Hook->apply_filters('<!-- wp:bytesco...', Array)
#19 /home/wordpress/public_html/wp-includes/blocks/post-content.php(50): apply_filters('the_content', '<!-- wp:bytesco...')
#20 /home/wordpress/public_html/wp-includes/class-wp-block.php(586): render_block_core_post_content(Array, '<!-- wp:bytesco...', Object(WP_Block))
#21 /home/wordpress/public_html/wp-includes/class-wp-block.php(566): WP_Block->render()
#22 /home/wordpress/public_html/wp-includes/blocks.php(2358): WP_Block->render()
#23 /home/wordpress/public_html/wp-includes/blocks.php(2410): render_block(Array)
#24 /home/wordpress/public_html/wp-includes/block-template.php(291): do_blocks('<!-- wp:templat...')
#25 /home/wordpress/public_html/wp-includes/template-canvas.php(12): get_the_block_template_html()
#26 /home/wordpress/public_html/wp-includes/template-loader.php(106): include('/home/wordpress/pu...')
#27 /home/wordpress/public_html/wp-blog-header.php(19): require_once('/home/wordpress/pu...')
#28 /home/wordpress/public_html/index.php(17): require('/home/wordpress/pu...')
#29 {main}
  thrown in /home/wordpress/public_html/wp-content/plugins/the-events-calendar/common/src/Tribe/Rewrite.php on line 1168
```

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
