### PR TITLE
fix(Classy) CTA font size

### DIFF
--- a/src/resources/packages/classy/style.pcss
+++ b/src/resources/packages/classy/style.pcss
@@ -539,6 +539,7 @@
 			gap: var(--tec-spacer-1);
 			justify-content: flex-start;
 			padding: 0 var(--tec-spacer-3);
+			border-bottom: 1px solid var(--tec-color-gutenberg-grey-300);
 
 			.classy-modal__header-title{
 				color: var(--tec-color-gutenberg-grey-900);

--- a/src/resources/packages/classy/style.pcss
+++ b/src/resources/packages/classy/style.pcss
@@ -384,7 +384,7 @@
 			align-items: center;
 			display: flex;
 			flex-direction: row;
-			font-size: var(--tec-font-size-3);
+			font-size: var(--tec-font-size-2);
 			font-weight: 600;
 			line-height: var(--tec-spacer-4);
 


### PR DESCRIPTION
This fixes the font size of the Call-to-action text in the context of the Classy UI.
Based on the current value of the font sizes: `16px -> 14px`.
