### PR TITLE
Move Start/End Selector to common

### DIFF
--- a/src/resources/packages/classy/components/CurrencySelector/CurrencySelector.tsx
+++ b/src/resources/packages/classy/components/CurrencySelector/CurrencySelector.tsx
@@ -30,7 +30,7 @@ type CurrencySelectOption = {
 };
 
 const currencyDefaultOption: CurrencySelectOption = {
-	label: _x( 'Default site currency', 'Default option for the currency selector', 'the-events-calendar' ),
+	label: _x( 'Default site currency', 'Default option for the currency selector', 'tribe-common' ),
 	value: 'default',
 };
 
@@ -214,15 +214,15 @@ export default function CurrencySelector( props: CurrencySelectorProps ): JSX.El
 				</Button>
 
 				<h4 className="classy-component__popover-title">
-					{ _x( 'Currency', 'Event currency selector title', 'the-events-calendar' ) }
+					{ _x( 'Currency', 'Event currency selector title', 'tribe-common' ) }
 				</h4>
 
 				<p className="classy-component__popover-description">
-					{ __( 'Choose a different currency than your default for this event.', 'the-events-calendar' ) }
+					{ __( 'Choose a different currency than your default for this event.', 'tribe-common' ) }
 				</p>
 
 				<SelectControl
-					label={ _x( 'Currency', 'Event currency selector label', 'the-events-calendar' ) }
+					label={ _x( 'Currency', 'Event currency selector label', 'tribe-common' ) }
 					hideLabelFromVision={ true }
 					value={ eventCurrencyCode === defaultCurrency.code ? 'default' : eventCurrencyCode }
 					onChange={ onCurrencyChange }
@@ -235,7 +235,7 @@ export default function CurrencySelector( props: CurrencySelectorProps ): JSX.El
 					label={ _x(
 						'Currency symbol precedes price',
 						'Event currency position toggle label',
-						'the-events-calendar'
+						'tribe-common'
 					) }
 					checked={ currencyPosition === 'prefix' }
 					onChange={ onCurrencyPositionChange }

--- a/src/resources/packages/classy/components/EndSelector/EndSelector.tsx
+++ b/src/resources/packages/classy/components/EndSelector/EndSelector.tsx
@@ -1,0 +1,107 @@
+import * as React from 'react';
+import { Fragment } from 'react';
+import { MouseEventHandler } from 'react';
+import type { StartOfWeek } from '../../types/StartOfWeek';
+import { DatePicker } from '../DatePicker';
+import { TimePicker } from '../TimePicker';
+import { RefObject, useRef } from '@wordpress/element';
+import { format } from '@wordpress/date';
+import { _x } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+
+export default function EndSelector( props: {
+	dateWithYearFormat: string;
+	endDate: Date;
+	highlightTime: boolean;
+	isAllDay: boolean;
+	isMultiday: boolean;
+	isSelectingDate: 'start' | 'end' | false;
+	onChange: ( selecting: 'start' | 'end', date: string ) => void;
+	onClick: MouseEventHandler;
+	onClose: () => void;
+	startDate: Date;
+	startOfWeek: StartOfWeek;
+	timeFormat: string;
+} ) {
+	const {
+		dateWithYearFormat,
+		endDate,
+		highlightTime,
+		isAllDay,
+		isMultiday,
+		isSelectingDate,
+		onChange,
+		onClick,
+		onClose,
+		startDate,
+		startOfWeek,
+		timeFormat,
+	} = props;
+
+	const ref: RefObject< HTMLDivElement > = useRef( null );
+	const timeInterval = useSelect( ( select ) => {
+		// @ts-ignore
+		return select( 'tec/classy' ).getTimeInterval();
+	}, [] );
+
+	const onTimeChange = ( date: Date ): void => {
+		onChange( 'end', format( 'Y-m-d H:i:s', date ) );
+	};
+
+	return (
+		<Fragment>
+			{ isMultiday && (
+				<Fragment>
+					<span className="classy-field__separator classy-field__separator--dates">
+						{ _x( 'to', 'multi-day start and end date separator', 'tribe-common' ) }
+					</span>
+
+					<div
+						className="classy-field__input classy-field__input--start-date classy-field__input--grow"
+						ref={ ref }
+					>
+						<div className="classy-field__input-title">
+							<h4>{ _x( 'Date', 'Event date selection input title', 'tribe-common' ) }</h4>
+						</div>
+
+						<DatePicker
+							anchor={ ref.current }
+							dateWithYearFormat={ dateWithYearFormat }
+							endDate={ endDate }
+							isSelectingDate={ isSelectingDate }
+							isMultiday={ isMultiday }
+							onChange={ onChange }
+							onClick={ onClick }
+							onClose={ onClose }
+							showPopover={ isSelectingDate === 'end' }
+							startDate={ startDate }
+							startOfWeek={ startOfWeek }
+							currentDate={ endDate }
+						/>
+					</div>
+				</Fragment>
+			) }
+
+			{ isAllDay ? (
+				<span className="classy-field__separator classy-field__separator--dates">
+					{ _x( 'All Day', 'All day label in the date/time Classy selection field', 'tribe-common' ) }
+				</span>
+			) : (
+				<div className="classy-field__input classy-field__input--end-time">
+					<div className="classy-field__input-title">
+						<h4>{ _x( 'End Time', 'Event end time selection input title', 'tribe-common' ) }</h4>
+					</div>
+
+					<TimePicker
+						currentDate={ endDate }
+						highlight={ highlightTime }
+						startDate={ isMultiday ? null : startDate }
+						timeFormat={ timeFormat }
+						timeInterval={ timeInterval }
+						onChange={ onTimeChange }
+					/>
+				</div>
+			) }
+		</Fragment>
+	);
+}

--- a/src/resources/packages/classy/components/EndSelector/index.ts
+++ b/src/resources/packages/classy/components/EndSelector/index.ts
@@ -1,0 +1,1 @@
+export { default as EndSelector } from './EndSelector';

--- a/src/resources/packages/classy/components/StartSelector/StartSelector.tsx
+++ b/src/resources/packages/classy/components/StartSelector/StartSelector.tsx
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { Fragment, MouseEventHandler } from 'react';
+import { RefObject, useRef } from '@wordpress/element';
+import type { StartOfWeek } from '../../types/StartOfWeek';
+import { DatePicker } from '../DatePicker';
+import { TimePicker } from '../TimePicker';
+import { format } from '@wordpress/date';
+import { _x } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+
+export default function StartSelector( props: {
+	dateWithYearFormat: string;
+	endDate: Date;
+	highightTime: boolean;
+	isAllDay: boolean;
+	isMultiday: boolean;
+	isSelectingDate: 'start' | 'end' | false;
+	onChange: ( selecting: 'start' | 'end', date: string ) => void;
+	onClick: MouseEventHandler;
+	onClose: () => void;
+	startDate: Date;
+	startOfWeek: StartOfWeek;
+	timeFormat: string;
+} ) {
+	const {
+		dateWithYearFormat,
+		endDate,
+		highightTime,
+		isAllDay,
+		isMultiday,
+		isSelectingDate,
+		onChange,
+		onClick,
+		onClose,
+		startDate,
+		startOfWeek,
+		timeFormat,
+	} = props;
+
+	const ref: RefObject< HTMLDivElement > = useRef( null );
+	const timeInterval = useSelect( ( select ) => {
+		// @ts-ignore
+		return select( 'tec/classy' ).getTimeInterval();
+	}, [] );
+
+	const onTimeChange = ( date: Date ): void => {
+		onChange( 'start', format( 'Y-m-d H:i:s', date ) );
+	};
+
+	const wrapperClassName = isAllDay
+		? 'classy-field__input classy-field__input--start-date classy-field__input-full-width'
+		: 'classy-field__input classy-field__input--start-date classy-field__input--grow';
+
+	return (
+		<Fragment>
+			<div className={ wrapperClassName } ref={ ref }>
+				<div className="classy-field__input-title">
+					<h4>{ _x( 'Date', 'Event date selection input title', 'tribe-common' ) }</h4>
+				</div>
+
+				<DatePicker
+					anchor={ ref.current }
+					dateWithYearFormat={ dateWithYearFormat }
+					endDate={ endDate }
+					isSelectingDate={ isSelectingDate }
+					isMultiday={ isMultiday }
+					onClick={ onClick }
+					onClose={ onClose }
+					onChange={ onChange }
+					showPopover={ isSelectingDate === 'start' }
+					startDate={ startDate }
+					startOfWeek={ startOfWeek }
+					currentDate={ startDate }
+				/>
+			</div>
+
+			{ ! isAllDay && (
+				<div className="classy-field__input classy-field__input--start-time">
+					<div className="classy-field__input-title">
+						<h4>{ _x( 'Start Time', 'Event start time selection input title', 'tribe-common' ) }</h4>
+					</div>
+
+					<TimePicker
+						currentDate={ startDate }
+						endDate={ isMultiday ? null : endDate }
+						highlight={ highightTime }
+						onChange={ onTimeChange }
+						timeFormat={ timeFormat }
+						timeInterval={ timeInterval }
+					/>
+				</div>
+			) }
+		</Fragment>
+	);
+}

--- a/src/resources/packages/classy/components/StartSelector/index.ts
+++ b/src/resources/packages/classy/components/StartSelector/index.ts
@@ -1,0 +1,1 @@
+export { default as StartSelector } from './StartSelector';

--- a/src/resources/packages/classy/components/TimeZone/TimeZone.tsx
+++ b/src/resources/packages/classy/components/TimeZone/TimeZone.tsx
@@ -18,7 +18,7 @@ export default function TimeZone( props: { onTimezoneChange: ( timezone: string 
 	return (
 		<div className="classy-field__control classy-field__control--timezone" ref={ ref }>
 			<span className="classy-field__timezone-label">
-				{ _x( 'Time Zone:', 'Timezone component label', 'the-events-calendar' ) }
+				{ _x( 'Time Zone:', 'Timezone component label', 'tribe-common' ) }
 			</span>{ ' ' }
 			<Button
 				variant="link"

--- a/src/resources/packages/classy/components/TimeZone/TimezoneSelectionPopover.tsx
+++ b/src/resources/packages/classy/components/TimeZone/TimezoneSelectionPopover.tsx
@@ -65,14 +65,14 @@ export default function TimezoneSelectionPopover( props: {
 				</Button>
 
 				<h4 className="classy-component__popover-title">
-					{ _x( 'Event Time Zone', 'Timezone selector popover title', 'the-events-calendar' ) }
+					{ _x( 'Event Time Zone', 'Timezone selector popover title', 'tribe-common' ) }
 				</h4>
 
 				<p className="classy-component__popover-description">
 					{ _x(
 						'Choose a different time zone than your default for this event.',
 						'Timezone selector popover description',
-						'the-events-calendar'
+						'tribe-common'
 					) }
 				</p>
 

--- a/src/resources/packages/classy/components/index.ts
+++ b/src/resources/packages/classy/components/index.ts
@@ -7,5 +7,7 @@ export { TimeZone } from './TimeZone';
 export { TinyMceEditor } from './TinyMceEditor';
 export { CenteredSpinner } from './CenteredSpinner';
 export { LabeledInput } from './LabeledInput';
+export { StartSelector } from './StartSelector';
+export { EndSelector } from './EndSelector';
 
 // Note: the Classy application is not exported by design, only components are.

--- a/src/resources/packages/classy/functions/addEditorTools.ts
+++ b/src/resources/packages/classy/functions/addEditorTools.ts
@@ -35,7 +35,7 @@ export function addEditorTools(
 			previewButton.dataset.toolbarItem = 'true';
 			previewButton.innerHTML = `<span class="dashicons dashicons-visibility"></span>${ __(
 				'Visual',
-				'the-events-calendar'
+				'tribe-common'
 			) }`;
 			editorDocumentTools.append( previewButton );
 			previewButton.onclick = onClick;


### PR DESCRIPTION
This PR moves the `StartSelector` and `EndSelector` components from TEC to Common to make those available for other plugins to use.

Furthermore, the PR fixes some text domain issues left-over from previuos moves.

[Related TEC PR](https://github.com/the-events-calendar/the-events-calendar/pull/5230)