### PR TITLE
Fix: add herald url to allow host list

### DIFF
--- a/changelog/fix-CONS-478-pue-allow-list
+++ b/changelog/fix-CONS-478-pue-allow-list
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolve license key validation server not available message on liceses screen

--- a/src/Common/Integrations/Harbor/PUE.php
+++ b/src/Common/Integrations/Harbor/PUE.php
@@ -40,7 +40,7 @@ class PUE extends Integration_Controller {
 		add_filter( 'pre_option', [ $this, 'filter_pre_get_option' ], 10, 3 );
 		add_filter( 'stellarwp/uplink/tec/license_get_key', [ $this, 'filter_stellarwp_uplink_tec_license_get_key' ], 10, 2 );
 		add_filter( 'tec_common_uplink_auth_url', [ $this, 'filter_stellarwp_uplink_tec_authorize_button_url' ], 10, 2 );
-		add_filter('pue_get_update_url', [ $this, 'filter_pue_get_update_url' ], 10, 2 );
+		add_filter( 'pue_get_update_url', [ $this, 'filter_pue_get_update_url' ], 10, 2 );
 	}
 
 	/**

--- a/src/Common/Integrations/Harbor/PUE.php
+++ b/src/Common/Integrations/Harbor/PUE.php
@@ -40,7 +40,7 @@ class PUE extends Integration_Controller {
 		add_filter( 'pre_option', [ $this, 'filter_pre_get_option' ], 10, 3 );
 		add_filter( 'stellarwp/uplink/tec/license_get_key', [ $this, 'filter_stellarwp_uplink_tec_license_get_key' ], 10, 2 );
 		add_filter( 'tec_common_uplink_auth_url', [ $this, 'filter_stellarwp_uplink_tec_authorize_button_url' ], 10, 2 );
-		add_filter( 'pue_get_update_url', [ $this, 'filter_pue_get_update_url' ], 10, 2 );
+		add_filter('pue_get_update_url', [ $this, 'filter_pue_get_update_url' ], 10, 2 );
 	}
 
 	/**
@@ -150,11 +150,13 @@ class PUE extends Integration_Controller {
 		}
 
 		$is_production = Config::get_licensing_base_url() === Config::DEFAULT_LICENSING_BASE_URL;
+		$herald_host = wp_parse_url(Config::get_herald_base_url(), PHP_URL_HOST);
 
 		$allowed_hosts = [
 			'licensing.nexcess.com',
 			'licensing.stellarwp.com',
 			'pue.theeventscalendar.com',
+			$herald_host,
 		];
 
 		// Be extra safe for production requests.


### PR DESCRIPTION
### 🎫 Ticket

[CONS-478](https://linear.app/nexcess/issue/CONS-478/lwsw-unified-key-leaking-into-events-calendar-legacy-license-field)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

<!--
Please describe what you have changed or added
What types of changes does your code introduce?
Bug fix (non-breaking change which fixes an issue)
New feature (non-breaking change which adds functionality)
Include any important information for reviewers
-->

With an active LWSW key, the TEC legacy license page was reporting the error "Sorry, key validation server is not available.".  This was because the herald production url was not in the hardcoded allow list during the pue filter http request.  This PR adds the herald base url from the config to prevent this error.

### 🎥 Artifacts <!-- if applicable-->
<!-- 🎥 screencast(s) or 📷 screenshot(s) -->

https://www.loom.com/share/e148572ae6124f10beaf7fba765e2364

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

[skip-changelog][skip-phpcs]