### PR TITLE
Fix: defer plugin-merge notice translations to init (WP 6.8 early-textdomain)

### DIFF
--- a/changelog/fix-defer-merge-provider-translations
+++ b/changelog/fix-defer-merge-provider-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Defer translated plugin-merge notices to `init` to avoid triggering `_doing_it_wrong` notices for early textdomain loading on WordPress 6.8+.

--- a/changelog/fix-defer-merge-provider-translations
+++ b/changelog/fix-defer-merge-provider-translations
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fix
-
-Defer translated plugin-merge notices to `init` to avoid triggering `_doing_it_wrong` notices for early textdomain loading on WordPress 6.8+.

--- a/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
+++ b/src/Common/Integrations/Plugin_Merge_Provider_Abstract.php
@@ -310,7 +310,12 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	 * @since 6.0.0
 	 */
 	public function send_updated_notice(): void {
-		$this->register_update();
+		// `register_update()` translates the plugin name; before `init` that triggers a `_doing_it_wrong` on WP 6.8+.
+		if ( did_action( 'init' ) ) {
+			$this->register_update();
+		} else {
+			add_action( 'init', [ $this, 'register_update' ] );
+		}
 
 		// Defer so we have time to register updates for each plugin.
 		add_action( 'admin_init', [ $this, 'register_updated_notice' ], 99 );
@@ -396,6 +401,12 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	 * @since 6.0.0
 	 */
 	public function send_updated_merge_notice(): void {
+		// The notice message is translated; before `init` that triggers a `_doing_it_wrong` on WP 6.8+.
+		if ( ! did_action( 'init' ) ) {
+			add_action( 'init', [ $this, 'send_updated_merge_notice' ] );
+			return;
+		}
+
 		// Remove dismissed flag since we want to show the notice every time this is triggered.
 		Tribe__Admin__Notices::instance()->undismiss( $this->get_merge_notice_slug() );
 
@@ -421,6 +432,12 @@ abstract class Plugin_Merge_Provider_Abstract extends Service_Provider {
 	 * @since 6.0.0
 	 */
 	public function send_activating_merge_notice(): void {
+		// The notice message is translated; before `init` that triggers a `_doing_it_wrong` on WP 6.8+.
+		if ( ! did_action( 'init' ) ) {
+			add_action( 'init', [ $this, 'send_activating_merge_notice' ] );
+			return;
+		}
+
 		// Remove dismissed flag since we want to show the notice every time this is triggered.
 		Tribe__Admin__Notices::instance()->undismiss( $this->get_merge_notice_slug() );
 


### PR DESCRIPTION
## Bug #1 of the WP 6.8 early-translation regression

On WP 6.7+, requesting a translation before the `init` action triggers a `_load_textdomain_just_in_time` `_doing_it_wrong` notice. On **WP 6.8** that notice now fires on English (`en_US`) sites too (6.8 removed the `'en_US' !== $locale` guard), so output is emitted mid-bootstrap → "headers already sent" → broken redirects and REST status codes.

`Plugin_Merge_Provider_Abstract::register()` runs during provider registration on `plugins_loaded` and eagerly translates the merge-notice name (`get_plugin_updated_name()` → `_x()`), corrupting the first web request after each DB state change. This surfaced as failures in Events Pro's `views_v2_functional` (mobile redirect) suite at WP 6.8.

### Fix
Defer the translating work in `send_updated_notice()` / `send_updated_merge_notice()` to `init` when called before it. The consolidated notice still renders on `admin_init`, so behavior is unchanged; front-end requests skip the admin-only work.

Fixes the `tribe-events-calendar-pro` domain offender for **all** plugins extending this abstract (Events Pro's Event Automator + Events Virtual merge providers).