### PR TITLE
fix: Use wp_date for year formatting in tribe_format_date function

### DIFF
--- a/src/functions/template-tags/date.php
+++ b/src/functions/template-tags/date.php
@@ -39,8 +39,8 @@ if ( ! function_exists( 'tribe_format_date' ) ) {
 		if ( $date_format ) {
 			$format = $date_format;
 		} else {
-			$date_year = date( 'Y', $date );
-			$cur_year  = date( 'Y', current_time( 'timestamp' ) );
+			$date_year = wp_date( 'Y', $date );
+			$cur_year  = wp_date( 'Y' );
 
 			// only show the year in the date if it's not in the current year
 			$with_year = $date_year == $cur_year ? false : true;


### PR DESCRIPTION
Directly related to https://github.com/the-events-calendar/the-events-calendar/pull/5630

This pull request makes a small update to the date formatting logic in the `tribe_format_date` function. It replaces the use of the native PHP `date` function with the WordPress-specific `wp_date` function for better localization and timezone handling.

* In `src/functions/template-tags/date.php`, the `tribe_format_date` function now uses `wp_date` instead of `date` to determine the year of the given date and the current year.