### PR TITLE
fix: send domain to promoter's auth payload during update notify

### DIFF
--- a/changelog/fix-smtnc-1351-send-domain-to-promoter
+++ b/changelog/fix-smtnc-1351-send-domain-to-promoter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Send the `domain` property over to Promoter's Authentication layer during update notificaitons. [SMTNC-1351]

--- a/changelog/fix-smtnc-1351-send-domain-to-promoter
+++ b/changelog/fix-smtnc-1351-send-domain-to-promoter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Send the `domain` property over to Promoter's Authentication layer during update notificaitons. [SMTNC-1351]
+Send the `domain` property over to Promoter's Authentication layer during update notifications. [SMTNC-1351]

--- a/src/Tribe/Promoter/Connector.php
+++ b/src/Tribe/Promoter/Connector.php
@@ -218,7 +218,8 @@ class Tribe__Promoter__Connector {
 
 		$payload = [
 			'licenseKey' => $license_key,
-			'sourceId' => $post_id instanceof WP_Post ? $post_id->ID : $post_id,
+			'sourceId'   => $post_id instanceof WP_Post ? $post_id->ID : $post_id,
+			'domain'     => strtolower( untrailingslashit( preg_replace( '#^https?://#i', '', home_url( '/' ) ) ) ),
 		];
 
 		$token = TEC_JWT::encode( $payload, $secret_key, 'HS256' );

--- a/tests/integration/Tribe/Promoter_Test.php
+++ b/tests/integration/Tribe/Promoter_Test.php
@@ -92,4 +92,37 @@ class Promoter_Test extends \Codeception\TestCase\WPTestCase {
 		$this->assertEquals( $payload['userId'], $user_id );
 	}
 
+	/**
+	 * @test
+	 */
+	public function should_send_domain_in_notify_payload(): void {
+		$connector   = tribe( Tribe__Promoter__Connector::class );
+		$secret_key  = 'bob';
+		$license_key = 'jan';
+
+		// The secret key used to sign the notify payload.
+		update_option( 'tribe_promoter_auth_key', $secret_key );
+		// The license info pulled by Tribe__Promoter__PUE::get_license_info().
+		update_option( 'pue_install_key_promoter', $license_key );
+
+		$post_id = self::factory()->post->create( [ 'post_type' => 'tribe_events' ] );
+
+		$payload = [];
+
+		add_filter( 'pre_http_request', function ( $response, $parsed_args, $url ) use ( $secret_key, &$payload ) {
+			$token   = $parsed_args['body']['token'];
+			$key     = new TEC_JWT_Key( $secret_key, 'HS256' );
+			$payload = (array) TEC_JWT::decode( $token, $key );
+
+			return [ 'headers' => '', 'body' => 'Hello World', 'response' => '', 'cookies' => '', 'filename' => '' ];
+		}, 99, 3 );
+
+		$connector->notify_promoter_of_changes( $post_id );
+
+		$this->assertArrayHasKey( 'domain', $payload );
+		$this->assertEquals( 'wordpress.test', $payload['domain'] );
+		$this->assertEquals( $license_key, $payload['licenseKey'] );
+		$this->assertEquals( $post_id, $payload['sourceId'] );
+	}
+
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1351]
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

Every other comms with promoter send over the domain. This one was missed. Since every other call sends the domain over, the issue would result into creating index keys including the domain.

In this call, since the domain was not being sent we had failure to identify the sender resulting in 403.

### 🎥 Artifacts <!-- if applicable-->

The added test is artifact enough for such a small change.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
