### PR TITLE
TEC-5583 Don't show opt in modal if onboarding is completed

### DIFF
--- a/changelog/fix-TEC-5583-remove-second-opt-in-message
+++ b/changelog/fix-TEC-5583-remove-second-opt-in-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add logic to not show the Telemetry opt in modal if the onboarding wizard was completed. [TEC-5583]

--- a/src/Common/Telemetry/Telemetry.php
+++ b/src/Common/Telemetry/Telemetry.php
@@ -594,11 +594,23 @@ final class Telemetry {
 	 * Calculate the optin status for the TEC plugins from various sources.
 	 *
 	 * @since 5.1.1.1
+	 * @since TBD Updated to check if the user completed the onboarding wizard.
 	 *
 	 * @return bool $show If the modal should show
 	 */
 	public static function calculate_modal_status(): bool {
-		// If we've already opted in, don't show the modal.
+		// First, check if the user completed the onboarding wizard.
+		$onboarding_data = get_option( 'tec_onboarding_wizard_data', [] );
+
+		if ( tribe_is_truthy( $onboarding_data['finished'] ) ) {
+			// If wizard was finished but only tab 0 is completed, user likely skipped the wizard.
+			// If that's the case, we should still show the modal, otherwise we skip it.
+			if ( ! $onboarding_data['completed_tabs'] === [ 0 ] ) {
+				return false;
+			}
+		}
+
+		// Check if they explicitly opted in through other means (like settings page).
 		$option = tribe_get_option( 'opt-in-status', null );
 		if ( tribe_is_truthy( $option ) ) {
 			return false;


### PR DESCRIPTION
### 🎫 Ticket

[TEC-5583]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

The Telemetry opt-in is being prompted in the onboarding wizard, so if a user completes the onboarding wizard, we should assume that they have opted out of Telemetry and not re-prompt them when they visit the Settings page. 

This PR adds logic to achieve that, while still accounting for if the user clicks `Skip guided setup`, the modal should still pop up because we are not sure if they consciously chose to opt out or not. 

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
