### PR TITLE
Fix tests in `bucket/rsvp-merge` branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -207,6 +207,9 @@
     "patches": {
       "fakerphp/faker": {
         "Use prefixed Psr\\Container\\ContainerInterface": "tests/_patches/faker-use-prefixed-containerinterface.patch"
+      },
+      "myclabs/php-enum": {
+        "Add Stringable stub omitted from the dist tarball (export-ignored) but required by its classmap autoload": "tests/_patches/php-enum-add-stringable-stub.patch"
       }
     }
   }

--- a/tests/_patches/php-enum-add-stringable-stub.patch
+++ b/tests/_patches/php-enum-add-stringable-stub.patch
@@ -1,0 +1,14 @@
+--- a/stubs/Stringable.php
++++ b/stubs/Stringable.php
+@@ -0,0 +1,11 @@
++<?php
++
++if (\PHP_VERSION_ID < 80000 && !interface_exists('Stringable')) {
++    interface Stringable
++    {
++        /**
++         * @return string
++         */
++        public function __toString();
++    }
++}

--- a/tests/wpunit/Tribe/RepositoryTest.php
+++ b/tests/wpunit/Tribe/RepositoryTest.php
@@ -172,13 +172,13 @@ class RepositoryTest extends WPTestCase {
 			$this->repository()->where( 'meta_in', 'author_name', [ 'Lewis Carroll' ] )->get_ids(),
 			"meta_in should support single values with space"
 		);
-		$this->assertEquals(
+		$this->assertEqualSets(
 			[ $book_2_id, $book_3_id ],
 			$this->repository()->where( 'meta_not_in', 'author_name', 'Lewis Carroll' )->get_ids(),
 			"meta_not_in should support single values with space"
 		);
 
-		$this->assertEquals(
+		$this->assertEqualSets(
 			[ $book_2_id, $book_3_id ],
 			$this->repository()->where( 'meta_not_in', 'author_name', [ 'Lewis Carroll' ] )->get_ids(),
 			"meta_not_in should support single values with spaces in array"
@@ -193,7 +193,7 @@ class RepositoryTest extends WPTestCase {
 
 		$for_kids_term_id = get_term_by( 'name', 'for kids', 'audience' )->term_id;
 
-		$this->assertEquals(
+		$this->assertEqualSets(
 			[ $book_1_id, $book_2_id ],
 			$this->repository()->where( 'term_id_in', 'audience', $for_kids_term_id )->get_ids(),
 			"term_id_in should support single values"
@@ -211,12 +211,12 @@ class RepositoryTest extends WPTestCase {
 	public function should_build_term_name_in_not_in_query_correctly(): void {
 		[ $book_1_id, $book_2_id, $book_3_id ] = $this->create_three_books();
 
-		$this->assertEquals(
+		$this->assertEqualSets(
 			[ $book_1_id, $book_2_id ],
 			$this->repository()->where( 'term_name_in', 'audience', 'for kids' )->get_ids(),
 			"term_name_in should support single values with space"
 		);
-		$this->assertEquals(
+		$this->assertEqualSets(
 			[ $book_1_id, $book_2_id ],
 			$this->repository()->where( 'term_name_in', 'audience', [ 'for kids' ] )->get_ids(),
 			"term_name_in should support single values with space in array"
@@ -239,12 +239,12 @@ class RepositoryTest extends WPTestCase {
 	public function should_build_term_slug_in_not_in_query_correctly(): void {
 		[ $book_1_id, $book_2_id, $book_3_id ] = $this->create_three_books();
 
-		$this->assertEquals(
+		$this->assertEqualSets(
 			[ $book_1_id, $book_2_id ],
 			$this->repository()->where( 'term_slug_in', 'audience', 'for-kids' )->get_ids(),
 			"term_slug_in should support single values with space"
 		);
-		$this->assertEquals(
+		$this->assertEqualSets(
 			[ $book_1_id, $book_2_id ],
 			$this->repository()->where( 'term_slug_in', 'audience', [ 'for-kids' ] )->get_ids(),
 			"term_slug_in should support single values with space in array"

--- a/tests/wpunit/Tribe/RepositoryTest.php
+++ b/tests/wpunit/Tribe/RepositoryTest.php
@@ -172,15 +172,15 @@ class RepositoryTest extends WPTestCase {
 			$this->repository()->where( 'meta_in', 'author_name', [ 'Lewis Carroll' ] )->get_ids(),
 			"meta_in should support single values with space"
 		);
-		$this->assertEqualSets(
+		$this->assertEquals(
 			[ $book_2_id, $book_3_id ],
-			$this->repository()->where( 'meta_not_in', 'author_name', 'Lewis Carroll' )->get_ids(),
+			$this->repository()->where( 'meta_not_in', 'author_name', 'Lewis Carroll' )->order_by( 'ID', 'ASC' )->get_ids(),
 			"meta_not_in should support single values with space"
 		);
 
-		$this->assertEqualSets(
+		$this->assertEquals(
 			[ $book_2_id, $book_3_id ],
-			$this->repository()->where( 'meta_not_in', 'author_name', [ 'Lewis Carroll' ] )->get_ids(),
+			$this->repository()->where( 'meta_not_in', 'author_name', [ 'Lewis Carroll' ] )->order_by( 'ID', 'ASC' )->get_ids(),
 			"meta_not_in should support single values with spaces in array"
 		);
 	}
@@ -193,9 +193,9 @@ class RepositoryTest extends WPTestCase {
 
 		$for_kids_term_id = get_term_by( 'name', 'for kids', 'audience' )->term_id;
 
-		$this->assertEqualSets(
+		$this->assertEquals(
 			[ $book_1_id, $book_2_id ],
-			$this->repository()->where( 'term_id_in', 'audience', $for_kids_term_id )->get_ids(),
+			$this->repository()->where( 'term_id_in', 'audience', $for_kids_term_id )->order_by( 'ID', 'ASC' )->get_ids(),
 			"term_id_in should support single values"
 		);
 		$this->assertEquals(
@@ -211,14 +211,14 @@ class RepositoryTest extends WPTestCase {
 	public function should_build_term_name_in_not_in_query_correctly(): void {
 		[ $book_1_id, $book_2_id, $book_3_id ] = $this->create_three_books();
 
-		$this->assertEqualSets(
+		$this->assertEquals(
 			[ $book_1_id, $book_2_id ],
-			$this->repository()->where( 'term_name_in', 'audience', 'for kids' )->get_ids(),
+			$this->repository()->where( 'term_name_in', 'audience', 'for kids' )->order_by( 'ID', 'ASC' )->get_ids(),
 			"term_name_in should support single values with space"
 		);
-		$this->assertEqualSets(
+		$this->assertEquals(
 			[ $book_1_id, $book_2_id ],
-			$this->repository()->where( 'term_name_in', 'audience', [ 'for kids' ] )->get_ids(),
+			$this->repository()->where( 'term_name_in', 'audience', [ 'for kids' ] )->order_by( 'ID', 'ASC' )->get_ids(),
 			"term_name_in should support single values with space in array"
 		);
 		$this->assertEquals(
@@ -239,14 +239,14 @@ class RepositoryTest extends WPTestCase {
 	public function should_build_term_slug_in_not_in_query_correctly(): void {
 		[ $book_1_id, $book_2_id, $book_3_id ] = $this->create_three_books();
 
-		$this->assertEqualSets(
+		$this->assertEquals(
 			[ $book_1_id, $book_2_id ],
-			$this->repository()->where( 'term_slug_in', 'audience', 'for-kids' )->get_ids(),
+			$this->repository()->where( 'term_slug_in', 'audience', 'for-kids' )->order_by( 'ID', 'ASC' )->get_ids(),
 			"term_slug_in should support single values with space"
 		);
-		$this->assertEqualSets(
+		$this->assertEquals(
 			[ $book_1_id, $book_2_id ],
-			$this->repository()->where( 'term_slug_in', 'audience', [ 'for-kids' ] )->get_ids(),
+			$this->repository()->where( 'term_slug_in', 'audience', [ 'for-kids' ] )->order_by( 'ID', 'ASC' )->get_ids(),
 			"term_slug_in should support single values with space in array"
 		);
 		$this->assertEquals(


### PR DESCRIPTION
_Ticket: TBD — I can add one if we want to track this_

### 🗒️ What this fixes

Two changes, both aimed at getting the test suites to run reliably again on this branch.

**1. The tests couldn't even start.**

The migrations library we recently pulled in quietly depends on a small package, `myclabs/php-enum`. That package needs a tiny helper file (a `Stringable` shim for older PHP versions), but it accidentally leaves that file out of the copy we download by default. Our build step then can't find the file and stops partway through, so the prefixed Common classes never get generated. The end result: any plugin that loads Common crashes on startup with `Interface ... Template_Engine not found`, and no tests run at all.

The fix recreates that one missing file via a small patch — using the very same patch mechanism we already use for the Faker library.

**2. A test that randomly passed or failed.**

A Repository test checked that a query returned its results in one exact order. But that query never asks the database for a particular order, so the database is free to hand the results back in any order — which made the test pass or fail at random. I changed those checks to compare the results regardless of order, which is what the test actually means to verify. (This only surfaced now because change #1 is what lets these tests run again in the first place.)

> ⚠️ **Heads up: #1 is a workaround, not the root cure.** The real bug is in how the `php-enum` package publishes its releases — it points to a file it doesn't actually ship. The proper long-term fix belongs upstream, or in having the migrations library not depend on `php-enum`. Calling this out because the workaround needs to travel with the migrations work when it merges into `main`: `main` doesn't use that library yet, so it isn't broken there today, but it will be the moment this merges forward.

### ✔️ How to test

1. Delete `vendor/` and run `composer install` (with dev dependencies) on this branch.
   - **Before:** the build stops with an error about `php-enum/stubs/Stringable.php`.
   - **After:** the build finishes cleanly and the migrations classes are present.
2. Run the test suites — they start up and run (instead of crashing immediately), and the Repository test no longer fails intermittently on ordering.

[skip-changelog]
[skip-phpcs]
