### PR TITLE
Fixes REST API status parameter and CTables compatibility

### DIFF
--- a/src/Common/REST/TEC/V1/Documentation/OpenAPI_Schema.php
+++ b/src/Common/REST/TEC/V1/Documentation/OpenAPI_Schema.php
@@ -319,6 +319,10 @@ class OpenAPI_Schema implements OpenAPI_Schema_Contract {
 					throw $exception;
 				}
 
+				if ( 'status' === $param_name && empty( $data[ $param_name ] ) ) {
+					$data[ $param_name ] = 'publish';
+				}
+
 				if ( ! isset( $data[ $param_name ] ) ) {
 					continue;
 				}

--- a/src/Common/REST/TEC/V1/Parameter_Types/Definition_Parameter.php
+++ b/src/Common/REST/TEC/V1/Parameter_Types/Definition_Parameter.php
@@ -119,8 +119,10 @@ class Definition_Parameter extends Entity {
 		foreach ( $collections as $collection ) {
 			/** @var Property $property */
 			foreach ( $collection as $property ) {
-				$argument = $this->get_name() ? $this->get_name() . '.' . $property->get_name() : $property->get_name();
-				if ( $property->is_required() && ! isset( $data[ $property->get_name() ] ) ) {
+				$param_name = $property->get_name();
+				$argument   = $this->get_name() ? $this->get_name() . '.' . $param_name : $param_name;
+
+				if ( $property->is_required() && ! isset( $data[ $param_name ] ) ) {
 					// translators: %s is the name of the property.
 					$exception = new InvalidRestArgumentException( sprintf( __( 'Property %s is required', 'the-events-calendar' ), $argument ) );
 					$exception->set_argument( $argument );
@@ -129,11 +131,15 @@ class Definition_Parameter extends Entity {
 					throw $exception;
 				}
 
-				if ( ! isset( $data[ $property->get_name() ] ) ) {
+				if ( 'status' === $param_name && empty( $data[ $param_name ] ) ) {
+					$data[ $param_name ] = 'publish';
+				}
+
+				if ( ! isset( $data[ $param_name ] ) ) {
 					continue;
 				}
 
-				$is_valid = $property->get_validator()( $data[ $property->get_name() ] );
+				$is_valid = $property->get_validator()( $data[ $param_name ] );
 
 				if ( ! $is_valid ) {
 					// translators: %s: The name of the invalid property.
@@ -144,7 +150,7 @@ class Definition_Parameter extends Entity {
 					throw $exception;
 				}
 
-				$sanitized_data[ $property->get_name() ] = $property->get_sanitizer()( $data[ $property->get_name() ] );
+				$sanitized_data[ $param_name ] = $property->get_sanitizer()( $data[ $param_name ] );
 			}
 		}
 

--- a/src/Common/REST/TEC/V1/Traits/Update_Entity_Response.php
+++ b/src/Common/REST/TEC/V1/Traits/Update_Entity_Response.php
@@ -12,6 +12,7 @@ declare( strict_types=1 );
 namespace TEC\Common\REST\TEC\V1\Traits;
 
 use WP_REST_Response;
+use TEC\Events_Pro\Custom_Tables\V1\WP_Query\Provider as Custom_Tables_Provider;
 
 /**
  * Trait to handle the response for update entity requests.
@@ -51,6 +52,10 @@ trait Update_Entity_Response {
 				],
 				404
 			);
+		}
+
+		if ( tribe()->isBound( Custom_Tables_Provider::class ) ) {
+			remove_filter( 'tec_events_custom_tables_v1_occurrence_select_fields', [ tribe( Custom_Tables_Provider::class ), 'filter_occurrence_fields' ] );
 		}
 
 		$save_result = $this->get_orm()->by_args(


### PR DESCRIPTION
- Ensures the `status` parameter defaults to 'publish' when empty in REST API requests.
- Adds compatibility adjustments for custom tables when updating entities via the REST API.

Fixes TEC-651