### PR TITLE
Remove template ${CARET} from live docblocks

### DIFF
--- a/src/Tribe/Log/Canonical_Formatter.php
+++ b/src/Tribe/Log/Canonical_Formatter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * ${CARET}
+ * This class is used to format the log messages in a canonical format.
  *
  * @since 4.9.16
  *

--- a/tests/_support/Provider/Controller_Test_Case.php
+++ b/tests/_support/Provider/Controller_Test_Case.php
@@ -67,7 +67,7 @@ class Controller_Test_Case extends WPBrowserTestCase {
 	 */
 	private ?Controller $original_controller;
 	/**
-	 * ${CARET}
+	 * The original Service Locator.
 	 *
 	 * @since 5.2.7
 	 *


### PR DESCRIPTION
These are from someone's malformed docblock template - they need to go.