### PR TITLE
Feat/uplink auth url decoration

### DIFF
--- a/changelog/feat-uplink-auth-url-decoration
+++ b/changelog/feat-uplink-auth-url-decoration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update Authentication URL for Assigned Seating's connector.

--- a/composer.lock
+++ b/composer.lock
@@ -905,16 +905,16 @@
         },
         {
             "name": "stellarwp/harbor",
-            "version": "v0.1.5",
+            "version": "v0.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/harbor.git",
-                "reference": "d204d37170e1f8f78b64a77f5bac6103b09d86b3"
+                "reference": "de53230b9635633b678810fd708c7f0e2150d2fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/d204d37170e1f8f78b64a77f5bac6103b09d86b3",
-                "reference": "d204d37170e1f8f78b64a77f5bac6103b09d86b3",
+                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/de53230b9635633b678810fd708c7f0e2150d2fc",
+                "reference": "de53230b9635633b678810fd708c7f0e2150d2fc",
                 "shasum": ""
             },
             "require": {
@@ -969,9 +969,9 @@
             "description": "A library that integrates a WordPress product with the Liquid Web licensing system.",
             "support": {
                 "issues": "https://github.com/stellarwp/harbor/issues",
-                "source": "https://github.com/stellarwp/harbor/tree/v0.1.5"
+                "source": "https://github.com/stellarwp/harbor/tree/v0.1.6"
             },
-            "time": "2026-04-21T18:58:25+00:00"
+            "time": "2026-04-22T20:50:33+00:00"
         },
         {
             "name": "stellarwp/installer",

--- a/src/Common/Integrations/Harbor/PUE.php
+++ b/src/Common/Integrations/Harbor/PUE.php
@@ -184,7 +184,7 @@ class PUE extends Integration_Controller {
 		$products = tribe( License_Repository::class )->get_products();
 
 		if ( $catalog && ! is_wp_error( $catalog ) && $products && ! is_wp_error( $products ) ) {
-			$tec_product         = $products->get( 'the-events-calendar' );
+			$tec_product         = $products->get_activated_entry( 'the-events-calendar' );
 			$tec_product_catalog = $catalog->get( 'the-events-calendar' );
 			if ( $tec_product && $tec_product_catalog ) {
 				$response = $this->response_from_catalog( $tec_product_catalog, $tec_product, $body['plugin'] );

--- a/src/Common/Integrations/Harbor/PUE.php
+++ b/src/Common/Integrations/Harbor/PUE.php
@@ -39,6 +39,7 @@ class PUE extends Integration_Controller {
 		add_filter( 'pre_http_request', [ $this, 'filter_pre_http_request' ], 10, 3 );
 		add_filter( 'pre_option', [ $this, 'filter_pre_get_option' ], 10, 3 );
 		add_filter( 'stellarwp/uplink/tec/license_get_key', [ $this, 'filter_stellarwp_uplink_tec_license_get_key' ], 10, 2 );
+		add_filter( 'tec_common_uplink_auth_url', [ $this, 'filter_stellarwp_uplink_tec_authorize_button_url' ], 10, 2 );
 		add_filter( 'pue_get_update_url', [ $this, 'filter_pue_get_update_url' ], 10, 2 );
 	}
 
@@ -50,10 +51,11 @@ class PUE extends Integration_Controller {
 	 * @return void
 	 */
 	public function unregister(): void {
-		remove_filter( 'pre_http_request', [ $this, 'filter_pre_http_request' ], 10, 3 );
-		remove_filter( 'pre_option', [ $this, 'filter_pre_get_option' ], 10, 3 );
-		remove_filter( 'stellarwp/uplink/tec/license_get_key', [ $this, 'filter_stellarwp_uplink_tec_license_get_key' ], 10, 2 );
-		remove_filter( 'pue_get_update_url', [ $this, 'filter_pue_get_update_url' ], 10, 2 );
+		remove_filter( 'pre_http_request', [ $this, 'filter_pre_http_request' ] );
+		remove_filter( 'pre_option', [ $this, 'filter_pre_get_option' ] );
+		remove_filter( 'stellarwp/uplink/tec/license_get_key', [ $this, 'filter_stellarwp_uplink_tec_license_get_key' ] );
+		remove_filter( 'tec_common_uplink_auth_url', [ $this, 'filter_stellarwp_uplink_tec_authorize_button_url' ] );
+		remove_filter( 'pue_get_update_url', [ $this, 'filter_pue_get_update_url' ] );
 	}
 
 	/**
@@ -316,5 +318,32 @@ class PUE extends Integration_Controller {
 			],
 			'cookies'  => [],
 		];
+	}
+
+	/**
+	 * Filter the StellarWP Uplink TEC authorize button URL.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $url   The URL.
+	 * @param string $slug  The slug.
+	 *
+	 * @return string
+	 */
+	public function filter_stellarwp_uplink_tec_authorize_button_url( string $url, string $slug ): string {
+		if ( 'tec-seating' !== $slug ) {
+			return $url;
+		}
+
+		$url_parsed = wp_parse_url( $url );
+		if ( empty( $url_parsed['host'] ) || empty( $url_parsed['path'] ) ) {
+			return $url;
+		}
+
+		if ( $url_parsed['path'] !== '/seating-connect/' ) {
+			return $url;
+		}
+
+		return $this->harbor->get_portal_url( $url_parsed['path'] );
 	}
 }

--- a/src/Common/Integrations/Uplink/Auth_URL_Decorator.php
+++ b/src/Common/Integrations/Uplink/Auth_URL_Decorator.php
@@ -6,6 +6,7 @@
  *
  * @package TEC\Common\Integrations\Uplink
  */
+
 namespace TEC\Common\Integrations\Uplink;
 
 use TEC\Common\StellarWP\Uplink\API\V3\Auth\Auth_Url_Cache_Decorator;
@@ -30,9 +31,9 @@ class Auth_URL_Decorator implements Auth_Url {
 	 *
 	 * @since TBD
 	 *
-	 * @param Auth_Url_Cache_Decorator $auth_url_cache_decorator
+	 * @param Auth_Url_Cache_Decorator $auth_url_cache_decorator The auth URL cache decorator.
 	 */
-	 public function __construct( Auth_Url_Cache_Decorator $auth_url_cache_decorator ) {
+	public function __construct( Auth_Url_Cache_Decorator $auth_url_cache_decorator ) {
 		$this->auth_url_cache_decorator = $auth_url_cache_decorator;
 	}
 

--- a/src/Common/Integrations/Uplink/Auth_URL_Decorator.php
+++ b/src/Common/Integrations/Uplink/Auth_URL_Decorator.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Auth URL decorator.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Integrations\Uplink
+ */
+namespace TEC\Common\Integrations\Uplink;
+
+use TEC\Common\StellarWP\Uplink\API\V3\Auth\Auth_Url_Cache_Decorator;
+use TEC\Common\StellarWP\Uplink\API\V3\Auth\Contracts\Auth_Url;
+
+/**
+ * Auth URL decorator.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Integrations\Uplink
+ */
+class Auth_URL_Decorator implements Auth_Url {
+
+	/**
+	 * @var Auth_Url_Cache_Decorator
+	 */
+	private Auth_Url_Cache_Decorator $auth_url_cache_decorator;
+
+	/**
+	 * The auth URL cache decorator constructor.
+	 *
+	 * @since TBD
+	 *
+	 * @param Auth_Url_Cache_Decorator $auth_url_cache_decorator
+	 */
+	 public function __construct( Auth_Url_Cache_Decorator $auth_url_cache_decorator ) {
+		$this->auth_url_cache_decorator = $auth_url_cache_decorator;
+	}
+
+	/**
+	 * Get the auth URL.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $slug The slug.
+	 *
+	 * @return string The auth URL.
+	 */
+	public function get( string $slug ): string {
+		$url = $this->auth_url_cache_decorator->get( $slug );
+
+		/**
+		 * Filter the auth URL.
+		 *
+		 * @since TBD
+		 *
+		 * @param string $url The auth URL.
+		 * @param string $slug The slug.
+		 *
+		 * @return string The auth URL.
+		 */
+		return apply_filters( 'tec_common_uplink_auth_url', $url, $slug );
+	}
+}

--- a/src/Common/Libraries/Harbor.php
+++ b/src/Common/Libraries/Harbor.php
@@ -14,6 +14,7 @@ use TEC\Common\Integrations\Harbor\PUE_Resolver;
 use TEC\Common\StellarWP\Uplink\API\V3\Auth\Contracts\Auth_Url;
 use TEC\Common\Integrations\Uplink\Auth_URL_Decorator;
 use Tribe__Dependency as Dependency;
+use Tribe__Main as Common;
 use function TEC\Common\StellarWP\Uplink\get_plugins;
 use function lw_harbor_has_unified_license_key;
 use function lw_harbor_get_unified_license_key;
@@ -55,7 +56,10 @@ class Harbor extends Controller_Contract {
 	 * @since TBD
 	 */
 	public function do_register(): void {
+		$common = Common::instance();
+
 		Config::set_container( $this->container );
+		Config::set_plugin_basename( plugin_basename( $common->get_parent_plugin_file_path() ) );
 
 		/**
 		 * Allow plugins to hook in before Harbor is initialized.

--- a/src/Common/Libraries/Harbor.php
+++ b/src/Common/Libraries/Harbor.php
@@ -11,6 +11,8 @@ use TEC\Common\LiquidWeb\Harbor\Harbor as Harbor_Provider;
 use TEC\Common\Integrations\Harbor\EventAggregator;
 use TEC\Common\Integrations\Harbor\PUE;
 use TEC\Common\Integrations\Harbor\PUE_Resolver;
+use TEC\Common\StellarWP\Uplink\API\V3\Auth\Contracts\Auth_Url;
+use TEC\Common\Integrations\Uplink\Auth_URL_Decorator;
 use Tribe__Dependency as Dependency;
 use function TEC\Common\StellarWP\Uplink\get_plugins;
 use function lw_harbor_has_unified_license_key;
@@ -68,6 +70,8 @@ class Harbor extends Controller_Contract {
 		Harbor_Provider::init();
 
 		add_filter( 'lw-harbor/legacy_licenses', [ $this,'register_legacy_licenses' ] );
+		// Uplink is being initialized in init with prio 8 - so we want to decorate it our own decorator later.
+		add_action( 'init', [ $this, 'decorate_uplinks_auth_url' ] );
 
 		$this->container->register( PUE::class );
 		$this->container->register( EventAggregator::class );
@@ -82,6 +86,18 @@ class Harbor extends Controller_Contract {
 	 */
 	public function unregister(): void {
 		remove_filter( 'lw-harbor/legacy_licenses', [ $this,'register_legacy_licenses' ] );
+		remove_action( 'init', [ $this, 'decorate_uplinks_auth_url' ] );
+	}
+
+	/**
+	 * Decorate the uplinks auth URL.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function decorate_uplinks_auth_url(): void {
+		$this->container->bind( Auth_Url::class, Auth_URL_Decorator::class );
 	}
 
 	/**
@@ -242,5 +258,18 @@ class Harbor extends Controller_Contract {
 		}
 
 		return self::TEC_PRODUCT_SLUG_TO_HARBOR_PRODUCT_SLUG_MAP[ $tec_product_slug ];
+	}
+
+	/**
+	 * Get the portal URL.
+	 *
+	 * @since TBD
+	 *
+	 * @param string $path The path.
+	 *
+	 * @return string The portal URL.
+	 */
+	public function get_portal_url( string $path = '' ): string {
+		return trailingslashit( trailingslashit( Config::get_portal_base_url() ) . ( $path ? ltrim( $path, '/' ) : '' ) );
 	}
 }

--- a/src/Common/Libraries/Harbor.php
+++ b/src/Common/Libraries/Harbor.php
@@ -74,7 +74,7 @@ class Harbor extends Controller_Contract {
 		Harbor_Provider::init();
 
 		add_filter( 'lw-harbor/legacy_licenses', [ $this,'register_legacy_licenses' ] );
-		// Uplink is being initialized in init with prio 8 - so we want to decorate it our own decorator later.
+		// Uplink is being initialized in init with prio 8 - so we want to decorate it with our own decorator later.
 		add_action( 'init', [ $this, 'decorate_uplinks_auth_url' ] );
 
 		$this->container->register( PUE::class );

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -92,7 +92,8 @@ class Tribe__Main {
 			$this->plugin_context_class = get_class( $context );
 		}
 
- 		$this->plugin_dir  = trailingslashit( basename( $this->plugin_path ) );
+		$this->plugin_path = trailingslashit( dirname( dirname( dirname( __FILE__ ) ) ) );
+		$this->plugin_dir  = trailingslashit( basename( $this->plugin_path ) );
 		$this->parent_plugin_dir = trailingslashit( plugin_basename( $this->plugin_path ) );
 		$this->plugin_url  = plugins_url( $this->parent_plugin_dir === $this->plugin_dir ? $this->plugin_dir : $this->parent_plugin_dir );
 

--- a/src/Tribe/Main.php
+++ b/src/Tribe/Main.php
@@ -92,8 +92,7 @@ class Tribe__Main {
 			$this->plugin_context_class = get_class( $context );
 		}
 
-		$this->plugin_path = trailingslashit( dirname( dirname( dirname( __FILE__ ) ) ) );
-		$this->plugin_dir  = trailingslashit( basename( $this->plugin_path ) );
+ 		$this->plugin_dir  = trailingslashit( basename( $this->plugin_path ) );
 		$this->parent_plugin_dir = trailingslashit( plugin_basename( $this->plugin_path ) );
 		$this->plugin_url  = plugins_url( $this->parent_plugin_dir === $this->plugin_dir ? $this->plugin_dir : $this->parent_plugin_dir );
 

--- a/tests/integration/Tribe/Common/Integrations/Harbor/PUE_Test.php
+++ b/tests/integration/Tribe/Common/Integrations/Harbor/PUE_Test.php
@@ -329,4 +329,26 @@ class PUE_Test extends WPTestCase {
 		delete_option( 'pue_install_key_event_tickets_plus' );
 		delete_option( 'pue_install_key_tribe_filterbar' );
 	}
+
+	/**
+	 * @test
+	 * @dataProvider auth_url_decorator_provider
+	 */
+	public function it_should_decorate_auth_url_only_for_matching_slug_and_path( string $slug, string $url, bool $should_change ): void {
+		$result = apply_filters( 'tec_common_uplink_auth_url', $url, $slug );
+
+		if ( $should_change ) {
+			$this->assertNotSame( $url, $result );
+		} else {
+			$this->assertSame( $url, $result );
+		}
+	}
+
+	public function auth_url_decorator_provider(): array {
+		return [
+			'matching slug and path rewrites to portal URL' => [ 'tec-seating', 'https://example.com/seating-connect/', true ],
+			'matching slug but wrong path leaves URL untouched' => [ 'tec-seating', 'https://example.com/seating-connect/wrong-path', false ],
+			'non-matching slug leaves URL untouched'        => [ 'events-calendar-pro', 'https://example.com/seating-connect/', false ],
+		];
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[TICKET_ID]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Adding a decorator in order to overwrite the auth URL for seating from pointing to my.tec to point to portal. Portal's URL is integrated with harbor so that env controll remains in harbor.

Updates harbor to its latest version.

Amends for harbor's API braking change.

Add's plugins basename.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
