### PR TITLE
Convert default values of protected vars to empty arrays.

### DIFF
--- a/changelog/fix-potential-fatal-in-rewrite
+++ b/changelog/fix-potential-fatal-in-rewrite
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Convert default values of protected vars to empty array to potential prevent fatals in PHP 8.3+
+Convert default values of protected vars to empty array to potential prevent fatals in PHP 8.3+ props to @aaronsilber! [TCMN-202]

--- a/changelog/fix-potential-fatal-in-rewrite
+++ b/changelog/fix-potential-fatal-in-rewrite
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Convert default values of protected vars to empty array to potential prevent fatals in PHP 8.3+

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -72,7 +72,7 @@ class Tribe__Rewrite {
 	 *
 	 * @var array
 	 */
-	protected $canonical_url_cache = [];
+	protected array $canonical_url_cache = [];
 
 	/**
 	 * An array cache of parsed URLs in the shape `[ <url> => <parsed_vars> ]`.
@@ -82,7 +82,7 @@ class Tribe__Rewrite {
 	 *
 	 * @var array
 	 */
-	protected $parse_request_cache = [];
+	protected array $parse_request_cache = [];
 
 	/**
 	 * And array cache of cleaned URLs.
@@ -92,7 +92,8 @@ class Tribe__Rewrite {
 	 *
 	 * @var array
 	 */
-	protected $clean_url_cache = [];
+	protected array $clean_url_cache = [];
+
 	/**
 	 * A reference to the Locale Switcher instance.
 	 *

--- a/src/Tribe/Rewrite.php
+++ b/src/Tribe/Rewrite.php
@@ -68,28 +68,31 @@ class Tribe__Rewrite {
 	 * An array cache of resolved canonical URLs in the shape `[ <url> => <canonical_url> ]`.
 	 *
 	 * @since 4.9.11
+	 * @since TBD    Changed default value to an empty array to prevent potential fatals.
 	 *
 	 * @var array
 	 */
-	protected $canonical_url_cache = null;
+	protected $canonical_url_cache = [];
 
 	/**
 	 * An array cache of parsed URLs in the shape `[ <url> => <parsed_vars> ]`.
 	 *
 	 * @since 4.9.11
+	 * @since TBD    Changed default value to an empty array to prevent potential fatals.
 	 *
 	 * @var array
 	 */
-	protected $parse_request_cache = null;
+	protected $parse_request_cache = [];
 
 	/**
 	 * And array cache of cleaned URLs.
 	 *
 	 * @since 4.9.11
+	 * @since TBD    Changed default value to an empty array to prevent potential fatals.
 	 *
 	 * @var array
 	 */
-	protected $clean_url_cache = null;
+	protected $clean_url_cache = [];
 	/**
 	 * A reference to the Locale Switcher instance.
 	 *


### PR DESCRIPTION
…prevent fatals in PHP 8.3+

### 🎫 Ticket
[TCMN-202]

### 🗒️ Description

Prevent potential fatals in PHP 8.3+ due to trying to assign a key->value to `null`.
see https://github.com/the-events-calendar/tribe-common/pull/2634

I think this is a more comprehensive solution than the proposal - which I assume was trying to minimize the change effects.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.


[TCMN-202]: https://stellarwp.atlassian.net/browse/TCMN-202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ