### PR TITLE
fix: guard Harbor legacy license resolution against early Uplink calls

### DIFF
--- a/changelog/fix-harbor-legacy-licenses-uplink-load-order
+++ b/changelog/fix-harbor-legacy-licenses-uplink-load-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Prevent a fatal error ("Call to undefined function TEC\Common\StellarWP\Uplink\get_plugins()") when Harbor resolves legacy licenses before Uplink is initialized, such as during a Promoter PUE license lookup on plugins_loaded.

--- a/src/Common/Libraries/Harbor.php
+++ b/src/Common/Libraries/Harbor.php
@@ -163,6 +163,12 @@ class Harbor extends Controller_Contract {
 	 * @return array
 	 */
 	public function register_legacy_licenses( array $licenses ): array {
+		// The imported get_plugins() is Uplink's, only declared once Uplink::init() requires its functions.php on `init`.
+		// This filter can fire earlier (e.g. a Promoter PUE license lookup on `plugins_loaded`), so bail until it is loaded.
+		if ( ! function_exists( '\TEC\Common\StellarWP\Uplink\get_plugins' ) ) {
+			return $licenses;
+		}
+
 		$plugins = get_plugins();
 
 		$filters_removed = false;


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1447](https://linear.app/nexcess/issue/SMTNC-1447/harbor-error-notice-related-to-event-tickets)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

register_legacy_licenses() calls Uplink's get_plugins(), which is only declared when Uplink::init() requires its functions.php on `init` (priority 8). The lw-harbor/legacy_licenses filter can fire earlier — e.g. a Promoter PUE license lookup during plugins_loaded — causing a fatal "Call to undefined function TEC\Common\StellarWP\Uplink\get_plugins()". Bail out of the callback until that function is available.


### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/8e6dbc0ea7b44cb5991c0a52bfb63113

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release
