### PR TITLE
TEC-5529 Fix add_submenu_page deprecation message

### DIFF
--- a/src/Common/Admin/Help_Hub/Hub.php
+++ b/src/Common/Admin/Help_Hub/Hub.php
@@ -177,7 +177,7 @@ class Hub {
 	 */
 	public function register_hidden_page(): void {
 		add_submenu_page(
-			null, // Make the page hidden.
+			'', // Make the page hidden.
 			__( 'Help Hub', 'tribe-common' ),
 			__( 'Help Hub', 'tribe-common' ),
 			'manage_options',


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5529]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The first parameter of `add_submenu_page()` was null, which was then passed to `str_replace()` and `str_pos()`, resulting in deprecation messages. Replacing `null` with an empty string `''` solves the issue and keeps the page hidden.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TEC-5529]: https://stellarwp.atlassian.net/browse/TEC-5529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ