### PR TITLE
test: phpcs CI — valid PHP file changed [DO NOT MERGE]

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -31,7 +31,7 @@ jobs:
   phpcs:
     needs: conditional
     if: needs.conditional.outputs.run_tests
-    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-empty-changed-files
+    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-xargs-exit-code
     with:
       ref: ${{ github.event.inputs.ref }}
       change_permissions: false

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -31,7 +31,7 @@ jobs:
   phpcs:
     needs: conditional
     if: needs.conditional.outputs.run_tests
-    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@main
+    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-empty-changed-files
     with:
       ref: ${{ github.event.inputs.ref }}
       change_permissions: false

--- a/test-phpcs-ci.php
+++ b/test-phpcs-ci.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Test file for phpcs CI validation.
+ *
+ * DO NOT MERGE - This file exists only to validate phpcs CI behavior.
+ *
+ * @package Test
+ */


### PR DESCRIPTION
⚠️ **DO NOT MERGE** — Test PR only.

Validates the fix from [stellarwp/github-actions#22](https://github.com/stellarwp/github-actions/pull/22) before it merges to `main`.

**Scenario:** A PHP file (`test-phpcs-ci.php`) is added in this PR.

**Expected CI result:** The `phpcs` job should **run** phpcs on the changed PHP file, produce a valid JSON report, and complete without crashing. phpcs may report style violations on the test file — that is expected and normal. The job should not exit with code 1 due to an invalid JSON or empty file list.

---
_Temporarily points `.github/workflows/phpcs.yml` to `fix/phpcs-empty-changed-files` to validate the fix before merge._