### PR TITLE
Fix - TinyMCE buttons to match classic editor, invalid focus on timezone popover.

### DIFF
--- a/src/resources/packages/classy/components/TimeZone/TimezoneSelectionPopover.tsx
+++ b/src/resources/packages/classy/components/TimeZone/TimezoneSelectionPopover.tsx
@@ -82,6 +82,7 @@ export default function TimezoneSelectionPopover( props: {
 					__nextHasNoMarginBottom
 					value={ timezone }
 					onChange={ onTimezoneChange }
+					autoFocus
 				>
 					{ timezoneOptions }
 				</SelectControl>

--- a/src/resources/packages/classy/components/TinyMceEditor/TinyMceEditor.tsx
+++ b/src/resources/packages/classy/components/TinyMceEditor/TinyMceEditor.tsx
@@ -34,8 +34,8 @@ export default function TinyMceEditor( { content, onChange, id }: TinyMceEditorP
 		window.wp.oldEditor.initialize( id, {
 			tinymce: {
 				wpautop: true,
-				toolbar1: 'formatselect bold italic | bullist numlist blockquote | alignleft aligncenter alignright | link wp_more',
-				toolbar2: '',
+                toolbar1: 'formatselect bold italic | bullist numlist blockquote | alignleft aligncenter alignright | link wp_more wp_adv',
+                toolbar2: 'strikethrough hr forecolor | pastetext removeformat charmap | outdent indent | undo redo | wp_help',
 			},
 			quicktags: true, // Show the "Visual / Text" tabs.
 			mediaButtons: true, // Show the "Add media" button.

--- a/src/resources/packages/classy/components/TinyMceEditor/TinyMceEditor.tsx
+++ b/src/resources/packages/classy/components/TinyMceEditor/TinyMceEditor.tsx
@@ -34,7 +34,7 @@ export default function TinyMceEditor( { content, onChange, id }: TinyMceEditorP
 		window.wp.oldEditor.initialize( id, {
 			tinymce: {
 				wpautop: true,
-				toolbar1: 'bold italic formatselect | blockquote bullist numlist link',
+				toolbar1: 'formatselect bold italic | bullist numlist blockquote | alignleft aligncenter alignright | link wp_more',
 				toolbar2: '',
 			},
 			quicktags: true, // Show the "Visual / Text" tabs.

--- a/src/resources/packages/classy/components/TinyMceEditor/TinyMceEditor.tsx
+++ b/src/resources/packages/classy/components/TinyMceEditor/TinyMceEditor.tsx
@@ -34,8 +34,10 @@ export default function TinyMceEditor( { content, onChange, id }: TinyMceEditorP
 		window.wp.oldEditor.initialize( id, {
 			tinymce: {
 				wpautop: true,
-                toolbar1: 'formatselect bold italic | bullist numlist blockquote | alignleft aligncenter alignright | link wp_more wp_adv',
-                toolbar2: 'strikethrough hr forecolor | pastetext removeformat charmap | outdent indent | undo redo | wp_help',
+				toolbar1:
+					'formatselect bold italic | bullist numlist blockquote | alignleft aligncenter alignright | link wp_more wp_adv',
+				toolbar2:
+					'strikethrough hr forecolor | pastetext removeformat charmap | outdent indent | undo redo | wp_help',
 			},
 			quicktags: true, // Show the "Visual / Text" tabs.
 			mediaButtons: true, // Show the "Add media" button.

--- a/src/resources/packages/classy/components/TinyMceEditor/TinyMceEditor.tsx
+++ b/src/resources/packages/classy/components/TinyMceEditor/TinyMceEditor.tsx
@@ -37,8 +37,8 @@ export default function TinyMceEditor( { content, onChange, id }: TinyMceEditorP
 				toolbar1: 'bold italic formatselect | blockquote bullist numlist link',
 				toolbar2: '',
 			},
-			quicktags: false, // Do not show the "Visual / Text" tabs.
-			mediaButtons: false, // Do not show the "Add media" button.
+			quicktags: true, // Show the "Visual / Text" tabs.
+			mediaButtons: true, // Show the "Add media" button.
 		} );
 
 		// @ts-ignore - Defined by the `wp-tinymce` dependency required by the Classy package.


### PR DESCRIPTION
### 🎫 Ticket
* Issue 7
* Issue 10
from classy issue sheet.