### PR TITLE
Fix string interpolation in JSON Packer

### DIFF
--- a/src/Common/Json_Packer/Json_Packer.php
+++ b/src/Common/Json_Packer/Json_Packer.php
@@ -492,7 +492,7 @@ class Json_Packer {
 			}
 		} catch ( ReflectionException $e ) {
 			if ( $this->fail_on_error ) {
-				throw new Unpack_Exception( "Error while unpacking ${class_name}: {$e->getMessage()}" );
+				throw new Unpack_Exception( "Error while unpacking {$class_name}: {$e->getMessage()}" );
 			}
 			// We cannot use the original class: use a stdClass instance in its place.
 			$object = new stdClass();


### PR DESCRIPTION
This fixes a small string interpolation deprecation warning in the JSON Packer.

The PR does not contain a changelog as it's a fix on a feature introduced in the release and already present in the changelog.
