### PR TITLE
KV Cache - first iteration

### DIFF
--- a/changelog/feat-key-value-cache
+++ b/changelog/feat-key-value-cache
@@ -1,0 +1,4 @@
+Significance: patch
+Type: feat
+
+Add a key-value cache system to support sites not using object-caching. [ETP-1021]

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "stellarwp/db": "^1.0.3",
     "stellarwp/installer": "^1.1.0",
     "stellarwp/models": "dev-main",
-    "stellarwp/schema": "^1.1.8",
+    "stellarwp/schema": "v201.x-dev",
     "stellarwp/telemetry": "^2.3.4",
     "stellarwp/uplink": "2.2.2",
     "woocommerce/action-scheduler": "3.9.2"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "stellarwp/db": "^1.0.3",
     "stellarwp/installer": "^1.1.0",
     "stellarwp/models": "dev-main",
-    "stellarwp/schema": "v201.x-dev",
+    "stellarwp/schema": "2.0.1",
     "stellarwp/telemetry": "^2.3.4",
     "stellarwp/uplink": "2.2.2",
     "woocommerce/action-scheduler": "3.9.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c1752a6ccfcafb495562704e2c23c5c",
+    "content-hash": "1bb9f651610190cb6a0353071d3d58e7",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -697,16 +697,16 @@
         },
         {
             "name": "stellarwp/schema",
-            "version": "v201.x-dev",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/schema.git",
-                "reference": "bf88b3882f1f567b54c99d63a8659e41d08c0512"
+                "reference": "b80c02c6ee6cebcf9c21b642a7b20db5480f0cd6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/schema/zipball/bf88b3882f1f567b54c99d63a8659e41d08c0512",
-                "reference": "bf88b3882f1f567b54c99d63a8659e41d08c0512",
+                "url": "https://api.github.com/repos/stellarwp/schema/zipball/b80c02c6ee6cebcf9c21b642a7b20db5480f0cd6",
+                "reference": "b80c02c6ee6cebcf9c21b642a7b20db5480f0cd6",
                 "shasum": ""
             },
             "require": {
@@ -751,9 +751,9 @@
             "description": "A library for simplifying the creation and updates of custom tables within WordPress.",
             "support": {
                 "issues": "https://github.com/stellarwp/schema/issues",
-                "source": "https://github.com/stellarwp/schema/tree/v201"
+                "source": "https://github.com/stellarwp/schema/tree/2.0.1"
             },
-            "time": "2025-07-18T12:47:43+00:00"
+            "time": "2025-07-18T14:24:06+00:00"
         },
         {
             "name": "stellarwp/telemetry",
@@ -7222,7 +7222,6 @@
     "stability-flags": {
         "stellarwp/coding-standards": 20,
         "stellarwp/models": 20,
-        "stellarwp/schema": 20,
         "the-events-calendar/tec-testing-facilities": 20
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "990434cb08e614b309234ac7afa048ab",
+    "content-hash": "7c1752a6ccfcafb495562704e2c23c5c",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -697,16 +697,16 @@
         },
         {
             "name": "stellarwp/schema",
-            "version": "1.1.8",
+            "version": "v201.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/schema.git",
-                "reference": "979344c46d9c54a7891a27e7399fd391fa51b755"
+                "reference": "bf88b3882f1f567b54c99d63a8659e41d08c0512"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/schema/zipball/979344c46d9c54a7891a27e7399fd391fa51b755",
-                "reference": "979344c46d9c54a7891a27e7399fd391fa51b755",
+                "url": "https://api.github.com/repos/stellarwp/schema/zipball/bf88b3882f1f567b54c99d63a8659e41d08c0512",
+                "reference": "bf88b3882f1f567b54c99d63a8659e41d08c0512",
                 "shasum": ""
             },
             "require": {
@@ -723,10 +723,11 @@
                 "codeception/module-rest": "^1.0",
                 "codeception/module-webdriver": "^1.0",
                 "codeception/util-universalframework": "^1.0",
-                "lucatume/di52": "^3.0",
-                "lucatume/wp-browser": "^3.0.14",
+                "lucatume/di52": "^4.0",
+                "lucatume/wp-browser": "^3.0 < 3.5",
+                "php-stubs/wp-cli-stubs": "^2.11",
                 "phpunit/phpunit": "~6.0",
-                "stellarwp/db": "^1.0",
+                "stellarwp/db": "^1.1",
                 "symfony/event-dispatcher-contracts": "^2.5.1",
                 "symfony/string": "^5.4",
                 "szepeviktor/phpstan-wordpress": "^1.1"
@@ -750,9 +751,9 @@
             "description": "A library for simplifying the creation and updates of custom tables within WordPress.",
             "support": {
                 "issues": "https://github.com/stellarwp/schema/issues",
-                "source": "https://github.com/stellarwp/schema/tree/1.1.8"
+                "source": "https://github.com/stellarwp/schema/tree/v201"
             },
-            "time": "2025-01-10T19:40:08+00:00"
+            "time": "2025-07-18T12:47:43+00:00"
         },
         {
             "name": "stellarwp/telemetry",
@@ -7221,6 +7222,7 @@
     "stability-flags": {
         "stellarwp/coding-standards": 20,
         "stellarwp/models": 20,
+        "stellarwp/schema": 20,
         "the-events-calendar/tec-testing-facilities": 20
     },
     "prefer-stable": true,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# Common Library Documentation
+
+This collection documents the APIs and implementation details for select components of the Common library.
+
+## Table of Contents
+
+### Caching
+- [Key-Value Cache API](./key-value-cache.md) - Unified caching interface that uses object caching when available, falling back to a custom database table for persistent storage.

--- a/docs/key-value-cache.md
+++ b/docs/key-value-cache.md
@@ -8,35 +8,71 @@ Access the cache via the `tec_kv_cache()` function:
 
 ```php
 $cache = tec_kv_cache();
+```
 
+### Basic String Storage
+
+Store and retrieve simple string values:
+
+```php
 // Store a value with 5-minute expiration (minimum allowed).
-$cache->set('user_data_123', 'serialized data here', 300);
+$cache->set( 'user_data_123', 'serialized data here', 300 );
 
 // Retrieve a value.
-$data = $cache->get('user_data_123'); // Returns the stored string.
-$data = $cache->get('missing_key', 'default'); // Returns 'default' if not found.
+$data = $cache->get( 'user_data_123' ); // Returns the stored string.
+$data = $cache->get( 'missing_key', 'default' ); // Returns 'default' if not found.
+```
 
-// Check if a key exists.
-if ($cache->has('user_data_123')) {
+### Checking Key Existence
+
+Verify if a key exists before retrieving:
+
+```php
+if ($cache->has( 'user_data_123' )) {
     // Key exists and hasn't expired.
+    $value = $cache->get( 'user_data_123' );
 }
+```
 
-// Store and retrieve JSON data.
-$cache->set_json('api_response', ['status' => 'ok', 'count' => 42], 3600);
-$response = $cache->get_json('api_response', true); // Returns associative array.
-$response = $cache->get_json('api_response'); // Returns stdClass object.
+### Working with JSON Data
 
-// Store and retrieve serialized objects.
+Store and retrieve structured data using JSON:
+
+```php
+// Store JSON data using set_json().
+$cache->set_json( 'api_response', [ 'status' => 'ok', 'count' => 42], 3600 );
+
+// Retrieve as associative array.
+$response = $cache->get_json( 'api_response', true );
+
+// Retrieve as stdClass object.
+$response = $cache->get_json( 'api_response', false );
+```
+
+### Serialized PHP Objects
+
+Store complex PHP objects with automatic serialization:
+
+```php
+// Store a complex object.
 $user_data = new stdClass();
 $user_data->name = 'John Doe';
-$user_data->preferences = ['theme' => 'dark', 'notifications' => true];
-$cache->set_serialized('user_123_data', $user_data, 600);
-$retrieved_data = $cache->get_serialized('user_123_data'); // Returns the original object.
+$user_data->preferences = [ 'theme' => 'dark', 'notifications' => true ];
+$cache->set_serialized( 'user_123_data', $user_data, 600 );
+
+// Retrieve the original object specifying the allowed classes.
+$retrieved_data = $cache->get_serialized( 'user_123_data', [ \stdClass::class ] );
 
 // Works with arrays and scalar values too.
-$cache->set_serialized('config_array', ['key' => 'value'], 300);
-$config = $cache->get_serialized('config_array'); // Returns the array.
+$cache->set_serialized( 'config_array', [ 'key' => 'value' ], 300 );
+$config = $cache->get_serialized( 'config_array' ); // Returns the array.
+```
 
+### Cache Management
+
+Delete specific keys or clear all cached data:
+
+```php
 // Delete a specific key.
 $cache->delete('user_data_123');
 

--- a/docs/key-value-cache.md
+++ b/docs/key-value-cache.md
@@ -1,0 +1,75 @@
+# Key-Value Cache API
+
+The key-value cache API provides a unified interface for storing computationally intensive data with automatic expiration. It uses WordPress object caching when available (Redis, Memcached, etc.) and falls back to a custom database table when object caching is not present.
+
+## Usage
+
+Access the cache via the `tec_kv_cache()` function:
+
+```php
+$cache = tec_kv_cache();
+
+// Store a value with 5-minute expiration (minimum allowed).
+$cache->set('user_data_123', 'serialized data here', 300);
+
+// Retrieve a value.
+$data = $cache->get('user_data_123'); // Returns the stored string.
+$data = $cache->get('missing_key', 'default'); // Returns 'default' if not found.
+
+// Check if a key exists.
+if ($cache->has('user_data_123')) {
+    // Key exists and hasn't expired.
+}
+
+// Store and retrieve JSON data.
+$json_string = wp_json_encode(['status' => 'ok', 'count' => 42]);
+$cache->set('api_response', $json_string, 3600);
+$response = $cache->get_json('api_response', true); // Returns associative array.
+$response = $cache->get_json('api_response'); // Returns stdClass object.
+
+// Delete a specific key.
+$cache->delete('user_data_123');
+
+// Clear all the cached data.
+// When using the WordPress cache this will only flush the group `tec_kv_cache`.
+// When using the table cache this will delete all entries from the table.
+$cache->flush();
+```
+
+## Implementation Details
+
+### Backend Selection
+
+The API automatically selects the appropriate backend:
+- **Object Cache**: Used when `wp_using_ext_object_cache()` returns `true`
+  See the `TEC\Common\Key_Value_Cache\Object_Cache` class for the implementation details.
+- **Database Table**: Used as fallback, stores data in `wp_tec_kv_cache` table
+  See the `TEC\Common\Key_Value_Cache\Key_Value_Cache_Table` class for the implementation details.
+
+The use of the database can be forced with a filter:
+```php
+add_filter('tec_key_value_cache_force_use_of_table_cache', '__return_true');
+```
+
+### Constraints
+
+- **Minimum expiration**: 300 seconds (5 minutes) - WordPress VIP requirement
+- **Maximum key length**: 191 characters to align with `postmeta.meta_key` index length.
+- **Value type**: Strings only (encode complex data as a JSON string)
+
+For cache durations under 5 minutes, use alternative caching or memoization systems like:
+- `wp_cache_` functions with persistent and non-persistent groups.
+- `tribe_cache()` and its `ArrayAccess` API for memoization.
+- `tribe_cache()` and its setter/getter API for caching.
+
+### Expired values cleaning
+
+A cron job is scheduled to clean expired values from the database table every 12 hours.
+The scheduled cron job action is the `tec_clear_expired_key_value_cache` one.
+
+If the backend used is the WordPress cache one, then the eviction of expired values is left to the cache backend.
+
+### Error Handling
+
+Any failure is handled gracefully and logged using the `tribe_log` action.
+The key-value cache API will not throw exceptions in any case, but will either not storee the value or return the fallback value.

--- a/src/Common/Controller.php
+++ b/src/Common/Controller.php
@@ -30,6 +30,7 @@ class Controller extends Controller_Contract {
 		$this->container->singleton( Template::class );
 		$this->container->singleton( Country_List::class );
 		$this->container->register( Hooks::class );
+		$this->container->register( Key_Value_Cache\Controller::class );
 	}
 
 	/**
@@ -41,5 +42,6 @@ class Controller extends Controller_Contract {
 	 */
 	public function unregister(): void {
 		$this->container->get( Hooks::class )->unregister();
+		$this->container->get( Key_Value_Cache\Controller::class )->unregister();
 	}
 }

--- a/src/Common/Key_Value_Cache/Controller.php
+++ b/src/Common/Key_Value_Cache/Controller.php
@@ -68,12 +68,7 @@ class Controller extends Controller_Contract {
 				wp_unschedule_event( time(), self::CLEAR_EXPIRED_ACTION );
 			}
 		} else {
-			if ( doing_action( 'plugins_loaded' ) || did_action( 'plugins_loaded' ) ) {
-				$this->register_table_schema();
-			} else {
-				add_action( 'plugins_loaded', [ $this, 'register_table_schema' ] );
-			}
-
+			$this->register_table_schema();
 			$this->container->singleton( Key_Value_Cache_Interface::class, Key_Value_Cache_Table::class );
 
 			// Schedule an action to clear the table of expired entries.

--- a/src/Common/Key_Value_Cache/Controller.php
+++ b/src/Common/Key_Value_Cache/Controller.php
@@ -69,14 +69,9 @@ class Controller extends Controller_Contract {
 			}
 		} else {
 			if ( doing_action( 'plugins_loaded' ) || did_action( 'plugins_loaded' ) ) {
-				$this->table_schema = Register::table( Schema::class );
+				$this->register_table_schema();
 			} else {
-				add_action(
-					'plugins_loaded',
-					function () {
-						$this->table_schema = Register::table( Schema::class );
-					} 
-				);
+				add_action( 'plugins_loaded', [ $this, 'register_table_schema' ] );
 			}
 
 			$this->container->singleton( Key_Value_Cache_Interface::class, Key_Value_Cache_Table::class );
@@ -88,6 +83,17 @@ class Controller extends Controller_Contract {
 
 			add_action( self::CLEAR_EXPIRED_ACTION, [ $this, 'clear_expired' ] );
 		}
+	}
+
+	/**
+	 * Register the custom table schema.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_table_schema(): void {
+		$this->table_schema = Register::table( Schema::class );
 	}
 
 	/**
@@ -103,6 +109,7 @@ class Controller extends Controller_Contract {
 	 */
 	public function unregister(): void {
 		remove_action( self::CLEAR_EXPIRED_ACTION, [ $this, 'clear_expired' ] );
+		remove_action( 'plugins_loaded', [ $this, 'register_table_schema' ] );
 
 		if ( ! wp_next_scheduled( self::CLEAR_EXPIRED_ACTION ) ) {
 			wp_unschedule_event( time(), self::CLEAR_EXPIRED_ACTION );

--- a/src/Common/Key_Value_Cache/Controller.php
+++ b/src/Common/Key_Value_Cache/Controller.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Handles the key-value cache API actions and filters.
+ *
+ * @since TBD
+ *
+ * @package Common\Key_Value_Cache;
+ */
+
+namespace TEC\Common\Key_Value_Cache;
+
+use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\Key_Value_Cache\Table\Schema;
+use TEC\Common\StellarWP\Schema\Register;
+use TEC\Common\StellarWP\Schema\Tables\Contracts\Schema_Interface;
+
+/**
+ * Class Controller.
+ *
+ * @since TBD
+ *
+ * @package Common\Key_Value_Cache;
+ */
+class Controller extends Controller_Contract {
+	/**
+	 * The action name for the clear expired entries action.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	const CLEAR_EXPIRED_ACTION = 'tec_clear_expired_key_value_cache';
+
+	/**
+	 * A reference to the key-value cache table schema. Null if not using the table.
+	 *
+	 * @since TBD
+	 *
+	 * @var Schema_Interface|null
+	 */
+	private ?Schema_Interface $table_schema;
+
+	/**
+	 * Registers the actions and filters required by the key-value cache functionality.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	protected function do_register(): void {
+		$wp_using_ext_object_cache = wp_using_ext_object_cache();
+
+		/**
+		 * Whether to force the use of the table cache when real object caching is present or not.
+		 * By default, the table cache is not used when real object caching is present.
+		 *
+		 * @since TBD
+		 *
+		 * @param bool $force_use_of_table_cache Whether to force the use of the table cache when real object caching is present or not.
+		 */
+		$force_use_of_table_cache = apply_filters( 'tec_key_value_cache_force_use_of_table_cache', false );
+
+		if ( $wp_using_ext_object_cache && ! $force_use_of_table_cache ) {
+			$this->container->singleton( Key_Value_Cache_Interface::class, Object_Cache::class );
+
+			// If we were using the table cache, we need to unschedule the cron event.
+			if ( ! wp_next_scheduled( self::CLEAR_EXPIRED_ACTION ) ) {
+				wp_unschedule_event( time(), self::CLEAR_EXPIRED_ACTION );
+			}
+		} else {
+			$this->table_schema = Register::table( Schema::class );
+			$this->container->singleton( Key_Value_Cache_Interface::class, Key_Value_Cache_Table::class );
+
+			// Schedule an action to clear the table of expired entries.
+			if ( ! wp_next_scheduled( self::CLEAR_EXPIRED_ACTION ) ) {
+				wp_schedule_event( time(), 'twicedaily', self::CLEAR_EXPIRED_ACTION );
+			}
+
+			add_action( self::CLEAR_EXPIRED_ACTION, [ $this, 'clear_expired' ] );
+		}
+	}
+
+	/**
+	 * Unregisters the actions and filters required by the key-value cache functionality.
+	 *
+	 * The method is unscheduling the cron event as well. While the purpose of the unregister method
+	 * is to control the controller filters and actions in the context of the current request, this
+	 * will not prevent a following request from scheduling it again.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function unregister(): void {
+		remove_action( self::CLEAR_EXPIRED_ACTION, [ $this, 'clear_expired' ] );
+
+		if ( ! wp_next_scheduled( self::CLEAR_EXPIRED_ACTION ) ) {
+			wp_unschedule_event( time(), self::CLEAR_EXPIRED_ACTION );
+		}
+	}
+
+	/**
+	 * Clears the expired entries from the table if using the table and it exists.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function clear_expired(): void {
+		if ( $this->table_schema === null || ! $this->table_schema->exists() ) {
+			// Not using the table or the table does not exist.
+			return;
+		}
+
+		$this->container->make( Key_Value_Cache_Table::class )->clear_expired();
+	}
+}

--- a/src/Common/Key_Value_Cache/Controller.php
+++ b/src/Common/Key_Value_Cache/Controller.php
@@ -68,7 +68,17 @@ class Controller extends Controller_Contract {
 				wp_unschedule_event( time(), self::CLEAR_EXPIRED_ACTION );
 			}
 		} else {
-			$this->table_schema = Register::table( Schema::class );
+			if ( doing_action( 'plugins_loaded' ) || did_action( 'plugins_loaded' ) ) {
+				$this->table_schema = Register::table( Schema::class );
+			} else {
+				add_action(
+					'plugins_loaded',
+					function () {
+						$this->table_schema = Register::table( Schema::class );
+					} 
+				);
+			}
+
 			$this->container->singleton( Key_Value_Cache_Interface::class, Key_Value_Cache_Table::class );
 
 			// Schedule an action to clear the table of expired entries.

--- a/src/Common/Key_Value_Cache/Key_Value_Cache_Interface.php
+++ b/src/Common/Key_Value_Cache/Key_Value_Cache_Interface.php
@@ -83,6 +83,43 @@ interface Key_Value_Cache_Interface {
 	public function get_json( string $key, bool $associative = false );
 
 	/**
+	 * Stores a JSON-encoded value for a key.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key        The key to store the value for.
+	 * @param mixed  $value      The value to encode as JSON and store.
+	 * @param int    $expiration The cache expiration, it cannot be below 300 seconds.
+	 *
+	 * @return bool Whether the value was correctly JSON-encoded and stored.
+	 */
+	public function set_json( string $key, $value, int $expiration = 300 ): bool;
+
+	/**
+	 * Gets a cached value and attempts to unserialize it.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key The key to return the value for.
+	 *
+	 * @return mixed The unserialized value if the key exists and can be unserialized, else null.
+	 */
+	public function get_serialized( string $key );
+
+	/**
+	 * Stores a serialized value for a key.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key        The key to store the value for.
+	 * @param mixed  $value      The value to serialize and store.
+	 * @param int    $expiration The cache expiration, it cannot be below 300 seconds.
+	 *
+	 * @return bool Whether the value was correctly serialized and stored.
+	 */
+	public function set_serialized( string $key, $value, int $expiration = 300 ): bool;
+
+	/**
 	 * Flushes the cache.
 	 *
 	 * @since TBD

--- a/src/Common/Key_Value_Cache/Key_Value_Cache_Interface.php
+++ b/src/Common/Key_Value_Cache/Key_Value_Cache_Interface.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * The interface exposed by a key-value cache implementation.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Key_Value_Cache;
+ */
+
+namespace TEC\Common\Key_Value_Cache;
+
+/**
+ * Interface Key_Value_Cache_Interface.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Key_Value_Cache;
+ */
+interface Key_Value_Cache_Interface {
+	/**
+	 * Whether a key exists in the cache.
+	 *
+	 * This method tells nothing about the nature of the value, it only checks whether the key exists in the cache.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key The key to check.
+	 *
+	 * @return bool Whether the key exists in the cache.
+	 */
+	public function has( string $key ): bool;
+
+	/**
+	 * Returns a cached value if it exists.
+	 *
+	 * Note the method does not inquire into the nature of the stored value, it's returned as it is and no guarantee
+	 * is made on the integrity or correctness of the value.
+	 *
+	 * @since TBD
+	 *
+	 * @param string      $key      The key to return the value for.
+	 * @param string|null $fallback The fallback value to return if the key does not exist.
+	 *
+	 * @return string The cached value or the default value if not set.
+	 */
+	public function get( string $key, string $fallback = '' ): string;
+
+	/**
+	 * Stores a value for a key.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key   The key to store the value for.
+	 * @param string $value The value to store for the key.
+	 * @param int    $expiration The cache expiration, it cannot be below 300 seconds.
+	 *
+	 * @return bool Whether the value was correctly stored or not.
+	 */
+	public function set( string $key, string $value, int $expiration = 300 ): bool;
+
+	/**
+	 * Deletes a value from the cache, if present.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key The key to delete.
+	 *
+	 * @return void The value is deleted if present, nothing is returned.
+	 */
+	public function delete( string $key ): void;
+
+	/**
+	 * Gets a cache value and attempts to decode it to a JSON object.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key         The key to return the value for.
+	 * @param bool   $associative Whether to return an associative array or an object.
+	 *
+	 * @return object|array<string|int,mixed>|null The decoded JSON object or array if the key exists and can be
+	 *                                             decoded, else `null`.
+	 */
+	public function get_json( string $key, bool $associative = false );
+
+	/**
+	 * Flushes the cache.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function flush(): void;
+}

--- a/src/Common/Key_Value_Cache/Key_Value_Cache_Interface.php
+++ b/src/Common/Key_Value_Cache/Key_Value_Cache_Interface.php
@@ -101,10 +101,11 @@ interface Key_Value_Cache_Interface {
 	 * @since TBD
 	 *
 	 * @param string $key The key to return the value for.
+	 * @param array  $allowed_classes The classes that are allowed to be unserialized.
 	 *
 	 * @return mixed The unserialized value if the key exists and can be unserialized, else null.
 	 */
-	public function get_serialized( string $key );
+	public function get_serialized( string $key, array $allowed_classes = [] );
 
 	/**
 	 * Stores a serialized value for a key.

--- a/src/Common/Key_Value_Cache/Key_Value_Cache_Methods_Trait.php
+++ b/src/Common/Key_Value_Cache/Key_Value_Cache_Methods_Trait.php
@@ -104,10 +104,11 @@ trait Key_Value_Cache_Methods_Trait {
 	 * @since TBD
 	 *
 	 * @param string $key The key to return the value for.
+	 * @param array  $allowed_classes The classes that are allowed to be unserialized.
 	 *
 	 * @return mixed The unserialized value if the key exists and can be unserialized, else null.
 	 */
-	public function get_serialized( string $key ) {
+	public function get_serialized( string $key, array $allowed_classes = [] ) {
 		$value = $this->get( $key );
 
 		if ( empty( $value ) ) {
@@ -116,7 +117,7 @@ trait Key_Value_Cache_Methods_Trait {
 
 		try {
 			// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize
-			$unserialized = unserialize( $value, [ 'allow_classes' => true ] );
+			$unserialized = unserialize( $value, [ 'allowed_classes' => $allowed_classes ] );
 		} catch ( \Exception $e ) {
 			do_action(
 				'tribe_log',

--- a/src/Common/Key_Value_Cache/Key_Value_Cache_Methods_Trait.php
+++ b/src/Common/Key_Value_Cache/Key_Value_Cache_Methods_Trait.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * A trait of common methods for kye-value cache implementations.
+ *
+ * @since TBD
+ *
+ * @package Common\Key_Value_Cache;
+ */
+
+namespace TEC\Common\Key_Value_Cache;
+
+/**
+ * Trait Key_Value_Cache_Methods_Trait.
+ *
+ * @since TBD
+ *
+ * @package Common\Key_Value_Cache;
+ */
+trait Key_Value_Cache_Methods_Trait {
+	/**
+	 * Gets a cache value and attempts to decode it to a JSON object.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key         The key to return the value for.
+	 * @param bool   $associative Whether to return an associative array or an object.
+	 *
+	 * @return object|array<string|int,mixed>|null The decoded JSON object or array if the key exists and can be
+	 *                                             decoded, else `null`.
+	 */
+	public function get_json( string $key, bool $associative = false ) {
+		$value = $this->get( $key );
+
+		if ( empty( $value ) ) {
+			return null;
+		}
+
+		$decoded = json_decode( $value, $associative );
+
+		// On error return null.
+		if ( null === $decoded || json_last_error() !== JSON_ERROR_NONE ) {
+			return null;
+		}
+
+		return $decoded;
+	}
+}

--- a/src/Common/Key_Value_Cache/Key_Value_Cache_Table.php
+++ b/src/Common/Key_Value_Cache/Key_Value_Cache_Table.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * The API of the key-value cache.
+ *
+ * @since TBD
+ *
+ * @package Common\Key_Value_Cache;
+ */
+
+namespace TEC\Common\Key_Value_Cache;
+
+use Exception;
+use TEC\Common\Key_Value_Cache\Table\Schema;
+use TEC\Common\StellarWP\DB\DB;
+
+/**
+ * Class Key_Value_Cache_Table.
+ *
+ * @since TBD
+ *
+ * @package Common\Key_Value_Cache;
+ */
+class Key_Value_Cache_Table implements Key_Value_Cache_Interface {
+	use Key_Value_Cache_Methods_Trait;
+
+	/**
+	 * Whether a key exists in the cache.
+	 *
+	 * This method tells nothing about the nature of the value, it only checks whether the key exists in the cache.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key The key to check.
+	 *
+	 * @return bool Whether the key exists in the cache.
+	 */
+	public function has( string $key ): bool {
+		$current_time = time();
+
+		try {
+			$exists = DB::get_var(
+				DB::prepare(
+					'SELECT COUNT(*) FROM %i WHERE `cache_key` = %s AND (`expiration` = 0 OR `expiration` > %d)',
+					Schema::table_name(),
+					$key,
+					$current_time
+				)
+			);
+		} catch ( Exception $e ) {
+			return false;
+		}
+
+		return $exists > 0;
+	}
+
+	/**
+	 * Returns a cached value if it exists.
+	 *
+	 * Note the method does not inquire into the nature of the stored value, it's returned as it is and no guarantee
+	 * is made on the integrity or correctness of the value.
+	 *
+	 * @since TBD
+	 *
+	 * @param string      $key      The key to return the value for.
+	 * @param string|null $fallback The fallback value to return if the key does not exist.
+	 *
+	 * @return string The cached value or the default value if not set.
+	 */
+	public function get( string $key, string $fallback = '' ): string {
+		$current_time = time();
+
+		try {
+			$value = DB::get_var(
+				DB::prepare(
+					'SELECT `value` FROM %i WHERE `cache_key` = %s AND (`expiration` = 0 OR `expiration` > %d)',
+					Schema::table_name(),
+					$key,
+					$current_time
+				)
+			);
+		} catch ( Exception $e ) {
+			return $fallback;
+		}
+
+		if ( null === $value ) {
+			return $fallback;
+		}
+
+		return (string) $value;
+	}
+
+	/**
+	 * Stores a value for a key.
+	 *
+	 * The maximum length of 191 chars aligns with the table definition and is the same length
+	 * of the index used in the `wp_postmeta` table for meta_keys.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key   The key to store the value for.
+	 * @param string $value The value to store for the key.
+	 * @param int    $expiration The cache expiration, it cannot be below 300 seconds.
+	 *
+	 * @return bool Whether the value was correctly stored or not.
+	 */
+	public function set( string $key, string $value, int $expiration = 300 ): bool {
+		// Bail if the key is longer than 191 characters.
+		if ( strlen( $key ) > 191 ) {
+			return false;
+		}
+
+		if ( $expiration < 300 ) {
+			// To stick with WP VIP min requirements, we're not going to store values with an expiration under 5 minutes.
+			return false;
+		}
+
+		$expiration_timestamp = $expiration + time();
+
+		try {
+			// Use INSERT ... ON DUPLICATE KEY UPDATE for upsert functionality.
+			$result = DB::query(
+				DB::prepare(
+					'INSERT INTO %i (`cache_key`, `value`, `expiration`) VALUES (%s, %s, %d)
+				ON DUPLICATE KEY UPDATE `value` = VALUES(`value`), `expiration` = VALUES(`expiration`)',
+					Schema::table_name(),
+					$key,
+					$value,
+					$expiration_timestamp
+				)
+			);
+		} catch ( Exception $e ) {
+			return false;
+		}
+
+		return false !== $result;
+	}
+
+	/**
+	 * Deletes a value from the cache, if present.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key The key to delete.
+	 *
+	 * @return void The value is deleted if present, nothing is returned.
+	 */
+	public function delete( string $key ): void {
+		$table_name = Schema::table_name();
+
+		try {
+			DB::delete(
+				$table_name,
+				[ 'cache_key' => $key ],
+				[ '%s' ]
+			);
+		} catch ( Exception $e ) {
+			do_action(
+				'tribe_log',
+				'error',
+				'Key Value Cache delete error: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Flushes the cache.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function flush(): void {
+		$table_name = Schema::table_name();
+
+		try {
+			DB::query( "TRUNCATE TABLE {$table_name}" );
+		} catch ( Exception $e ) {
+			do_action(
+				'tribe_log',
+				'error',
+				'Key Value Cache flush error: ' . $e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Clears the expired values from the table.
+	 *
+	 * This method is not part of the key-value interface as it applies only to the table version.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function clear_expired(): void {
+		$table_name   = Schema::table_name();
+		$current_time = time();
+
+		try {
+			DB::query(
+				DB::prepare(
+					'DELETE FROM %i WHERE `expiration` > 0 AND `expiration` < %d',
+					$table_name,
+					$current_time
+				)
+			);
+		} catch ( Exception $e ) {
+			do_action(
+				'tribe_log',
+				'error',
+				'Key Value Cache clear expired error: ' . $e->getMessage()
+			);
+		}
+	}
+}

--- a/src/Common/Key_Value_Cache/Object_Cache.php
+++ b/src/Common/Key_Value_Cache/Object_Cache.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * A key-value cache implementation based on the WordPress cache layer.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Key_Value_Cache;
+ */
+
+namespace TEC\Common\Key_Value_Cache;
+
+/**
+ * Class Object_Cache.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Key_Value_Cache;
+ */
+class Object_Cache implements Key_Value_Cache_Interface {
+	use Key_Value_Cache_Methods_Trait;
+
+	/**
+	 * The cache group to use for the object cache.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	public const CACHE_GROUP = 'tec_kv_cache';
+
+	/**
+	 * Whether a key exists in the cache.
+	 *
+	 * This method tells nothing about the nature of the value, it only checks whether the key exists in the cache.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key The key to check.
+	 *
+	 * @return bool Whether the key exists in the cache.
+	 */
+	public function has( string $key ): bool {
+		$value = wp_cache_get( $key, static::CACHE_GROUP );
+
+		return false !== $value;
+	}
+
+	/**
+	 * Returns a cached value if it exists.
+	 *
+	 * Note the method does not inquire into the nature of the stored value, it's returned as it is and no guarantee
+	 * is made on the integrity or correctness of the value.
+	 *
+	 * @since TBD
+	 *
+	 * @param string      $key      The key to return the value for.
+	 * @param string|null $fallback The fallback value to return if the key does not exist.
+	 *
+	 * @return string The cached value or the default value if not set.
+	 */
+	public function get( string $key, string $fallback = '' ): string {
+		$value = wp_cache_get( $key, static::CACHE_GROUP );
+
+		if ( false === $value ) {
+			return $fallback;
+		}
+
+		return (string) $value;
+	}
+
+	/**
+	 * Stores a value for a key.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key   The key to store the value for.
+	 * @param string $value The value to store for the key.
+	 * @param int    $expiration The cache expiration, it cannot be below 300 seconds.
+	 *
+	 * @return bool Whether the value was correctly stored or not.
+	 */
+	public function set( string $key, string $value, int $expiration = 300 ): bool {
+		if ( $expiration < 300 ) {
+			// To stick with WP VIP min requirements, we're not going to store values with an expiration under 5 minutes.
+			return false;
+		}
+
+		// We're dealing with this above.
+		// phpcs:ignore WordPressVIPMinimum.Performance.LowExpiryCacheTime.CacheTimeUndetermined
+		return wp_cache_set( $key, $value, static::CACHE_GROUP, $expiration );
+	}
+
+	/**
+	 * Deletes a value from the cache, if present.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $key The key to delete.
+	 *
+	 * @return void The value is deleted if present, nothing is returned.
+	 */
+	public function delete( string $key ): void {
+		wp_cache_delete( $key, static::CACHE_GROUP );
+	}
+
+	/**
+	 * Flushes the cache.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function flush(): void {
+		wp_cache_flush_group( static::CACHE_GROUP );
+	}
+}

--- a/src/Common/Key_Value_Cache/Table/Schema.php
+++ b/src/Common/Key_Value_Cache/Table/Schema.php
@@ -77,7 +77,7 @@ class Schema extends Table {
 		 * `wp_postmeta` table.
 		 */
 
-		return "CREATE TABE {$table_name} (
+		return "CREATE TABLE {$table_name} (
 				cache_key varchar(191) NOT NULL,
 				value longtext DEFAULT NULL,
 				expiration bigint(20) UNSIGNED DEFAULT 0,

--- a/src/Common/Key_Value_Cache/Table/Schema.php
+++ b/src/Common/Key_Value_Cache/Table/Schema.php
@@ -77,7 +77,7 @@ class Schema extends Table {
 		 * `wp_postmeta` table.
 		 */
 
-		return "CREATE TABLE {$table_name} (
+		return "CREATE TABE {$table_name} (
 				cache_key varchar(191) NOT NULL,
 				value longtext DEFAULT NULL,
 				expiration bigint(20) UNSIGNED DEFAULT 0,

--- a/src/Common/Key_Value_Cache/Table/Schema.php
+++ b/src/Common/Key_Value_Cache/Table/Schema.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Defines the schema for the key-value cache table.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Key_Value_Cache\Table;
+ */
+
+namespace TEC\Common\Key_Value_Cache\Table;
+
+use TEC\Common\StellarWP\Schema\Tables\Contracts\Table;
+
+/**
+ * Class Schema.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Key_Value_Cache\Table;
+ */
+class Schema extends Table {
+	/**
+	 * The version number for this schema definition.
+	 *
+	 * @since TBD
+	 *
+	 * @var string|null
+	 */
+	const SCHEMA_VERSION = '1.0.0';
+
+	/**
+	 * The base table name.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected static $base_table_name = 'tec_kv_cache';
+
+	/**
+	 * The organizational group this table belongs to.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected static $group = 'tec';
+
+	/**
+	 * The slug used to identify the custom table.
+	 *
+	 * @since TBD
+	 *
+	 * @var string|null
+	 */
+	protected static $schema_slug = 'tec-kv-cache';
+
+	/**
+	 * The field that uniquely identifies a row in the table.
+	 *
+	 * @since TBD
+	 *
+	 * @var string
+	 */
+	protected static $uid_column = 'key';
+
+	/**
+	 * {@inheritdoc}
+	 */
+	protected function get_definition() {
+		global $wpdb;
+		$table_name      = self::table_name( true );
+		$charset_collate = $wpdb->get_charset_collate();
+
+		/*
+		 * The cache_key length of 191 is taken to stick with the index length of the meta_key freom the
+		 * `wp_postmeta` table.
+		 */
+
+		return "CREATE TABLE {$table_name} (
+				cache_key varchar(191) NOT NULL,
+				value longtext DEFAULT NULL,
+				expiration bigint(20) UNSIGNED DEFAULT 0,
+				PRIMARY KEY  (cache_key)
+			) {$charset_collate}; ";
+	}
+}

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -3,7 +3,6 @@
  * Display functions (template-tags) for use in WordPress templates.
  */
 
-use TEC\Common\Key_Value_Cache\Key_Value_Cache;
 use TEC\Common\Key_Value_Cache\Key_Value_Cache_Interface;
 use TEC\Common\StellarWP\Assets\Asset;
 use TEC\Common\StellarWP\Assets\Assets;

--- a/src/functions/template-tags/general.php
+++ b/src/functions/template-tags/general.php
@@ -3,6 +3,8 @@
  * Display functions (template-tags) for use in WordPress templates.
  */
 
+use TEC\Common\Key_Value_Cache\Key_Value_Cache;
+use TEC\Common\Key_Value_Cache\Key_Value_Cache_Interface;
 use TEC\Common\StellarWP\Assets\Asset;
 use TEC\Common\StellarWP\Assets\Assets;
 
@@ -1058,4 +1060,17 @@ if ( ! function_exists( 'tec_assets' ) ) {
 		return $registered;
 	}
 	//phpcs:enable Squiz.Commenting.FunctionComment.ParamCommentFullStop
+}
+
+if ( ! function_exists( 'tec_kv_cache' ) ) {
+	/**
+	 * Returns the shared instance of the key-value cache API object.
+	 *
+	 * @since TBD
+	 *
+	 * @return Key_Value_Cache_Interface The shared instance of the key-value cache API object.
+	 */
+	function tec_kv_cache(): Key_Value_Cache_Interface {
+		return tribe( Key_Value_Cache_Interface::class );
+	}
 }

--- a/tests/integration/Key_Value_Cache/Controller_Test.php
+++ b/tests/integration/Key_Value_Cache/Controller_Test.php
@@ -2,6 +2,7 @@
 
 namespace TEC\Common\Key_Value_Cache;
 
+use TEC\Common\Key_Value_Cache\Table\Schema;
 use TEC\Common\Tests\Provider\Controller_Test_Case;
 use Tribe\Tests\Traits\With_Uopz;
 
@@ -73,21 +74,21 @@ class Controller_Test extends Controller_Test_Case {
 
 		// Set up an expired key.
 		$wpdb->insert(
-			$wpdb->prefix . 'tec_kv_cache',
+			Schema::table_name(),
 			[
 				'cache_key'  => 'expired',
 				'value'      => 'expired_value',
 				'expiration' => time() - 1000,
-			] 
+			]
 		);
 		// Set up a non-expired key.
 		$wpdb->insert(
-			$wpdb->prefix . 'tec_kv_cache',
+			Schema::table_name(),
 			[
 				'cache_key'  => 'not_expired',
 				'value'      => 'not_expired_value',
 				'expiration' => time() + 1000,
-			] 
+			]
 		);
 
 		// Pre-clear checks.
@@ -98,7 +99,7 @@ class Controller_Test extends Controller_Test_Case {
 				'expired',
 				'not_expired',
 			],
-			$wpdb->get_col( "SELECT cache_key FROM {$wpdb->prefix}tec_kv_cache ORDER BY cache_key" ) 
+			$wpdb->get_col( "SELECT cache_key FROM {$wpdb->prefix}tec_kv_cache ORDER BY cache_key" )
 		);
 
 		$controller->clear_expired();
@@ -107,7 +108,7 @@ class Controller_Test extends Controller_Test_Case {
 		$this->assertEquals( 'not_expired_value', tec_kv_cache()->get( 'not_expired' ) );
 		$this->assertEquals(
 			[ 'not_expired' ],
-			$wpdb->get_col( "SELECT cache_key FROM {$wpdb->prefix}tec_kv_cache ORDER BY cache_key" ) 
+			$wpdb->get_col( "SELECT cache_key FROM {$wpdb->prefix}tec_kv_cache ORDER BY cache_key" )
 		);
 	}
 }

--- a/tests/integration/Key_Value_Cache/Controller_Test.php
+++ b/tests/integration/Key_Value_Cache/Controller_Test.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace TEC\Common\Key_Value_Cache;
+
+use TEC\Common\Tests\Provider\Controller_Test_Case;
+use Tribe\Tests\Traits\With_Uopz;
+
+class Controller_Test extends Controller_Test_Case {
+	use With_Uopz;
+
+	protected $controller_class = Controller::class;
+
+	/**
+	 * @before
+	 */
+	public function unschedule_action(): void {
+		wp_unschedule_event( time(), Controller::CLEAR_EXPIRED_ACTION );
+	}
+
+	/**
+	 * @covers \TEC\Common\Key_Value_Cache\Controller::register
+	 */
+	public function test_uses_object_cache_if_available(): void {
+		$this->set_fn_return( 'wp_using_ext_object_cache', true );
+
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$this->assertInstanceOf( Object_Cache::class, tec_kv_cache() );
+	}
+
+	/**
+	 * @covers \TEC\Common\Key_Value_Cache\Controller::register
+	 */
+	public function test_uses_table_cache_if_not_available(): void {
+		$this->set_fn_return( 'wp_using_ext_object_cache', false );
+
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$this->assertInstanceOf( Key_Value_Cache_Table::class, tec_kv_cache() );
+		$this->assertNotFalse( wp_next_scheduled( Controller::CLEAR_EXPIRED_ACTION ) );
+		$this->assertEquals(
+			10,
+			has_action( Controller::CLEAR_EXPIRED_ACTION, [ $controller, 'clear_expired' ] )
+		);
+	}
+
+	public function test_uses_table_cache_if_forced_to_by_filter(): void {
+		$this->set_fn_return( 'wp_using_ext_object_cache', true );
+		add_filter( 'tec_key_value_cache_force_use_of_table_cache', '__return_true' );
+
+		$controller = $this->make_controller();
+		$controller->register();
+
+		$this->assertInstanceOf( Key_Value_Cache_Table::class, tec_kv_cache() );
+		$this->assertNotFalse( wp_next_scheduled( Controller::CLEAR_EXPIRED_ACTION ) );
+		$this->assertEquals(
+			10,
+			has_action( Controller::CLEAR_EXPIRED_ACTION, [ $controller, 'clear_expired' ] )
+		);
+	}
+
+	/**
+	 * @covers \TEC\Common\Key_Value_Cache\Controller::clear_expired
+	 */
+	public function test_clear_expired(): void {
+		global $wpdb;
+		$this->set_fn_return( 'wp_using_ext_object_cache', false );
+
+		$controller = $this->make_controller();
+		$controller->register();
+
+		// Set up an expired key.
+		$wpdb->insert(
+			$wpdb->prefix . 'tec_kv_cache',
+			[
+				'cache_key'  => 'expired',
+				'value'      => 'expired_value',
+				'expiration' => time() - 1000,
+			] 
+		);
+		// Set up a non-expired key.
+		$wpdb->insert(
+			$wpdb->prefix . 'tec_kv_cache',
+			[
+				'cache_key'  => 'not_expired',
+				'value'      => 'not_expired_value',
+				'expiration' => time() + 1000,
+			] 
+		);
+
+		// Pre-clear checks.
+		$this->assertEquals( '', tec_kv_cache()->get( 'expired' ) );
+		$this->assertEquals( 'not_expired_value', tec_kv_cache()->get( 'not_expired' ) );
+		$this->assertEquals(
+			[
+				'expired',
+				'not_expired',
+			],
+			$wpdb->get_col( "SELECT cache_key FROM {$wpdb->prefix}tec_kv_cache ORDER BY cache_key" ) 
+		);
+
+		$controller->clear_expired();
+
+		$this->assertEquals( '', tec_kv_cache()->get( 'expired' ) );
+		$this->assertEquals( 'not_expired_value', tec_kv_cache()->get( 'not_expired' ) );
+		$this->assertEquals(
+			[ 'not_expired' ],
+			$wpdb->get_col( "SELECT cache_key FROM {$wpdb->prefix}tec_kv_cache ORDER BY cache_key" ) 
+		);
+	}
+}

--- a/tests/integration/Key_Value_Cache/Function_API_Test.php
+++ b/tests/integration/Key_Value_Cache/Function_API_Test.php
@@ -1,0 +1,204 @@
+<?php
+
+namespace TEC\Common\Key_Value_Cache;
+
+use TEC\Common\Tests\Provider\Controller_Test_Case;
+use Tribe\Tests\Traits\With_Uopz;
+
+/**
+ * This uses the Controller test case to ease the registration under different cache contexts.
+ */
+class Function_API_Test extends Controller_Test_Case {
+	use With_Uopz;
+
+	protected $controller_class = Controller::class;
+
+	public function test_function_api_when_using_object_caching(): void {
+		$this->set_fn_return( 'wp_using_ext_object_cache', true );
+
+		// Register the controller that will find object caching available.
+		$this->make_controller()->register();
+
+		$cache = tec_kv_cache();
+		$this->assertInstanceOf( Object_Cache::class, $cache );
+
+		// Test has() should return false for non-existent key.
+		$this->assertFalse( $cache->has( 'test_key' ) );
+		$this->assertFalse( wp_cache_get( 'test_key', Object_Cache::CACHE_GROUP ) );
+
+		// Test set() and get() with expiration = 0 should fail.
+		$this->assertFalse( $cache->set( 'test_key_zero', 'test_value', 0 ) );
+		$this->assertFalse( $cache->has( 'test_key_zero' ) );
+		$this->assertEquals( '', $cache->get( 'test_key_zero' ) );
+		$this->assertFalse( wp_cache_get( 'test_key_zero', Object_Cache::CACHE_GROUP ) );
+
+		// Test set() and get() with valid expiration.
+		$this->assertTrue( $cache->set( 'test_key', 'test_value', 300 ) );
+		$this->assertEquals( 'test_value', $cache->get( 'test_key' ) );
+		$this->assertTrue( $cache->has( 'test_key' ) );
+		// Verify the value is stored in WordPress cache.
+		$this->assertEquals( 'test_value', wp_cache_get( 'test_key', Object_Cache::CACHE_GROUP ) );
+
+		// Test get() with default.
+		$this->assertEquals( 'default_value', $cache->get( 'non_existent_key', 'default_value' ) );
+		$this->assertFalse( wp_cache_get( 'non_existent_key', Object_Cache::CACHE_GROUP ) );
+
+		// Test update existing key.
+		$this->assertTrue( $cache->set( 'test_key', 'updated_value', 300 ) );
+		$this->assertEquals( 'updated_value', $cache->get( 'test_key' ) );
+		// Verify the updated value in WordPress cache.
+		$this->assertEquals( 'updated_value', wp_cache_get( 'test_key', Object_Cache::CACHE_GROUP ) );
+
+		// Test with expiration.
+		$this->assertTrue( $cache->set( 'expiring_key', 'expiring_value', 3600 ) );
+		$this->assertEquals( 'expiring_value', $cache->get( 'expiring_key' ) );
+		// Verify the value is stored in WordPress cache.
+		$this->assertEquals( 'expiring_value', wp_cache_get( 'expiring_key', Object_Cache::CACHE_GROUP ) );
+
+		// Test expiration below 300 seconds should not store value.
+		$this->assertFalse( $cache->set( 'short_expiry_key', 'short_expiry_value', 299 ) );
+		// Verify the value was not stored.
+		$this->assertFalse( $cache->has( 'short_expiry_key' ) );
+		$this->assertEquals( '', $cache->get( 'short_expiry_key' ) );
+		$this->assertFalse( wp_cache_get( 'short_expiry_key', Object_Cache::CACHE_GROUP ) );
+
+		// Test expiration exactly 300 seconds should store value.
+		$this->assertTrue( $cache->set( 'min_expiry_key', 'min_expiry_value', 300 ) );
+		// Verify the value was stored.
+		$this->assertTrue( $cache->has( 'min_expiry_key' ) );
+		$this->assertEquals( 'min_expiry_value', $cache->get( 'min_expiry_key' ) );
+		$this->assertEquals( 'min_expiry_value', wp_cache_get( 'min_expiry_key', Object_Cache::CACHE_GROUP ) );
+
+		// Test getJson().
+		$json_data = [
+			'name'  => 'test',
+			'value' => 123,
+		];
+		$this->assertTrue( $cache->set( 'json_key', json_encode( $json_data ), 300 ) );
+		$this->assertEquals( $json_data, $cache->get_json( 'json_key', true ) );
+		$this->assertEquals( (object) $json_data, $cache->get_json( 'json_key', false ) );
+		// Verify the JSON string is stored in WordPress cache.
+		$this->assertEquals( json_encode( $json_data ), wp_cache_get( 'json_key', Object_Cache::CACHE_GROUP ) );
+
+		// Test delete().
+		$cache->delete( 'test_key' );
+		$this->assertFalse( $cache->has( 'test_key' ) );
+		$this->assertEquals( '', $cache->get( 'test_key' ) );
+		// Verify the key is deleted from WordPress cache.
+		$this->assertFalse( wp_cache_get( 'test_key', Object_Cache::CACHE_GROUP ) );
+
+		// Test flush().
+		$cache->set( 'key1', 'value1', 300 );
+		$cache->set( 'key2', 'value2', 300 );
+		// Verify values are in WordPress cache before flush.
+		$this->assertEquals( 'value1', wp_cache_get( 'key1', Object_Cache::CACHE_GROUP ) );
+		$this->assertEquals( 'value2', wp_cache_get( 'key2', Object_Cache::CACHE_GROUP ) );
+
+		$cache->flush();
+		$this->assertFalse( $cache->has( 'key1' ) );
+		$this->assertFalse( $cache->has( 'key2' ) );
+		// Verify the keys are flushed from WordPress cache.
+		$this->assertFalse( wp_cache_get( 'key1', Object_Cache::CACHE_GROUP ) );
+		$this->assertFalse( wp_cache_get( 'key2', Object_Cache::CACHE_GROUP ) );
+	}
+
+	private function run_table_cache_tests(): void {
+		global $wpdb;
+
+		// Register the controller that will find object caching not available.
+		$this->make_controller()->register();
+
+		$cache = tec_kv_cache();
+		$this->assertInstanceOf( Key_Value_Cache_Table::class, $cache );
+
+		// Test has() should return false for non-existent key.
+		$this->assertFalse( $cache->has( 'test_key' ) );
+
+		// Test set() and get() with expiration = 0 should fail.
+		$this->assertFalse( $cache->set( 'test_key_zero', 'test_value', 0 ) );
+		$this->assertFalse( $cache->has( 'test_key_zero' ) );
+		$this->assertEquals( '', $cache->get( 'test_key_zero' ) );
+
+		// Test set() and get() with valid expiration.
+		$this->assertTrue( $cache->set( 'test_key', 'test_value', 300 ) );
+		$this->assertEquals( 'test_value', $cache->get( 'test_key' ) );
+		$this->assertTrue( $cache->has( 'test_key' ) );
+
+		// Test get() with default.
+		$this->assertEquals( 'default_value', $cache->get( 'non_existent_key', 'default_value' ) );
+
+		// Test update existing key.
+		$this->assertTrue( $cache->set( 'test_key', 'updated_value', 300 ) );
+		$this->assertEquals( 'updated_value', $cache->get( 'test_key' ) );
+
+		// Test with expiration - future expiration
+		$this->assertTrue( $cache->set( 'expiring_key', 'expiring_value', 3600 ) );
+		$this->assertEquals( 'expiring_value', $cache->get( 'expiring_key' ) );
+		$this->assertTrue( $cache->has( 'expiring_key' ) );
+
+		// Test expiration below 300 seconds should not store value.
+		$this->assertFalse( $cache->set( 'short_expiry_key', 'short_expiry_value', 299 ) );
+		// Verify the value was not stored.
+		$this->assertFalse( $cache->has( 'short_expiry_key' ) );
+		$this->assertEquals( '', $cache->get( 'short_expiry_key' ) );
+
+		// Test expiration exactly 300 seconds should store value.
+		$this->assertTrue( $cache->set( 'min_expiry_key', 'min_expiry_value', 300 ) );
+		// Verify the value was stored.
+		$this->assertTrue( $cache->has( 'min_expiry_key' ) );
+		$this->assertEquals( 'min_expiry_value', $cache->get( 'min_expiry_key' ) );
+
+		// Test getJson().
+		$json_data = [
+			'name'  => 'test',
+			'value' => 123,
+		];
+		$this->assertTrue( $cache->set( 'json_key', json_encode( $json_data ), 300 ) );
+		$this->assertEquals( $json_data, $cache->get_json( 'json_key', true ) );
+		$this->assertEquals( (object) $json_data, $cache->get_json( 'json_key', false ) );
+
+		// Test invalid JSON
+		$this->assertTrue( $cache->set( 'invalid_json', 'not json', 300 ) );
+		$this->assertNull( $cache->get_json( 'invalid_json' ) );
+
+		// Test delete().
+		$cache->delete( 'test_key' );
+		$this->assertFalse( $cache->has( 'test_key' ) );
+		$this->assertEquals( '', $cache->get( 'test_key' ) );
+
+		// Test key length validation (max 191 chars).
+		$long_key = str_repeat( 'a', 192 );
+		$this->assertFalse( $cache->set( $long_key, 'value', 300 ) );
+		// Verify the value was not stored.
+		$this->assertFalse( $cache->has( $long_key ) );
+		$this->assertEquals( '', $cache->get( $long_key ) );
+
+		$valid_key = str_repeat( 'a', 191 );
+		$this->assertTrue( $cache->set( $valid_key, 'value', 300 ) );
+		// Verify the value was stored.
+		$this->assertTrue( $cache->has( $valid_key ) );
+		$this->assertEquals( 'value', $cache->get( $valid_key ) );
+
+		// Test flush().
+		$cache->set( 'key1', 'value1', 300 );
+		$cache->set( 'key2', 'value2', 300 );
+		$cache->flush();
+		$this->assertFalse( $cache->has( 'key1' ) );
+		$this->assertFalse( $cache->has( 'key2' ) );
+
+		// Verify database is actually empty after flush.
+		$count = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}tec_kv_cache" );
+		$this->assertEquals( 0, $count );
+	}
+
+	public function test_function_when_using_table_cache(): void {
+		$this->set_fn_return( 'wp_using_ext_object_cache', false );
+		$this->run_table_cache_tests();
+	}
+
+	public function test_function_when_forcing_use_of_table_cache(): void {
+		$this->set_fn_return( 'wp_using_ext_object_cache', true );
+		add_filter( 'tec_key_value_cache_force_use_of_table_cache', '__return_true' );
+		$this->run_table_cache_tests();
+	}
+}

--- a/tests/integration/Key_Value_Cache/Function_API_Test.php
+++ b/tests/integration/Key_Value_Cache/Function_API_Test.php
@@ -13,8 +13,8 @@ class Function_API_Test extends Controller_Test_Case {
 
 	protected $controller_class = Controller::class;
 
-	private function deactivate_log_listener():void{
-		remove_all_filters('tribe_log');
+	private function deactivate_log_listener(): void {
+		remove_all_filters( 'tribe_log' );
 	}
 
 	public function test_function_api_when_using_object_caching(): void {
@@ -88,15 +88,15 @@ class Function_API_Test extends Controller_Test_Case {
 		$this->assertEquals( json_encode( $json_data ), wp_cache_get( 'json_key', Object_Cache::CACHE_GROUP ) );
 
 		// Test set_json().
-		$json_data2 = [
+		$json_data2          = [
 			'status' => 'active',
 			'count'  => 42,
 			'nested' => [ 'deep' => 'value' ],
 		];
-		$expected_json_data2 = (object)[
+		$expected_json_data2 = (object) [
 			'status' => 'active',
 			'count'  => 42,
-			'nested' => (object)[ 'deep' => 'value' ],
+			'nested' => (object) [ 'deep' => 'value' ],
 		];
 		$this->assertTrue( $cache->set_json( 'json_key2', $json_data2, 300 ) );
 		$this->assertEquals( $json_data2, $cache->get_json( 'json_key2', true ) );
@@ -105,7 +105,10 @@ class Function_API_Test extends Controller_Test_Case {
 		$this->assertEquals( wp_json_encode( $json_data2 ), wp_cache_get( 'json_key2', Object_Cache::CACHE_GROUP ) );
 
 		// Test set_json() with object.
-		$obj = (object) [ 'property' => 'value', 'number' => 123 ];
+		$obj = (object) [
+			'property' => 'value',
+			'number'   => 123,
+		];
 		$this->assertTrue( $cache->set_json( 'json_object', $obj, 300 ) );
 		$retrieved_as_object = $cache->get_json( 'json_object', false );
 		$this->assertEquals( $obj, $retrieved_as_object );
@@ -151,11 +154,14 @@ class Function_API_Test extends Controller_Test_Case {
 			'property3' => [ 'nested' => 'array' ],
 		];
 		$this->assertTrue( $cache->set_serialized( 'serialized_object', $test_object, 300 ) );
-		$retrieved_object = $cache->get_serialized( 'serialized_object' );
+		$retrieved_object = $cache->get_serialized( 'serialized_object', [ \stdClass::class ] );
 		$this->assertEquals( $test_object, $retrieved_object );
 
 		// Test serializing array.
-		$test_array = [ 'key1' => 'value1', 'key2' => [ 'nested' => true ] ];
+		$test_array = [
+			'key1' => 'value1',
+			'key2' => [ 'nested' => true ],
+		];
 		$this->assertTrue( $cache->set_serialized( 'serialized_array', $test_array, 300 ) );
 		$retrieved_array = $cache->get_serialized( 'serialized_array' );
 		$this->assertEquals( $test_array, $retrieved_array );
@@ -238,22 +244,25 @@ class Function_API_Test extends Controller_Test_Case {
 		$this->assertNull( $cache->get_json( 'invalid_json' ) );
 
 		// Test set_json().
-		$json_data2 = [
+		$json_data2          = [
 			'status' => 'active',
 			'count'  => 42,
 			'nested' => [ 'deep' => 'value' ],
 		];
-		$expected_json_data2 = (object)[
+		$expected_json_data2 = (object) [
 			'status' => 'active',
 			'count'  => 42,
-			'nested' => (object)[ 'deep' => 'value' ],
+			'nested' => (object) [ 'deep' => 'value' ],
 		];
 		$this->assertTrue( $cache->set_json( 'json_key2', $json_data2, 300 ) );
 		$this->assertEquals( $json_data2, $cache->get_json( 'json_key2', true ) );
 		$this->assertEquals( $expected_json_data2, $cache->get_json( 'json_key2', false ) );
 
 		// Test set_json() with object.
-		$obj = (object) [ 'property' => 'value', 'number' => 123 ];
+		$obj = (object) [
+			'property' => 'value',
+			'number'   => 123,
+		];
 		$this->assertTrue( $cache->set_json( 'json_object', $obj, 300 ) );
 		$retrieved_as_object = $cache->get_json( 'json_object', false );
 		$this->assertEquals( $obj, $retrieved_as_object );
@@ -307,11 +316,14 @@ class Function_API_Test extends Controller_Test_Case {
 			'property3' => [ 'nested' => 'array' ],
 		];
 		$this->assertTrue( $cache->set_serialized( 'serialized_object', $test_object, 300 ) );
-		$retrieved_object = $cache->get_serialized( 'serialized_object' );
+		$retrieved_object = $cache->get_serialized( 'serialized_object', [ \stdClass::class ] );
 		$this->assertEquals( $test_object, $retrieved_object );
 
 		// Test serializing array.
-		$test_array = [ 'key1' => 'value1', 'key2' => [ 'nested' => true ] ];
+		$test_array = [
+			'key1' => 'value1',
+			'key2' => [ 'nested' => true ],
+		];
 		$this->assertTrue( $cache->set_serialized( 'serialized_array', $test_array, 300 ) );
 		$retrieved_array = $cache->get_serialized( 'serialized_array' );
 		$this->assertEquals( $test_array, $retrieved_array );

--- a/tests/integration/Key_Value_Cache/Function_API_Test.php
+++ b/tests/integration/Key_Value_Cache/Function_API_Test.php
@@ -13,11 +13,18 @@ class Function_API_Test extends Controller_Test_Case {
 
 	protected $controller_class = Controller::class;
 
+	private function deactivate_log_listener():void{
+		remove_all_filters('tribe_log');
+	}
+
 	public function test_function_api_when_using_object_caching(): void {
 		$this->set_fn_return( 'wp_using_ext_object_cache', true );
 
 		// Register the controller that will find object caching available.
 		$this->make_controller()->register();
+
+		// The controller case is monitoring it, but it's not needed here.
+		$this->deactivate_log_listener();
 
 		$cache = tec_kv_cache();
 		$this->assertInstanceOf( Object_Cache::class, $cache );
@@ -80,6 +87,42 @@ class Function_API_Test extends Controller_Test_Case {
 		// Verify the JSON string is stored in WordPress cache.
 		$this->assertEquals( json_encode( $json_data ), wp_cache_get( 'json_key', Object_Cache::CACHE_GROUP ) );
 
+		// Test set_json().
+		$json_data2 = [
+			'status' => 'active',
+			'count'  => 42,
+			'nested' => [ 'deep' => 'value' ],
+		];
+		$expected_json_data2 = (object)[
+			'status' => 'active',
+			'count'  => 42,
+			'nested' => (object)[ 'deep' => 'value' ],
+		];
+		$this->assertTrue( $cache->set_json( 'json_key2', $json_data2, 300 ) );
+		$this->assertEquals( $json_data2, $cache->get_json( 'json_key2', true ) );
+		$this->assertEquals( $expected_json_data2, $cache->get_json( 'json_key2', false ) );
+		// Verify the JSON string is stored in WordPress cache.
+		$this->assertEquals( wp_json_encode( $json_data2 ), wp_cache_get( 'json_key2', Object_Cache::CACHE_GROUP ) );
+
+		// Test set_json() with object.
+		$obj = (object) [ 'property' => 'value', 'number' => 123 ];
+		$this->assertTrue( $cache->set_json( 'json_object', $obj, 300 ) );
+		$retrieved_as_object = $cache->get_json( 'json_object', false );
+		$this->assertEquals( $obj, $retrieved_as_object );
+
+		// Test set_json() with scalar values.
+		$this->assertTrue( $cache->set_json( 'json_string', 'test string', 300 ) );
+		$this->assertEquals( 'test string', $cache->get_json( 'json_string', true ) );
+
+		$this->assertTrue( $cache->set_json( 'json_number', 42, 300 ) );
+		$this->assertEquals( 42, $cache->get_json( 'json_number', true ) );
+
+		$this->assertTrue( $cache->set_json( 'json_bool', true, 300 ) );
+		$this->assertEquals( true, $cache->get_json( 'json_bool', true ) );
+
+		$this->assertTrue( $cache->set_json( 'json_null', null, 300 ) );
+		$this->assertEquals( null, $cache->get_json( 'json_null', true ) );
+
 		// Test delete().
 		$cache->delete( 'test_key' );
 		$this->assertFalse( $cache->has( 'test_key' ) );
@@ -100,6 +143,36 @@ class Function_API_Test extends Controller_Test_Case {
 		// Verify the keys are flushed from WordPress cache.
 		$this->assertFalse( wp_cache_get( 'key1', Object_Cache::CACHE_GROUP ) );
 		$this->assertFalse( wp_cache_get( 'key2', Object_Cache::CACHE_GROUP ) );
+
+		// Test set_serialized() and get_serialized().
+		$test_object = (object) [
+			'property1' => 'value1',
+			'property2' => 42,
+			'property3' => [ 'nested' => 'array' ],
+		];
+		$this->assertTrue( $cache->set_serialized( 'serialized_object', $test_object, 300 ) );
+		$retrieved_object = $cache->get_serialized( 'serialized_object' );
+		$this->assertEquals( $test_object, $retrieved_object );
+
+		// Test serializing array.
+		$test_array = [ 'key1' => 'value1', 'key2' => [ 'nested' => true ] ];
+		$this->assertTrue( $cache->set_serialized( 'serialized_array', $test_array, 300 ) );
+		$retrieved_array = $cache->get_serialized( 'serialized_array' );
+		$this->assertEquals( $test_array, $retrieved_array );
+
+		// Test serializing scalar values.
+		$this->assertTrue( $cache->set_serialized( 'serialized_int', 42, 300 ) );
+		$this->assertSame( 42, $cache->get_serialized( 'serialized_int' ) );
+
+		$this->assertTrue( $cache->set_serialized( 'serialized_bool', false, 300 ) );
+		$this->assertSame( false, $cache->get_serialized( 'serialized_bool' ) );
+
+		// Test get_serialized with non-existent key.
+		$this->assertNull( $cache->get_serialized( 'non_existent_serialized' ) );
+
+		// Test get_serialized with invalid serialized data.
+		$cache->set( 'invalid_serialized', 'not serialized data', 300 );
+		$this->assertNull( $cache->get_serialized( 'invalid_serialized' ) );
 	}
 
 	private function run_table_cache_tests(): void {
@@ -107,6 +180,9 @@ class Function_API_Test extends Controller_Test_Case {
 
 		// Register the controller that will find object caching not available.
 		$this->make_controller()->register();
+
+		// The controller case is monitoring it, but it's not needed here.
+		$this->deactivate_log_listener();
 
 		$cache = tec_kv_cache();
 		$this->assertInstanceOf( Key_Value_Cache_Table::class, $cache );
@@ -161,6 +237,40 @@ class Function_API_Test extends Controller_Test_Case {
 		$this->assertTrue( $cache->set( 'invalid_json', 'not json', 300 ) );
 		$this->assertNull( $cache->get_json( 'invalid_json' ) );
 
+		// Test set_json().
+		$json_data2 = [
+			'status' => 'active',
+			'count'  => 42,
+			'nested' => [ 'deep' => 'value' ],
+		];
+		$expected_json_data2 = (object)[
+			'status' => 'active',
+			'count'  => 42,
+			'nested' => (object)[ 'deep' => 'value' ],
+		];
+		$this->assertTrue( $cache->set_json( 'json_key2', $json_data2, 300 ) );
+		$this->assertEquals( $json_data2, $cache->get_json( 'json_key2', true ) );
+		$this->assertEquals( $expected_json_data2, $cache->get_json( 'json_key2', false ) );
+
+		// Test set_json() with object.
+		$obj = (object) [ 'property' => 'value', 'number' => 123 ];
+		$this->assertTrue( $cache->set_json( 'json_object', $obj, 300 ) );
+		$retrieved_as_object = $cache->get_json( 'json_object', false );
+		$this->assertEquals( $obj, $retrieved_as_object );
+
+		// Test set_json() with scalar values.
+		$this->assertTrue( $cache->set_json( 'json_string', 'test string', 300 ) );
+		$this->assertEquals( 'test string', $cache->get_json( 'json_string', true ) );
+
+		$this->assertTrue( $cache->set_json( 'json_number', 42, 300 ) );
+		$this->assertEquals( 42, $cache->get_json( 'json_number', true ) );
+
+		$this->assertTrue( $cache->set_json( 'json_bool', true, 300 ) );
+		$this->assertEquals( true, $cache->get_json( 'json_bool', true ) );
+
+		$this->assertTrue( $cache->set_json( 'json_null', null, 300 ) );
+		$this->assertEquals( null, $cache->get_json( 'json_null', true ) );
+
 		// Test delete().
 		$cache->delete( 'test_key' );
 		$this->assertFalse( $cache->has( 'test_key' ) );
@@ -189,6 +299,36 @@ class Function_API_Test extends Controller_Test_Case {
 		// Verify database is actually empty after flush.
 		$count = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}tec_kv_cache" );
 		$this->assertEquals( 0, $count );
+
+		// Test set_serialized() and get_serialized().
+		$test_object = (object) [
+			'property1' => 'value1',
+			'property2' => 42,
+			'property3' => [ 'nested' => 'array' ],
+		];
+		$this->assertTrue( $cache->set_serialized( 'serialized_object', $test_object, 300 ) );
+		$retrieved_object = $cache->get_serialized( 'serialized_object' );
+		$this->assertEquals( $test_object, $retrieved_object );
+
+		// Test serializing array.
+		$test_array = [ 'key1' => 'value1', 'key2' => [ 'nested' => true ] ];
+		$this->assertTrue( $cache->set_serialized( 'serialized_array', $test_array, 300 ) );
+		$retrieved_array = $cache->get_serialized( 'serialized_array' );
+		$this->assertEquals( $test_array, $retrieved_array );
+
+		// Test serializing scalar values.
+		$this->assertTrue( $cache->set_serialized( 'serialized_int', 42, 300 ) );
+		$this->assertSame( 42, $cache->get_serialized( 'serialized_int' ) );
+
+		$this->assertTrue( $cache->set_serialized( 'serialized_bool', false, 300 ) );
+		$this->assertSame( false, $cache->get_serialized( 'serialized_bool' ) );
+
+		// Test get_serialized with non-existent key.
+		$this->assertNull( $cache->get_serialized( 'non_existent_serialized' ) );
+
+		// Test get_serialized with invalid serialized data.
+		$cache->set( 'invalid_serialized', 'not serialized data', 300 );
+		$this->assertNull( $cache->get_serialized( 'invalid_serialized' ) );
 	}
 
 	public function test_function_when_using_table_cache(): void {
@@ -197,6 +337,8 @@ class Function_API_Test extends Controller_Test_Case {
 	}
 
 	public function test_function_when_forcing_use_of_table_cache(): void {
+		// The controller case is monitoring it, but it's not needed here.
+		$this->deactivate_log_listener();
 		$this->set_fn_return( 'wp_using_ext_object_cache', true );
 		add_filter( 'tec_key_value_cache_force_use_of_table_cache', '__return_true' );
 		$this->run_table_cache_tests();


### PR DESCRIPTION
This objective of this first iteration of the key-value cache API is to provide a transparent API to store computationally intensive and possible large string values across requests.

When object-caching it's available the API will use it, else it will use a custom table with a pretty simple structure.

The unique API is the `tec_kv_cache()` function, see more in the documentation.

Following a WP VIP lead, I've set the minimum accepted expiration time to 300 seconds, 5 minutes, else this is not the cache to use.

Furthermore the cache key column is set to a length of 191 chars following the example of the `wp_postmeta.meta_key` column: 255 chars long, but only 191 are indexed. I've picked the lower value to play on the safe side.

The feature first application would be to adress an ET performance issue, but it comes with tests.

The current implementation is a first step to test the waters and has a dumb-cache approach that will work, but might end up storing redundant values. E.g.:
```
- my_plugin_all_items -> JSON array of 3 items
- my_plugin_item_23 -> JSON object representing item 23
- my_plugin_item_89 -> JSON object representing item 89
- my_plugin_item_66 -> JSON object representing item 66
```

The items `23, 66, 89` are repeated inside the `all_items` key, it's redundant.
_Some_ system avoiding this would be nice.

