### PR TITLE
Classy - tweak modal header

### DIFF
--- a/src/resources/packages/classy/style.pcss
+++ b/src/resources/packages/classy/style.pcss
@@ -544,7 +544,7 @@
 
 .classy-modal {
 	.components-modal__content {
-		padding: var(--tec-spacer-6) 0 0;
+		padding: 0;
 
 		.classy-modal__header {
 			height:60px;


### PR DESCRIPTION
Avoid the excess white space at the top of the modal content, before the header.

[Before](https://share.cleanshot.com/gWWQ3kcJ)
[After](https://share.cleanshot.com/xCmvL96k)
