### PR TITLE
Fix - Show block templates while using classy for existing events with blocks.

### DIFF
--- a/src/Common/Classy/Controller.php
+++ b/src/Common/Classy/Controller.php
@@ -128,7 +128,6 @@ class Controller extends Controller_Contract {
 		$this->container->singleton( 'events.editor', $back_compatible_editor );
 		$this->container->singleton( 'events.editor.compatibility', $back_compatible_editor );
 		$this->container->singleton( 'editor.utils', new Editor_Utils() );
-		$this->container->singleton( 'events.editor.template', 'Tribe__Events__Editor__Template' );
 
 		$this->container->register( REST\Controller::class );
 

--- a/src/Common/Classy/Controller.php
+++ b/src/Common/Classy/Controller.php
@@ -124,7 +124,6 @@ class Controller extends Controller_Contract {
 	protected function do_register(): void {
 		// Register the `editor` binding replacement for back-compatibility purposes.
 		$back_compatible_editor = new Editor();
-		$this->container->singleton( 'editor', $back_compatible_editor );
 		$this->container->singleton( 'events.editor', $back_compatible_editor );
 		$this->container->singleton( 'events.editor.compatibility', $back_compatible_editor );
 		$this->container->singleton( 'editor.utils', new Editor_Utils() );

--- a/src/Common/Classy/Controller.php
+++ b/src/Common/Classy/Controller.php
@@ -131,7 +131,7 @@ class Controller extends Controller_Contract {
 		$this->container->register( REST\Controller::class );
 
 		// Tell Common, TEC, ET and so on NOT to load blocks.
-		add_filter( 'tribe_editor_should_load_blocks', [ self::class, 'return_false' ] );
+		add_filter( 'tribe_editor_should_load_blocks', [ $this, 'disable_in_admin' ], 100 );
 
 		// We're using Classy editor.
 		add_filter( 'tec_using_classy_editor', [ self::class, 'return_true' ] );
@@ -428,5 +428,22 @@ class Controller extends Controller_Contract {
 		 * @since TBD
 		 */
 		do_action( 'tribe_editor_register_blocks' );
+	}
+
+	/**
+	 * Disable loading blocks in the admin.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $should_load Whether to load the blocks or not.
+	 *
+	 * @return bool Whether to load the blocks or not.
+	 */
+	public function disable_in_admin( $should_load ): bool {
+		if ( is_admin() ) {
+			return false;
+		}
+
+		return $should_load;
 	}
 }

--- a/src/Common/Classy/Controller.php
+++ b/src/Common/Classy/Controller.php
@@ -175,7 +175,6 @@ class Controller extends Controller_Contract {
 		remove_filter( 'tribe_editor_should_load_blocks', [ self::class, 'return_false' ] );
 		remove_filter( 'tec_using_classy_editor', [ self::class, 'return_true' ] );
 		remove_filter( 'block_editor_settings_all', [ $this, 'filter_block_editor_settings' ], 100 );
-		remove_filter( 'tec_using_classy_editor', [ self::class, 'return_true' ] );
 		remove_filter( 'tribe_editor_should_load_blocks', [ self::class, 'return_false' ] );
 		remove_action( 'tec_common_assets_loaded', [ $this, 'register_assets' ] );
 		remove_filter( 'get_user_metadata', [ $this,'disable_block_editor_welcome_screen' ] );


### PR DESCRIPTION
* Updated classy provider in common to properly support block templates.