### PR TITLE
Adds string casting for REST parameter validation

### DIFF
--- a/src/Common/REST/TEC/V1/Parameter_Types/Date_Time.php
+++ b/src/Common/REST/TEC/V1/Parameter_Types/Date_Time.php
@@ -33,7 +33,7 @@ class Date_Time extends Text {
 	 */
 	public function get_validator(): ?Closure {
 		return $this->validator ?? function ( $value ): bool {
-			if ( null !== $this->get_pattern() && ! preg_match( '/' . $this->get_pattern() . '/', $value ) ) {
+			if ( null !== $this->get_pattern() && ! preg_match( '/' . $this->get_pattern() . '/', (string) $value ) ) {
 				// translators: 1) is the name of the parameter.
 				$exception = new InvalidRestArgumentException( sprintf( __( 'Parameter `{%1$s}` must match the pattern.', 'the-events-calendar' ), $this->get_name() ) );
 

--- a/src/Common/REST/TEC/V1/Parameter_Types/Hex_Color.php
+++ b/src/Common/REST/TEC/V1/Parameter_Types/Hex_Color.php
@@ -44,7 +44,7 @@ class Hex_Color extends Text {
 				throw $exception;
 			}
 
-			if ( ! ( preg_match( '/^#([0-9a-fA-F]{3})$/', $value ) || preg_match( '/^#([0-9a-fA-F]{6})$/', $value ) ) ) {
+			if ( ! ( preg_match( '/^#([0-9a-fA-F]{3})$/', (string) $value ) || preg_match( '/^#([0-9a-fA-F]{6})$/', (string) $value ) ) ) {
 				// translators: 1) is the name of the parameter.
 				$exception = new InvalidRestArgumentException( sprintf( __( 'Parameter `{%1$s}` must be a valid hex color.', 'the-events-calendar' ), $this->get_name() ) );
 				$exception->set_argument( $this->get_name() );

--- a/src/Common/REST/TEC/V1/Parameter_Types/Text.php
+++ b/src/Common/REST/TEC/V1/Parameter_Types/Text.php
@@ -125,7 +125,7 @@ class Text extends Parameter {
 					throw $exception;
 				}
 
-				if ( ! preg_match( '/' . $this->get_pattern() . '/', $value ) ) {
+				if ( ! preg_match( '/' . $this->get_pattern() . '/', (string) $value ) ) {
 					// translators: 1) is the name of the parameter.
 					$exception = new InvalidRestArgumentException( sprintf( __( 'Parameter `{%1$s}` must match the pattern.', 'the-events-calendar' ), $this->get_name() ) );
 

--- a/src/Common/REST/TEC/V1/Parameter_Types/UUID.php
+++ b/src/Common/REST/TEC/V1/Parameter_Types/UUID.php
@@ -33,7 +33,7 @@ class UUID extends Text {
 	 */
 	public function get_validator(): ?Closure {
 		return $this->validator ?? function ( $value ): bool {
-			if ( ! is_string( $value ) || ! preg_match( '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $value ) ) {
+			if ( ! is_string( $value ) || ! preg_match( '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', (string) $value ) ) {
 				// translators: 1) is the name of the parameter.
 				$exception = new InvalidRestArgumentException( sprintf( __( 'Parameter `{%1$s}` must be a valid UUID.', 'tribe-common' ), $this->get_name() ) );
 				$exception->set_argument( $this->get_name() );


### PR DESCRIPTION
Ensures that REST parameters are cast to strings before validation.

This prevents potential errors when parameters of unexpected types are passed to validation functions, which expect strings.

YY-0000