### PR TITLE
fix(Classy) add missing is_wp_version() method

### DIFF
--- a/src/Common/Classy/Back_Compatibility/Editor.php
+++ b/src/Common/Classy/Back_Compatibility/Editor.php
@@ -76,4 +76,18 @@ class Editor {
 	public function is_events_post_type(): bool {
 		return false;
 	}
+
+	/**
+	 * Checks if the current WordPress version supports the Block Editor.
+	 *
+	 * This method is used to determine if the current WordPress version is compatible with the Block Editor.
+	 * In this implementation, it always returns false, indicating that the Block Editor is not supported.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool True if the current WordPress version supports the Block Editor, false otherwise.
+	 */
+	public function is_wp_version(): bool {
+		return false;
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Adds the `is_wp_version()` method to the backwards compatible `Editor` class in Classy.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
