### PR TITLE
Rebrand to Nexcess | SCON-355

### DIFF
--- a/changelog/rebrand-to-liquid-web
+++ b/changelog/rebrand-to-liquid-web
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Updated branding references from StellarWP to Liquid Web.
+Updated branding references from StellarWP to Nexcess.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -9,13 +9,13 @@
 	</rule>
 
 	<rule ref="WordPress">
-		<!-- Exclude Generic rules that overlap with or are overridden by Liquid Web standards -->
+		<!-- Exclude Generic rules that overlap with or are overridden by Nexcess standards -->
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax"/>
 
-		<!-- Exclude PEAR rules that overlap with Liquid Web standards -->
+		<!-- Exclude PEAR rules that overlap with Nexcess standards -->
 		<exclude name="PEAR.NamingConventions.ValidClassName.Invalid"/>
 
-		<!-- Exclude WP rules that overlap with or are overridden by Liquid Web standards -->
+		<!-- Exclude WP rules that overlap with or are overridden by Nexcess standards -->
 		<exclude name="WordPress.Files.FileName"/>
 		<exclude name="WordPress.DB.DirectDatabaseQuery"/>
 		<exclude name="WordPress.PHP.YodaConditions.NotYoda"/>

--- a/src/Common/Telemetry/Telemetry.php
+++ b/src/Common/Telemetry/Telemetry.php
@@ -248,7 +248,7 @@ final class Telemetry {
 	 * @since 5.1.0
 	 *
 	 * @param array<string|mixed> $args The current optin modal args.
-	 * @param ?string             $slug The Liquid Web slug being used for Telemetry.
+	 * @param ?string             $slug The Nexcess slug being used for Telemetry.
 	 *
 	 * @return array<string|mixed>
 	 */

--- a/src/Tribe/App_Shop.php
+++ b/src/Tribe/App_Shop.php
@@ -280,7 +280,7 @@ if ( ! class_exists( 'Tribe__App_Shop' ) ) {
 		}
 
 		/**
-		 * Gets Liquid Web brands
+		 * Gets Nexcess brands
 		 *
 		 * @return array|WP_Error
 		 */

--- a/src/admin-views/app-shop.php
+++ b/src/admin-views/app-shop.php
@@ -53,7 +53,7 @@ use Tribe\Admin\Troubleshooting;
 				<li class="selected" data-tab="tribe-all-solutions"><?php esc_html_e( 'All Solutions', 'tribe-common' ); ?></li>
 				<li data-tab="tribe-bundles"><?php esc_html_e( 'Save with Bundles', 'tribe-common' ); ?></li>
 				<li data-tab="tribe-extensions"><?php esc_html_e( 'Extensions', 'tribe-common' ); ?></li>
-				<li data-tab="tribe-stellar"><?php esc_html_e( 'Liquid Web Discounts', 'tribe-common' ); ?></li>
+				<li data-tab="tribe-stellar"><?php esc_html_e( 'Nexcess Discounts', 'tribe-common' ); ?></li>
 			</ul>
 		</div>
 	</div>
@@ -224,14 +224,14 @@ use Tribe\Admin\Troubleshooting;
 			</div>
 
 			<div class="stellar-discounts-description">
-				<p><?php esc_html_e( 'Liquid Web is the company behind The Events Calendar and a number of other category-leading tools for site building, online learning, and fundraising. In addition to its plugins, Liquid Web offers world-class hosting for WordPress, WooCommerce, and more.', 'tribe-common' ); ?></p>
+				<p><?php esc_html_e( 'Nexcess is the company behind The Events Calendar and a number of other category-leading tools for site building, online learning, and fundraising. In addition to its plugins, Nexcess offers world-class hosting for WordPress, WooCommerce, and more.', 'tribe-common' ); ?></p>
 			</div>
 
 			<div class="stellar-discounts-coupon-callout">
 				<p>
 					<?php
 					/* translators: %s is the coupon code */
-					printf( wp_kses( __( '$25 towards any Liquid Web product using code <u>%s</u>', 'tribe-common' ), [ 'u' => [] ] ), 'Stellar25' );
+					printf( wp_kses( __( '$25 towards any Nexcess product using code <u>%s</u>', 'tribe-common' ), [ 'u' => [] ] ), 'Stellar25' );
 					?>
 				</p>
 			</div>


### PR DESCRIPTION
:ticket: [SCON-355]


Rebrand from Liquid Web to Nexcess. Follows the original `Rebrand to Liquid Web | SCON-355` PR (#2875).

The substitutions were derived from #2875's diff: every `+` line that introduced "Liquid Web" content was rewritten to say "Nexcess". Telemetry-related text and test snapshots were intentionally excluded so they can be reviewed separately.

**Note:** This PR targets `bucket/product-consolidation`. If a more appropriate base branch exists, a reviewer can update the base accordingly.

[SCON-355]: https://stellarwp.atlassian.net/browse/SCON-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ