### PR TITLE
Fix REST API entity update to separate set_args and save calls

### DIFF
--- a/src/Common/REST/TEC/V1/Traits/Update_Entity_Response.php
+++ b/src/Common/REST/TEC/V1/Traits/Update_Entity_Response.php
@@ -75,7 +75,7 @@ trait Update_Entity_Response {
 			$this->get_formatted_entity(
 				$this->get_orm()->by_args(
 					[
-						'id'     => array_keys( $entity )[0],
+						'id'     => $id,
 						'status' => 'any',
 					]
 				)->first()

--- a/src/Common/REST/TEC/V1/Traits/Update_Entity_Response.php
+++ b/src/Common/REST/TEC/V1/Traits/Update_Entity_Response.php
@@ -58,7 +58,9 @@ trait Update_Entity_Response {
 				'id'     => $id,
 				'status' => 'any',
 			]
-		)->set_args( $params )->save();
+		)->set_args( $params );
+
+		$entity->save();
 
 		if ( empty( $entity ) ) {
 			return new WP_REST_Response(


### PR DESCRIPTION
## Fix REST API entity update to separate set_args and save calls

This change separates the set_args() and save() method calls in the Update_Entity_Response trait to allow for proper method chaining and better debugging of entity updates.

Related to multiple venue support implementation.

Also

## Fix TypeError in Update_Entity_Response trait 

Correct an issues where array_keys() was being called on a repository object instead of using the entity ID directly.

Issue: Line 78 called array_keys()[0] where  was a repository object (e.g., Tribe__Events__Pro__Repositories__Venue) rather than an array.

Solution: Use the  parameter directly instead of trying to extract it from the repository object.

Error details:
- TypeError: array_keys() expects parameter 1 to be array, object given
- Occurred during venue/organizer updates via REST API
- Data was being saved correctly but response was returning HTTP 500

Tested scenarios:
✅ Venue updates now return HTTP 200 with proper response data
✅ Organizer updates work correctly
✅ Invalid IDs still return appropriate 403/404 errors
