### PR TITLE
Registers REST API infrastructure

### DIFF
--- a/src/Common/Controller.php
+++ b/src/Common/Controller.php
@@ -11,6 +11,7 @@ namespace TEC\Common;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
 use TEC\Common\Lists\Country as Country_List;
+use TEC\Common\REST\Controller as REST_Controller;
 
 /**
  * Class Controller
@@ -30,6 +31,7 @@ class Controller extends Controller_Contract {
 		$this->container->singleton( Template::class );
 		$this->container->singleton( Country_List::class );
 		$this->container->register( Hooks::class );
+		$this->container->register( REST_Controller::class );
 	}
 
 	/**
@@ -41,5 +43,6 @@ class Controller extends Controller_Contract {
 	 */
 	public function unregister(): void {
 		$this->container->get( Hooks::class )->unregister();
+		$this->container->get( REST_Controller::class )->unregister();
 	}
 }

--- a/src/Common/REST/Controller.php
+++ b/src/Common/REST/Controller.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Controller for the TEC REST API.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST;
+
+use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\REST\TEC\V1\Controller as V1_Controller;
+
+/**
+ * Controller for the TEC REST API.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST
+ */
+class Controller extends Controller_Contract {
+	/**
+	 * The namespace of the REST API.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const NAMESPACE = 'tec';
+
+	/**
+	 * Registers the filters and actions hooks added by the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function do_register(): void {
+		$this->container->register( V1_Controller::class );
+	}
+
+	/**
+	 * Unregisters the filters and actions hooks added by the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function unregister(): void {
+		$this->container->get( V1_Controller::class )->unregister();
+	}
+}

--- a/src/Common/REST/TEC/V1/Abstracts/Endpoint.php
+++ b/src/Common/REST/TEC/V1/Abstracts/Endpoint.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Endpoint class.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Abstracts
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1\Abstracts;
+
+use TEC\Common\REST\TEC\V1\Contracts\Endpoint_Interface;
+use TEC\Common\REST\TEC\V1\Contracts\Readable_Endpoint;
+use TEC\Common\REST\TEC\V1\Contracts\Creatable_Endpoint;
+use TEC\Common\REST\TEC\V1\Contracts\Updatable_Endpoint;
+use TEC\Common\REST\TEC\V1\Contracts\Deletable_Endpoint;
+use TEC\Common\REST\TEC\V1\Controller;
+use WP_REST_Server;
+use WP_REST_Request;
+
+/**
+ * Endpoint class.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Abstracts
+ */
+abstract class Endpoint implements Endpoint_Interface {
+	/**
+	 * Alias for PUT, PATCH transport methods together.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const EDITABLE = 'PUT, PATCH';
+
+	/**
+	 * Registers the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			Controller::get_versioned_namespace(),
+			$this->get_path(),
+			$this->get_methods()
+		);
+	}
+
+	/**
+	 * Returns the methods for the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	protected function get_methods(): array {
+		$methods = [];
+
+		if ( $this instanceof Readable_Endpoint ) {
+			$methods[] = [
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'read' ],
+				'permission_callback' => [ $this, 'can_read' ],
+				'args'                => $this->read_args(),
+			];
+		}
+
+		if ( $this instanceof Creatable_Endpoint ) {
+			$methods[] = [
+				'methods'             => WP_REST_Server::CREATABLE,
+				'callback'            => [ $this, 'create' ],
+				'permission_callback' => [ $this, 'can_create' ],
+				'args'                => $this->create_args(),
+			];
+		}
+
+		if ( $this instanceof Updatable_Endpoint ) {
+			$methods[] = [
+				'methods'             => self::EDITABLE,
+				'callback'            => [ $this, 'update' ],
+				'permission_callback' => [ $this, 'can_update' ],
+				'args'                => $this->update_args(),
+			];
+		}
+
+		if ( $this instanceof Deletable_Endpoint ) {
+			$methods[] = [
+				'methods'             => WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'delete' ],
+				'permission_callback' => [ $this, 'can_delete' ],
+				'args'                => $this->delete_args(),
+			];
+		}
+
+		$methods['schema'] = fn() => $this->get_schema();
+
+		return $methods;
+	}
+
+	/**
+	 * Returns whether the user can read the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool
+	 */
+	public function can_read( WP_REST_Request $request ): bool {
+		return true;
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Returns whether the user can create the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool
+	 */
+	public function can_create( WP_REST_Request $request ): bool {
+		return $this->can_read( $request );
+	}
+
+	/**
+	 * Returns whether the user can update the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool
+	 */
+	public function can_update( WP_REST_Request $request ): bool {
+		return $this->can_read( $request );
+	}
+
+	/**
+	 * Returns whether the user can delete the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool
+	 */
+	public function can_delete( WP_REST_Request $request ): bool {
+		return $this->can_read( $request );
+	}
+}

--- a/src/Common/REST/TEC/V1/Contracts/Creatable_Endpoint.php
+++ b/src/Common/REST/TEC/V1/Contracts/Creatable_Endpoint.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Creatable endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1\Contracts;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Creatable endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+interface Creatable_Endpoint {
+	/**
+	 * Creates the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function create( WP_REST_Request $request ): WP_REST_Response;
+
+	/**
+	 * Returns whether the user can create the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool
+	 */
+	public function can_create( WP_REST_Request $request ): bool;
+
+	/**
+	 * Returns the arguments for the create method.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function create_args(): array;
+}

--- a/src/Common/REST/TEC/V1/Contracts/Definition_Interface.php
+++ b/src/Common/REST/TEC/V1/Contracts/Definition_Interface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Definition interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1\Contracts;
+
+/**
+ * Definition interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+interface Definition_Interface {
+	/**
+	 * Returns the OpenAPI documentation for the definition.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function get_documentation(): array;
+
+	/**
+	 * Returns the type of the definition.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_type(): string;
+}

--- a/src/Common/REST/TEC/V1/Contracts/Deletable_Endpoint.php
+++ b/src/Common/REST/TEC/V1/Contracts/Deletable_Endpoint.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Deletable endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1\Contracts;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Deletable endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+interface Deletable_Endpoint {
+	/**
+	 * Deletes the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function delete( WP_REST_Request $request ): WP_REST_Response;
+
+	/**
+	 * Returns whether the user can delete the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool
+	 */
+	public function can_delete( WP_REST_Request $request ): bool;
+
+	/**
+	 * Returns the arguments for the delete method.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function delete_args(): array;
+}

--- a/src/Common/REST/TEC/V1/Contracts/Endpoint_Interface.php
+++ b/src/Common/REST/TEC/V1/Contracts/Endpoint_Interface.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1\Contracts;
+
+/**
+ * Endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+interface Endpoint_Interface {
+	/**
+	 * Registers the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void;
+
+	/**
+	 * Returns the OpenAPI documentation for the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function get_documentation(): array;
+
+	/**
+	 * Returns the schema for the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function get_schema(): array;
+
+	/**
+	 * Returns the path of the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_path(): string;
+}

--- a/src/Common/REST/TEC/V1/Contracts/Readable_Endpoint.php
+++ b/src/Common/REST/TEC/V1/Contracts/Readable_Endpoint.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Readable endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1\Contracts;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Readable endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+interface Readable_Endpoint {
+	/**
+	 * Returns the response for the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function read( WP_REST_Request $request ): WP_REST_Response;
+
+	/**
+	 * Returns whether the endpoint can be read.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool
+	 */
+	public function can_read( WP_REST_Request $request ): bool;
+
+	/**
+	 * Returns the arguments for the read method.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function read_args(): array;
+}

--- a/src/Common/REST/TEC/V1/Contracts/Updatable_Endpoint.php
+++ b/src/Common/REST/TEC/V1/Contracts/Updatable_Endpoint.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Updatable endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1\Contracts;
+
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * Updatable endpoint interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Contracts
+ */
+interface Updatable_Endpoint {
+	/**
+	 * Updates the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function update( WP_REST_Request $request ): WP_REST_Response;
+
+	/**
+	 * Returns whether the user can update the object.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return bool
+	 */
+	public function can_update( WP_REST_Request $request ): bool;
+
+	/**
+	 * Returns the arguments for the update method.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function update_args(): array;
+}

--- a/src/Common/REST/TEC/V1/Controller.php
+++ b/src/Common/REST/TEC/V1/Controller.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Controller for the TEC REST API.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1;
+
+use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\REST\Controller as REST_Controller;
+
+/**
+ * Controller for the TEC REST API.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST
+ */
+class Controller extends Controller_Contract {
+	/**
+	 * The version of the REST API.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const VERSION = '1';
+
+	/**
+	 * Registers the filters and actions hooks added by the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function do_register(): void {
+		$this->container->singleton( Documentation::class );
+		$this->container->register( Endpoints::class );
+	}
+
+	/**
+	 * Unregisters the filters and actions hooks added by the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function unregister(): void {
+		$this->container->get( Endpoints::class )->unregister();
+	}
+
+	/**
+	 * Returns the namespace of the REST API.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public static function get_versioned_namespace(): string {
+		return REST_Controller::NAMESPACE . '/v' . self::VERSION;
+	}
+}

--- a/src/Common/REST/TEC/V1/Documentation.php
+++ b/src/Common/REST/TEC/V1/Documentation.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Swagger documentation endpoint for the TEC REST API.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1;
+
+use TEC\Common\REST\TEC\V1\Contracts\Endpoint_Interface;
+use TEC\Common\REST\TEC\V1\Contracts\Definition_Interface;
+
+/**
+ * Swagger documentation endpoint for the Events REST API.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1
+ */
+class Documentation {
+	/**
+	 * The OpenAPI version.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const SWAGGER_VERSION = '3.1.1';
+
+	/**
+	 * The TEC REST API version.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected const TEC_REST_API_VERSION = '1.0.0';
+
+	/**
+	 * The registered endpoints.
+	 *
+	 * @since TBD
+	 *
+	 * @var Endpoint_Interface[]
+	 */
+	protected $endpoints = [];
+
+	/**
+	 * The registered definitions.
+	 *
+	 * @since TBD
+	 *
+	 * @var Definition_Interface[]
+	 */
+	protected $definitions = [];
+
+	/**
+	 * Returns an array in the format used by Swagger 3.1.1.
+	 *
+	 * @since TBD
+	 *
+	 * @link http://swagger.io/
+	 *
+	 * @return array An array description of a Swagger supported component.
+	 */
+	public function get(): array {
+		$documentation = [
+			'openapi'    => self::SWAGGER_VERSION,
+			'info'       => $this->get_api_info(),
+			'components' => [ 'schemas' => $this->get_definitions() ],
+			'servers'    => [
+				[
+					'url' => rest_url( Controller::get_versioned_namespace() ),
+				],
+			],
+			'paths'      => $this->get_paths(),
+		];
+
+		/**
+		 * Filters the Swagger documentation generated for the TEC REST API.
+		 *
+		 * @param array         $documentation An associative PHP array in the format supported by Swagger.
+		 * @param Documentation $this          This instance of the documentation.
+		 *
+		 * @link https://swagger.io/specification/
+		 */
+		return apply_filters( 'tec_rest_swagger_documentation', $documentation, $this );
+	}
+
+	/**
+	 * Returns the API info.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	protected function get_api_info(): array {
+		return [
+			'version'     => self::TEC_REST_API_VERSION,
+			'title'       => __( 'The Events Calendar REST API', 'the-events-calendar' ),
+			'description' => __( 'The Events Calendar REST API allows accessing upcoming events information easily and conveniently.', 'the-events-calendar' ),
+		];
+	}
+
+	/**
+	 * Registers an endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @param Endpoint_Interface $endpoint The endpoint to register.
+	 */
+	public function register_endpoint( Endpoint_Interface $endpoint ): void {
+		$this->endpoints[] = $endpoint;
+	}
+
+	/**
+	 * Registers a definition.
+	 *
+	 * @since TBD
+	 *
+	 * @param Definition_Interface $definition The definition to register.
+	 */
+	public function register_definition( Definition_Interface $definition ): void {
+		$this->definitions[] = $definition;
+	}
+
+	/**
+	 * Returns the paths documentation for each endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	protected function get_paths(): array {
+		$paths = [];
+		foreach ( $this->endpoints as $endpoint ) {
+			/** @var Endpoint_Interface $endpoint */
+			$paths[ $endpoint->get_path() ] = $endpoint->get_documentation();
+		}
+
+		return $paths;
+	}
+
+	/**
+	 * Returns the definitions documentation for each definition.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	protected function get_definitions(): array {
+		$definitions = [];
+		/** @var Definition_Interface $definition */
+		foreach ( $this->definitions as $definition ) {
+			$definitions[ $definition->get_type() ] = $definition->get_documentation();
+		}
+
+		return $definitions;
+	}
+}

--- a/src/Common/REST/TEC/V1/Endpoints.php
+++ b/src/Common/REST/TEC/V1/Endpoints.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Endpoints Controller class.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1;
+
+use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\REST\TEC\V1\Endpoints\OpenApiDocs;
+use TEC\Common\Contracts\Container;
+
+/**
+ * Endpoints Controller class.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1
+ */
+class Endpoints extends Controller_Contract {
+	/**
+	 * The endpoints to register.
+	 *
+	 * @since TBD
+	 *
+	 * @var Endpoint_Interface[]
+	 */
+	protected const ENDPOINTS = [
+		OpenApiDocs::class,
+	];
+
+	/**
+	 * The documentation instance.
+	 *
+	 * @since TBD
+	 *
+	 * @var Documentation
+	 */
+	private Documentation $documentation;
+
+	/**
+	 * Endpoints constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param Container     $container     The container instance.
+	 * @param Documentation $documentation The documentation instance.
+	 */
+	public function __construct( Container $container, Documentation $documentation ) {
+		parent::__construct( $container );
+		$this->documentation = $documentation;
+	}
+
+	/**
+	 * Registers the filters and actions hooks added by the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function do_register(): void {
+		foreach ( self::ENDPOINTS as $endpoint ) {
+			$this->container->singleton( $endpoint );
+		}
+
+		add_action( 'rest_api_init', [ $this, 'register_endpoints' ] );
+	}
+
+	/**
+	 * Unregisters the filters and actions hooks added by the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function unregister(): void {
+		remove_action( 'rest_api_init', [ $this, 'register_endpoints' ] );
+	}
+
+	/**
+	 * Registers the endpoints.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_endpoints(): void {
+		foreach ( self::ENDPOINTS as $endpoint ) {
+			$endpoint = $this->container->get( $endpoint );
+			$endpoint->register_routes();
+			$this->documentation->register_endpoint( $endpoint );
+		}
+	}
+}

--- a/src/Common/REST/TEC/V1/Endpoints/OpenApiDocs.php
+++ b/src/Common/REST/TEC/V1/Endpoints/OpenApiDocs.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * OpenAPI docs endpoint.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Endpoints
+ */
+
+declare( strict_types=1 );
+
+namespace TEC\Common\REST\TEC\V1\Endpoints;
+
+// phpcs:disable StellarWP.Classes.ValidClassName.NotSnakeCase
+
+use TEC\Common\REST\TEC\V1\Abstracts\Endpoint;
+use TEC\Common\REST\TEC\V1\Contracts\Readable_Endpoint;
+use TEC\Common\REST\TEC\V1\Documentation;
+use WP_REST_Request;
+use WP_REST_Response;
+
+/**
+ * OpenAPI docs endpoint.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\REST\TEC\V1\Endpoints
+ */
+class OpenApiDocs extends Endpoint implements Readable_Endpoint {
+	/**
+	 * Returns the arguments for the read method.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function read_args(): array {
+		return [];
+	}
+
+	/**
+	 * Returns the response for the read method.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function read( WP_REST_Request $request ): WP_REST_Response {
+		/** @var Documentation $documentation */
+		$documentation = tribe( Documentation::class );
+		return new WP_REST_Response( $documentation->get() );
+	}
+
+	/**
+	 * Returns the schema for the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function get_schema(): array {
+		return [];
+	}
+
+	/**
+	 * Returns the documentation for the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return array
+	 */
+	public function get_documentation(): array {
+		return [];
+	}
+
+	/**
+	 * Returns the path of the endpoint.
+	 *
+	 * @since TBD
+	 *
+	 * @return string
+	 */
+	public function get_path(): string {
+		return '/docs';
+	}
+}


### PR DESCRIPTION
Initializes the REST API infrastructure for the project.

This includes:
- Registers a REST controller and versioned namespace.
- Sets up abstract endpoint classes and interfaces.
- Provides documentation generation based on registered endpoints and definitions.
- Registers an endpoint to serve the OpenAPI documentation.

YY-XXXX