### PR TITLE
test: phpcs CI — PHP file with space in name [DO NOT MERGE]

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -31,7 +31,7 @@ jobs:
   phpcs:
     needs: conditional
     if: needs.conditional.outputs.run_tests
-    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-empty-changed-files
+    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-xargs-exit-code
     with:
       ref: ${{ github.event.inputs.ref }}
       change_permissions: false

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -31,7 +31,7 @@ jobs:
   phpcs:
     needs: conditional
     if: needs.conditional.outputs.run_tests
-    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@main
+    uses: stellarwp/github-actions/.github/workflows/phpcs.yml@fix/phpcs-empty-changed-files
     with:
       ref: ${{ github.event.inputs.ref }}
       change_permissions: false

--- a/test phpcs file.php
+++ b/test phpcs file.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Test file with space in filename for phpcs CI validation.
+ *
+ * DO NOT MERGE - This file exists only to validate phpcs CI behavior with
+ * filenames that contain spaces (previously caused word-splitting bug).
+ *
+ * @package Test
+ */


### PR DESCRIPTION
⚠️ **DO NOT MERGE** — Test PR only.

Validates the fix from [stellarwp/github-actions#22](https://github.com/stellarwp/github-actions/pull/22) before it merges to `main`.

**Scenario:** A PHP file with a space in its filename (`test phpcs file.php`) is added in this PR.

**Expected CI result:** The `phpcs` job should **run** phpcs on the file with a space in its name without error. Previously, word-splitting caused phpcs to receive corrupted file paths (e.g. `test` and `phpcs` and `file.php` as separate arguments instead of `test phpcs file.php`), resulting in "file does not exist" errors and exit code 1. The fix uses `printf '%s\\n'` piped to `xargs -d '\\n'` to preserve filenames with spaces.

---
_Temporarily points `.github/workflows/phpcs.yml` to `fix/phpcs-empty-changed-files` to validate the fix before merge._