### PR TITLE
TCMN-198 fix autoshare sysinfo

### DIFF
--- a/changelog/fix-TCMN-198-fix-autoshare-sysinfo
+++ b/changelog/fix-TCMN-198-fix-autoshare-sysinfo
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Restore proper functionality of system information opt-in checkbox. [TCMN-198]

--- a/src/resources/js/admin/help-page.js
+++ b/src/resources/js/admin/help-page.js
@@ -144,7 +144,7 @@ tribe.helpPage = tribe.helpPage || {};
 		obj.$system_info_opt_in = $( obj.selectors.autoInfoOptIn );
 		obj.$system_info_opt_in_msg = $( obj.selectors.optInMsg );
 
-		obj.$system_info_opt_in.on( 'change', function(e) {
+		obj.$system_info_opt_in.on( 'change', ( e ) => {
 			if ( e.target.checked ) {
 				obj.doAjaxRequest( 'generate' );
 			} else {

--- a/src/resources/js/admin/help-page.js
+++ b/src/resources/js/admin/help-page.js
@@ -144,8 +144,8 @@ tribe.helpPage = tribe.helpPage || {};
 		obj.$system_info_opt_in = $( obj.selectors.autoInfoOptIn );
 		obj.$system_info_opt_in_msg = $( obj.selectors.optInMsg );
 
-		obj.$system_info_opt_in.on( 'change', () => {
-			if ( this.checked ) {
+		obj.$system_info_opt_in.on( 'change', function(e) {
+			if ( e.target.checked ) {
 				obj.doAjaxRequest( 'generate' );
 			} else {
 				obj.doAjaxRequest( 'remove' );


### PR DESCRIPTION
### 🎫 Ticket

[TCMN-198]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Clicking the "Yes, automatically share my system information..." checkbox stopped functioning in TEC 6.8.2 because scripts were moved around. This implements the small fix needed to make it work again.

### 🎥 Artifacts <!-- if applicable-->
[Screencast](https://docs.google.com/videos/d/14Kuu4qD2b-qjZejmuTLl9rRR0DA2nCq7KEnyl2hLdtw/edit?usp=sharing)

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.


[TCMN-198]: https://stellarwp.atlassian.net/browse/TCMN-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ