### PR TITLE
fix(Classy) popover close button position

### DIFF
--- a/src/resources/packages/classy/style.pcss
+++ b/src/resources/packages/classy/style.pcss
@@ -502,6 +502,7 @@
 				display: flex;
 				flex-direction: column;
 				gap: var(--tec-spacer-3);
+				position: relative;
 
 				.classy-component__popover-title {
 					margin: 0;
@@ -519,8 +520,7 @@
 			.classy-component__popover-close {
 				position: absolute;
 				display: block;
-				top: var(--tec-spacer-3);
-				right: var(--tec-spacer-3);
+				right: 0;
 			}
 
 		}


### PR DESCRIPTION
Fix the positioning of the popover close button in Firefox and other browsers:

[Firefox](https://share.cleanshot.com/NbdxT73z)
[Chrome](https://share.cleanshot.com/v7Ndpc79)
[Safari](https://share.cleanshot.com/m7xyWrNz)
