### PR TITLE
Test/tbd fails

### DIFF
--- a/.github/workflows/release-prepare-branch.yml
+++ b/.github/workflows/release-prepare-branch.yml
@@ -40,21 +40,61 @@ jobs:
           echo "sha_short=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
           echo "version_bump_type=${versionBumpType%% *}" >> $GITHUB_OUTPUT
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-dev --no-interaction --prefer-dist
+
       - name: Set up Git configuration
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "github-actions"
 
-      - name: Check for .puprc file and paths.versions
+      - name: Check for .puprc file and validate versions
         id: check-puprc
         run: |
           if [ ! -f ".puprc" ]; then
-            echo "Error: .puprc file not found" >> $GITHUB_STEP_SUMMARY
+            echo "❌ Error: .puprc file not found" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
           if ! jq -e '.paths.versions' .puprc > /dev/null; then
-            echo "Error: paths.versions not found in .puprc" >> $GITHUB_STEP_SUMMARY
+            echo "❌ Error: paths.versions not found in .puprc" >> $GITHUB_STEP_SUMMARY
             exit 1
+          fi
+
+          # Run pup version-conflict check
+          if ! composer pup check version-conflict > /tmp/pup-output.txt 2>&1; then
+            echo "## ⚠️ Version Conflict Detected (Before Bump)" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            cat /tmp/pup-output.txt >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The PR will resolve these conflicts by updating all version files. Please review the changes to ensure they're correct." >> $GITHUB_STEP_SUMMARY
+
+            # Store conflict message for PR description
+            echo "has_conflict=true" >> $GITHUB_OUTPUT
+            {
+              echo 'conflict_message<<EOF'
+              echo '## ℹ️ Version Conflict Detected Before Bump'
+              echo ''
+              echo 'The following version conflicts were found before the version bump:'
+              echo ''
+              echo '```'
+              cat /tmp/pup-output.txt
+              echo '```'
+              echo ''
+              echo 'These conflicts have been resolved by this PR, which updates all version files to the new version.'
+              echo 'Please review the changes to ensure the version updates are correct and investigate if this indicates an issue with a past release.'
+              echo 'EOF'
+            } >> $GITHUB_OUTPUT
+          else
+            echo "✅ No version conflicts detected" >> $GITHUB_STEP_SUMMARY
+            echo "has_conflict=false" >> $GITHUB_OUTPUT
+            echo "conflict_message=" >> $GITHUB_OUTPUT
           fi
 
       - name: Create and push release branch
@@ -78,68 +118,79 @@ jobs:
           git push origin "$changeBranch"
           versionBumpType="${{ steps.vars.outputs.version_bump_type }}"
 
+          # Get current version using pup
+          existing_version=$(composer pup get-version)
+          if [ -z "$existing_version" ] || [ "$existing_version" = "unknown" ]; then
+            echo "❌ Error: Could not determine current version using pup" >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+          echo "## Version Bump" >> $GITHUB_STEP_SUMMARY
+          echo "* Current version: \`$existing_version\`" >> $GITHUB_STEP_SUMMARY
+          echo "* Bump type: \`$versionBumpType\`" >> $GITHUB_STEP_SUMMARY
+
+          # Parse version parts
+          IFS='.' read -r -a version_parts <<< "$existing_version"
+
+          # Apply version bump
+          case "$versionBumpType" in
+            major)
+              version_parts[0]=$((version_parts[0] + 1))
+              version_parts[1]=0
+              version_parts[2]=0
+              unset version_parts[3]
+              ;;
+            feature)
+              version_parts[1]=$((version_parts[1] + 1))
+              version_parts[2]=0
+              unset version_parts[3]
+              ;;
+            maintenance)
+              version_parts[2]=$((version_parts[2] + 1))
+              unset version_parts[3]
+              ;;
+            hotfix)
+              if [ -z "${version_parts[3]}" ]; then
+                version_parts[3]=1
+              else
+                version_parts[3]=$((version_parts[3] + 1))
+              fi
+              ;;
+          esac
+
+          new_version="${version_parts[0]}.${version_parts[1]}.${version_parts[2]}"
+          if [ -n "${version_parts[3]}" ]; then
+            new_version="$new_version.${version_parts[3]}"
+          fi
+
+          echo "* New version: \`$new_version\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "## Files Updated" >> $GITHUB_STEP_SUMMARY
+
+          # Update all version files using pup's configuration
           jq -c '.paths.versions[]' .puprc | while read -r version; do
-            echo "Processing version info: $version"
             file=$(echo "$version" | jq -r '.file')
             regex=$(echo "$version" | jq -r '.regex')
 
-            echo "## \`$file\`" >> $GITHUB_STEP_SUMMARY
-            if [ -f "$file" ]; then
-              existing_version=$(grep -Po "$regex" "$file" | grep -Po '(\d+\.\d+\.\d+(\.\d+)?)')
-              if [ -z "$existing_version" ]; then
-                echo "Error: No version found in \`$file\` using regex \`$regex\`" >> $GITHUB_STEP_SUMMARY
-                exit 1
-              fi
-              echo "* Found: \`$existing_version\`" >> $GITHUB_STEP_SUMMARY
-
-              if [ "$versionBumpType" = "hotfix" ] && [ "$file" = "package.json" ]; then
-                echo "Skipping version bump in \`package.json\` for \`hotfix\` mode" >> $GITHUB_STEP_SUMMARY
-                continue
-              fi
-              
-              IFS='.' read -r -a version_parts <<< "$existing_version"
-
-              case "$versionBumpType" in
-                major)
-                  version_parts[0]=$((version_parts[0] + 1))
-                  version_parts[1]=0
-                  version_parts[2]=0
-                  unset version_parts[3]
-                  ;;
-                feature)
-                  version_parts[1]=$((version_parts[1] + 1))
-                  version_parts[2]=0
-                  unset version_parts[3]
-                  ;;
-                maintenance)
-                  version_parts[2]=$((version_parts[2] + 1))
-                  unset version_parts[3]
-                  ;;
-                hotfix)
-                  if [ -z "${version_parts[3]}" ]; then
-                    version_parts[3]=1
-                  else
-                    version_parts[3]=$((version_parts[3] + 1))
-                  fi
-                  ;;
-              esac
-
-              new_version="${version_parts[0]}.${version_parts[1]}.${version_parts[2]}"
-              if [ -n "${version_parts[3]}" ]; then
-                new_version="$new_version.${version_parts[3]}"
-              fi
-
-              echo "* Modified: \`$new_version\`" >> $GITHUB_STEP_SUMMARY
-
-              php_regex=$(echo "$regex" | sed "s/'/\\\\'/g")
-              php -r "file_put_contents('$file', preg_replace('/$php_regex/', '\${1}$new_version', file_get_contents('$file')));"
-
-              echo "new_version=$new_version" >> $GITHUB_OUTPUT
-            else
-              echo "Error: File \`$file\` not found" >> $GITHUB_STEP_SUMMARY
+            if [ ! -f "$file" ]; then
+              echo "❌ Error: File \`$file\` not found" >> $GITHUB_STEP_SUMMARY
               exit 1
             fi
+
+            # Special handling for hotfix + package.json (skip the bump)
+            if [ "$versionBumpType" = "hotfix" ] && [ "$file" = "package.json" ]; then
+              echo "- \`$file\`: Skipped (hotfix does not bump package.json)" >> $GITHUB_STEP_SUMMARY
+              continue
+            fi
+
+            # Update the version in the file
+            php_regex=$(echo "$regex" | sed "s/'/\\\\'/g")
+            php -r "file_put_contents('$file', preg_replace('/$php_regex/', '\${1}$new_version', file_get_contents('$file')));"
+
+            echo "- \`$file\`: Updated to \`$new_version\`" >> $GITHUB_STEP_SUMMARY
           done
+
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
@@ -152,6 +203,8 @@ jobs:
           body: |
             This is an automated PR created by ${{ github.actor }}.
             It was generated by [this GitHub Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+
+            ${{ steps.check-puprc.outputs.conflict_message }}
           labels: "automation"
           commit-message: |
             Version bump for ${{ github.event.inputs.new-branch }}

--- a/.github/workflows/release-replace-tbd-entries.yml
+++ b/.github/workflows/release-replace-tbd-entries.yml
@@ -25,41 +25,55 @@ jobs:
           echo "timestamp=$(date +%Y%m%d-%H%M%S)" >> $GITHUB_OUTPUT
           echo "current_branch=${{ github.ref_name }}" >> $GITHUB_OUTPUT
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: composer install --no-dev --no-interaction --prefer-dist
+
       - name: Set up Git configuration
         run: |
           git config --global user.email "actions@github.com"
           git config --global user.name "github-actions"
 
-      - name: Check for version files
+      - name: Check for version conflicts
         id: check-version
         run: |
-          # Set default version in case we can't find one
-          CURRENT_VERSION="0.0.0"
-          
-          # Look for package.json
-          if [ -f "package.json" ]; then
-            PACKAGE_VERSION=$(grep -Po '"version":\s*"\K[^"]+' package.json)
-            if [ ! -z "$PACKAGE_VERSION" ]; then
-              CURRENT_VERSION="$PACKAGE_VERSION"
-              echo "Found version in package.json: $CURRENT_VERSION" >> $GITHUB_STEP_SUMMARY
-            fi
+          echo "## Version Detection" >> $GITHUB_STEP_SUMMARY
+
+          # Check if .puprc exists
+          if [ ! -f ".puprc" ]; then
+            echo "❌ Error: .puprc file not found" >> $GITHUB_STEP_SUMMARY
+            echo "This workflow requires a .puprc file with version paths configured." >> $GITHUB_STEP_SUMMARY
+            exit 1
           fi
-          
-          # Look for plugin.php or main PHP file
-          for file in $(find . -name "*.php" -type f -not -path "*/vendor/*" -not -path "*/node_modules/*"); do
-            if grep -q "Version:" "$file"; then
-              PHP_VERSION=$(grep -Po 'Version:\s*\K[0-9]+\.[0-9]+\.[0-9]+(?:\.[0-9]+)?' "$file")
-              if [ ! -z "$PHP_VERSION" ]; then
-                CURRENT_VERSION="$PHP_VERSION"
-                echo "Found version in $file: $CURRENT_VERSION" >> $GITHUB_STEP_SUMMARY
-                break
-              fi
-            fi
-          done
-          
+
+          # Run pup version-conflict check
+          if ! composer pup check version-conflict > /tmp/pup-output.txt 2>&1; then
+            echo "## ❌ Version Conflict Detected" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            cat /tmp/pup-output.txt >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "Please ensure all version numbers match before running this workflow." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
+          # Get the version using pup
+          CURRENT_VERSION=$(composer pup get-version)
+
+          if [ -z "$CURRENT_VERSION" ] || [ "$CURRENT_VERSION" = "unknown" ]; then
+            echo "## ❌ Error: No Version Found" >> $GITHUB_STEP_SUMMARY
+            echo "Could not determine the current version using pup." >> $GITHUB_STEP_SUMMARY
+            exit 1
+          fi
+
           echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-          echo "## Current Version" >> $GITHUB_STEP_SUMMARY
-          echo "* Version: \`$CURRENT_VERSION\`" >> $GITHUB_STEP_SUMMARY
+          echo "## ✅ Current Version" >> $GITHUB_STEP_SUMMARY
+          echo "Version: \`$CURRENT_VERSION\`" >> $GITHUB_STEP_SUMMARY
 
       - name: Create branch for changes
         id: create-branch
@@ -76,9 +90,9 @@ jobs:
           CURRENT_VERSION="${{ steps.check-version.outputs.current_version }}"
           FOUND_TBD=false
           CHANGES_MADE=false
-          
+
           echo "## Files Changed" >> $GITHUB_STEP_SUMMARY
-          
+
           # Define file extensions to search
           FILE_EXTENSIONS=(
             "*.php"
@@ -91,7 +105,7 @@ jobs:
             "*.md"
             "*.txt"
           )
-          
+
           # Define directories to exclude
           EXCLUDE_DIRS=(
             "*/vendor/*"
@@ -99,10 +113,10 @@ jobs:
             "*/.git/*"
             "*/tests/*"
           )
-          
+
           # Build the find command
           FIND_CMD="find . -type f \("
-          
+
           # Add file extensions with proper separator
           for i in "${!FILE_EXTENSIONS[@]}"; do
             if [ "$i" -gt 0 ]; then
@@ -110,19 +124,19 @@ jobs:
             fi
             FIND_CMD+=" -name \"${FILE_EXTENSIONS[$i]}\""
           done
-          
+
           FIND_CMD+=" \)"
-          
+
           # Add excluded directories
           for dir in "${EXCLUDE_DIRS[@]}"; do
             FIND_CMD+=" -not -path \"$dir\""
           done
-          
+
           # Search in files based on the constructed command
           for file in $(eval "$FIND_CMD"); do
             if grep -q "TBD" "$file"; then
               FOUND_TBD=true
-              
+
               # Find and display all line numbers where TBD appears
               grep -n "TBD" "$file" | while IFS=: read -r line_num content; do
                 # Create a GitHub-compatible file path (remove leading ./ if present)
@@ -130,25 +144,25 @@ jobs:
                 if [[ "$github_file_path" == "./"* ]]; then
                   github_file_path="${github_file_path:2}"
                 fi
-                
+
                 # Create a markdown link to the file at specific line in the branch
                 echo "- [\`$file@L$line_num\`](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/$github_file_path#L$line_num)" >> $GITHUB_STEP_SUMMARY
               done
-              
+
               # Replace TBD with version
               sed -i "s/TBD/$CURRENT_VERSION/g" "$file"
               CHANGES_MADE=true
             fi
           done
-          
+
           if [ "$FOUND_TBD" = false ]; then
             echo "No TBD entries found in the repository." >> $GITHUB_STEP_SUMMARY
             echo "found_tbd=false" >> $GITHUB_OUTPUT
           else
             echo "found_tbd=true" >> $GITHUB_OUTPUT
           fi
-          
-          if [ "$CHANGES_MADE" = true ]; then            
+
+          if [ "$CHANGES_MADE" = true ]; then
             # Let PR creation handle it
             echo "changes_made=true" >> $GITHUB_OUTPUT
           else
@@ -168,12 +182,12 @@ jobs:
           body: |
             This is an automated PR created by ${{ github.actor }}.
             It replaces all "TBD" entries in the codebase with the current version: ${{ steps.check-version.outputs.current_version }}
-            
+
             Generated by: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           labels: "automation"
           commit-message: |
             Replace TBD entries with version ${{ steps.check-version.outputs.current_version }}
-            
+
             This is an automated PR created by ${{ github.actor }}.
             Generated by: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           delete-branch: false
@@ -190,4 +204,4 @@ jobs:
         if: steps.replace-tbd.outputs.changes_made == 'false'
         run: |
           echo "## No Pull Request Created" >> $GITHUB_STEP_SUMMARY
-          echo "No TBD entries were found or changed in the repository." >> $GITHUB_STEP_SUMMARY 
+          echo "No TBD entries were found or changed in the repository." >> $GITHUB_STEP_SUMMARY

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tribe-common",
-  "version": "6.9.6",
+  "version": "6.9.23",
   "repository": "git@github.com:the-events-calendar/tribe-common.git",
   "_resourcepath": "src/resources",
   "_domainPath": "lang",

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -23,7 +23,7 @@ class Tribe__Main {
 	const OPTIONNAME        = 'tribe_events_calendar_options';
 	const OPTIONNAMENETWORK = 'tribe_events_calendar_network_options';
 	const FEED_URL          = 'https://theeventscalendar.com/feed/';
-	const VERSION           = '6.9.6';
+	const VERSION           = '6.9.7';
 
 	protected $plugin_context;
 	protected $plugin_context_class;

--- a/src/functions/test.php
+++ b/src/functions/test.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Test file for triggering conditionals in workflows.
+ */
+
+/**
+ * Test function.
+ *
+ * @since TBD
+ *
+ * @return bool
+ */
+function test_function() {
+	$true = true;
+
+	/**
+	 * Test filter.
+	 *
+	 * @since TBD
+	 *
+	 * @param bool $true The true value.
+	 */
+	return apply_filters( 'tec_pup_test_function', $true );
+}

--- a/tribe-common.php
+++ b/tribe-common.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Tribe Common
  * Description: An event settings framework for managing shared options.
- * Version: 6.9.6
+ * Version: 6.9.4
  * Requires at least: 6.6
  * Requires PHP: 7.4
  * Author: The Events Calendar


### PR DESCRIPTION
### What is this?

This branch attempts to modify our TBD and "prepare branch" workflows to better handle version conflicts should they arise.

Looking for comments/suggestions. 

This should not get merged directly - it has "broken" things in it to test the workflows!

## Logic

- Both workflows use the list in `.puprc` for version check locations
- `Replace TBD Entries` task will fail if version conflict is found
- `Release Prepare Branch` will attempt to carry on, hopefully fixing the version conflict in the generated PR
- The order in the `.puprc` list determines the order of precedence - the _**first version found**_ will be the one used in the PR
- The `Release Prepare Branch` workflow AND PR will include comments to check the versions and also to check  previous releases (in case  this was caused by an issue in a previous release.

### See:

TBDs: https://github.com/the-events-calendar/tribe-common/actions/runs/18292342870

Prepare branch: https://github.com/the-events-calendar/tribe-common/actions/runs/18292336224 and https://github.com/the-events-calendar/tribe-common/pull/2794
