### PR TITLE
[EBT-157] EBT Licenses not working properly.

### DIFF
--- a/changelog/fix-EBT-157_remove_empty_notices
+++ b/changelog/fix-EBT-157_remove_empty_notices
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fix
+
+Corrected an issue where PUE License data had an empty key. [EBT-156]

--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -252,8 +252,8 @@ class Tribe__PUE__Notices {
 	 *
 	 * @since TBD Added early bail if $plugin_name is an empty string.
 	 *
-	 * @param string $notice_type
-	 * @param string $plugin_name
+	 * @param string $notice_type Notice Type.
+	 * @param string $plugin_name Plugin Name.
 	 */
 	public function add_notice( $notice_type, $plugin_name ) {
 		if ( '' === trim( (string) $plugin_name ) ) {

--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -269,8 +269,8 @@ class Tribe__PUE__Notices {
 	 *
 	 * @since TBD Bail early if the $plugin_name is an empty string.
 	 *
-	 * @param string      $plugin_name
-	 * @param string|null $notice_type
+	 * @param string      $plugin_name Plugin Name.
+	 * @param string|null $notice_type Notice Type.
 	 *
 	 * @return boolean
 	 */

--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -250,10 +250,15 @@ class Tribe__PUE__Notices {
 	 * was already added to the MISSING_KEY group and is subsequently added to the
 	 * INVALID_KEY group, the previous entry (under MISSING_KEY) will be cleared.
 	 *
+	 * @since TBD Added early bail if $plugin_name is an empty string.
+	 *
 	 * @param string $notice_type
 	 * @param string $plugin_name
 	 */
 	public function add_notice( $notice_type, $plugin_name ) {
+		if ( '' === trim( (string) $plugin_name ) ) {
+			return;
+		}
 		$this->clear_notices( $plugin_name, true );
 		$this->notices[ $notice_type ][ $plugin_name ] = true;
 		$this->save_notices();

--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -262,6 +262,8 @@ class Tribe__PUE__Notices {
 	/**
 	 * Returns whether or not a given plugin name has a specific notice
 	 *
+	 * @since TBD Bail early if the $plugin_name is an empty string.
+	 *
 	 * @param string      $plugin_name
 	 * @param string|null $notice_type
 	 *

--- a/src/Tribe/PUE/Notices.php
+++ b/src/Tribe/PUE/Notices.php
@@ -152,8 +152,12 @@ class Tribe__PUE__Notices {
 			}
 		}
 
-		// Remove numeric keys to ensure the notices array only contains valid string keys.
-		$notices = array_filter( $notices, fn( $key ) => ! is_numeric( $key ), ARRAY_FILTER_USE_KEY );
+		// Remove numeric keys and empty keys to ensure the notices array only contains valid string keys.
+		$notices = array_filter(
+			$notices,
+			fn( $key ) => is_string( $key ) && strlen( trim( $key ) ) > 0,
+			ARRAY_FILTER_USE_KEY
+		);
 
 		return $this->setup_notice_structure( $notices );
 	}
@@ -258,13 +262,18 @@ class Tribe__PUE__Notices {
 	/**
 	 * Returns whether or not a given plugin name has a specific notice
 	 *
-	 * @param string $plugin_name
+	 * @param string      $plugin_name
 	 * @param string|null $notice_type
 	 *
 	 * @return boolean
 	 */
 	public function has_notice( $plugin_name, $notice_type = null ) {
-		// If we match a pue key we use that value
+		// Bail if plugin name is empty.
+		if ( '' === trim( (string) $plugin_name ) ) {
+			return false;
+		}
+
+		// If we match a pue key we use that value.
 		if ( isset( $this->plugin_names[ $plugin_name ] ) ) {
 			$plugin_name = $this->plugin_names[ $plugin_name ];
 		}

--- a/tests/wpunit/Tribe/PUE/Notices_Test.php
+++ b/tests/wpunit/Tribe/PUE/Notices_Test.php
@@ -99,33 +99,8 @@ class Notices_Test extends WPTestCase {
 
 		$this->assertArrayNotHasKey(
 			'',
-			$saved[ Notices::EXPIRED_KEY ],
+			$saved[ Notices::EXPIRED_KEY ] ?? [],
 			'add_notice() should not persist empty plugin names.'
-		);
-	}
-
-	/**
-	 * @test
-	 */
-	public function sanitize_notices_should_remove_empty_plugin_names(): void {
-		$corrupted = [
-			'expired_key' => [
-				'Event Aggregator' => true,
-				''                 => true,
-			],
-			'invalid_key' => [],
-			'upgrade_key' => [],
-		];
-
-		update_option( Notices::STORE_KEY, $corrupted );
-
-		$notices = new Notices();
-		$clean   = get_option( Notices::STORE_KEY );
-
-		$this->assertArrayNotHasKey(
-			'',
-			$clean['expired_key'],
-			'sanitize_notices() should strip out empty plugin names.'
 		);
 	}
 }


### PR DESCRIPTION
[EBT-157]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description
Some sites were returning `WP_Error` from the Event Aggregator service even though a valid Eventbrite license key was present.

After debugging, we found that the option `tribe_pue_key_notices` contained corrupted data. Specifically, an **empty string** key was being stored inside the `expired_key` notices array:

```php
array (
  'expired_key' => array(
    'Promoter'         => true,
    ''                 => true,   // ❌ Invalid entry
    'Event Aggregator' => true,
  ),
  'invalid_key' => array(),
  'upgrade_key' => array(),
)
```

Because `has_notice()` treated `''` as a valid key, it returned `true` and caused Event Aggregator to be considered invalid. This resulted in the API call returning a `WP_Error` and breaking the authorization flow.

---

**Root Cause**

* The `add_notice()` method allowed empty plugin names to be added.
* The `sanitize_notices()` method only removed numeric keys, not empty strings.
* As a result, corrupted entries persisted in the DB and polluted notice checks.
<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[EBT-157]: https://stellarwp.atlassian.net/browse/EBT-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ