### PR TITLE
Update strauss to 0.27.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
       "[ -d './vendor/fakerphp/faker/src/Faker/Provider' ] && echo 'Removing folders:' && find ./vendor/fakerphp/faker/src/Faker/Provider -mindepth 1 -maxdepth 1 -type d ! -path './vendor/fakerphp/faker/src/Faker/Provider/en_US' -print -exec rm -r {} + || true"
     ],
     "strauss": [
-      "test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.24.0/strauss.phar",
+      "test -f ./bin/strauss.phar || curl -o bin/strauss.phar -L -C - https://github.com/BrianHenryIE/strauss/releases/download/0.27.3/strauss.phar",
       "@clean-faker-lang",
       "vendor/stellarwp/installer/bin/set-domain domain=tribe-common",
       "@php -d display_errors=on bin/strauss.phar",
@@ -139,6 +139,7 @@
         "stellarwp/models",
         "stellarwp/schema",
         "stellarwp/schema-models",
+        "stellarwp/migrations",
         "stellarwp/shepherd",
         "stellarwp/installer",
         "stellarwp/telemetry",


### PR DESCRIPTION
Same thing done [here](https://github.com/stellarwp/learndash-notifications/pull/67) and worked successfully

Intention of fixing CI errors.

[skip-changelog] [skip-phpcs]