### PR TITLE
Classy - better localized data export

### DIFF
--- a/src/resources/packages/classy/index.ts
+++ b/src/resources/packages/classy/index.ts
@@ -6,7 +6,7 @@ import {
 	insertElement as insertClassyElement,
 	toggleElementVisibility as toggleClassyElementVisibility,
 } from './functions/classy';
-import { localizedData } from './localizedData';
+import { getLocalizedData, getSettings } from './localizedData';
 import './style.pcss';
 
 whenEditorIsReady().then( () => {
@@ -22,4 +22,18 @@ export * as components from './components';
 export * as fields from './fields';
 export * as functions from './functions';
 export * as store from './store';
-export { localizedData };
+
+/*
+ * Re-export localized data accessors and not the localized data object directly.
+ * Packages outside of this will be able to access the localized data in one of two ways:
+ *
+ * Recommended:
+ * - import {getLocalizedData, getSettings} from '@tec/common/classy/localizedData';
+ *
+ * Not ideal but still possible:
+ * - const {getLocalizedData, getSettings} = window.tec.common.classy.localizedData;
+ */
+export const localizedData = {
+	getLocalizedData,
+	getSettings,
+};

--- a/src/resources/packages/classy/localizedData.ts
+++ b/src/resources/packages/classy/localizedData.ts
@@ -1,4 +1,4 @@
-import { LocalizedData } from './types/LocalizedData';
+import { LocalizedData, Settings } from './types/LocalizedData';
 import { WPDataRegistry } from '@wordpress/data/build-types/registry';
 
 declare global {
@@ -38,3 +38,32 @@ export const localizedData: LocalizedData = window?.tec?.common?.classy?.data ??
 		timeInterval: 15,
 	},
 };
+
+/**
+ * Gets the localized data.
+ *
+ * Extending plugins should use this function rather than accessing the localized
+ * data directly.
+ *
+ * @since TBD
+ *
+ * @returns {LocalizedData} The localized data.
+ */
+export function getLocalizedData(): LocalizedData {
+	return localizedData;
+}
+
+/**
+ * Gets the settings from the localized data.
+ *
+ * Extending plugins should use this function rather than accessing the localized
+ * data directly.
+ *
+ * @since TBD
+ *
+ * @returns {Settings} The settings from the localized data.
+ *
+ */
+export function getSettings(): Settings {
+	return localizedData.settings;
+}


### PR DESCRIPTION
This updates the localized data export to allow for a cleaner use in Classy packages outside of Common
 than a direct access to the `window.tec.common.classy.localizedData` object.

 ```js
 import {getLocalizedData, getSettings} from '@tec/common/classy/localizedData';

 const localizedData = getLocalizedData();

 const settings = getSettings();
 ```

 To complicate the example and take Typescript and types into account:

 ```typescript
// types.d.ts
import {
    LocalizedData as CommonLocalizeData,
    Settings as CommonSettings,
} from '@tec/common/classy/types/LocalizedData';

// Define a type of settings for the plugin that is the Classy Common type plus some custom keys.
epxort type MySettings = CommonSettings & {
    someKey: string;
}

// Define a type of localized data for the plugin that is the Classy Common type plus some custom keys.
export type MyLocalizedData = CommonLocalizeData & {
    someOtherKey: string;
};

// The plugin controller filters the localized data to add a `someKey` entry to the settings.

// selectors.ts
import {MyLocalizedData, MySettings} from '../types.d.ts';
import {getLocalizedData, getSettings} from '@tec/common/classy/localizedData';

function getSomeOtherKey(): string {
    return (getLocalizedData() as MyLocalizedData).someOtherKey;
}

function getSomeKeySetting(): string {
    return (getSettings() as MySettings).someKey;
}
 ```

The `getLocalizedData` and `getSettings` function are still avaiable on the `window.tec.common.classy.localizedData` object, but using them like that is not the reccomended way.
