### PR TITLE
TEC-5362 Fix IAN and QM conflict

### DIFF
--- a/changelog/fix-TEC-5362-ian-qm-conflict
+++ b/changelog/fix-TEC-5362-ian-qm-conflict
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Fixed conflict with IAN being injected into Query Monitor headers. [TEC-5362]

--- a/src/resources/js/ian-client.js
+++ b/src/resources/js/ian-client.js
@@ -49,14 +49,25 @@
 		 * Wrap the headings with a div to allow for positioning of the sidebar.
 		 *
 		 * @since 6.4.0
+		 * @since TBD Added check for Query Monitor or other overlays.
 		 *
 		 * @return {void}
 		 */
 		const wrapHeadings = () => {
+			// Early bail if we're inside Query Monitor or other overlays.
+			if ( document.querySelector( '#query-monitor' ) || document.querySelector( '.qm' ) ) {
+				return;
+			}
+
 			const headings = document.querySelectorAll(
 				'.edit-php.post-type-tribe_events h1, .post-php.post-type-tribe_events h1'
 			);
 			headings.forEach( ( heading ) => {
+				// Skip headings that are inside Query Monitor or other plugin overlays.
+				if ( heading.closest( '.qm' ) || heading.closest( '#query-monitor' ) ) {
+					return;
+				}
+
 				const pageAction = heading.nextElementSibling;
 				if ( pageAction ) {
 					const wrapper = document.createElement( 'div' );

--- a/src/resources/js/ian-client.js
+++ b/src/resources/js/ian-client.js
@@ -54,20 +54,10 @@
 		 * @return {void}
 		 */
 		const wrapHeadings = () => {
-			// Early bail if we're inside Query Monitor or other overlays.
-			if ( document.querySelector( '#query-monitor' ) || document.querySelector( '.qm' ) ) {
-				return;
-			}
-
 			const headings = document.querySelectorAll(
-				'.edit-php.post-type-tribe_events h1, .post-php.post-type-tribe_events h1'
+				'.edit-php.post-type-tribe_events h1.wp-heading-inline, .post-php.post-type-tribe_events h1.wp-heading-inline'
 			);
 			headings.forEach( ( heading ) => {
-				// Skip headings that are inside Query Monitor or other plugin overlays.
-				if ( heading.closest( '.qm' ) || heading.closest( '#query-monitor' ) ) {
-					return;
-				}
-
 				const pageAction = heading.nextElementSibling;
 				if ( pageAction ) {
 					const wrapper = document.createElement( 'div' );


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5362]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

IAN headers were being injected into Query Monitor headers - this PR simply adds a bail to the `wrapHeadings` method to bail if within the Query Monitor interface.

### 🎥 Artifacts 
Before: 
<img width="3442" height="1930" alt="TEC-5362-Before" src="https://github.com/user-attachments/assets/f379f87a-ad78-42f8-907f-9327e7241923" />

After:
<img width="3448" height="1938" alt="TEC-5362-After" src="https://github.com/user-attachments/assets/6f9a0fbb-a4f5-46fa-abee-1e2ab1c94e33" />


### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TEC-5362]: https://stellarwp.atlassian.net/browse/TEC-5362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ