### PR TITLE
[SOFT-3335] feat: enhance DayPickerInput component

### DIFF
--- a/__mocks__/@wordpress/components.js
+++ b/__mocks__/@wordpress/components.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import React from 'react';
 import { noop } from 'lodash';
 
 export const withAPIData = () => noop;
@@ -15,3 +16,9 @@ export const Dashicon = ( { className, icon } ) => <span className={ className }
 export const Dropdown = () => <span>Dropdown</span>;
 export const Tooltip = () => <span>Tooltip</span>;
 export const PanelBody = ({ children }) => <span className="PanelBody">{ children }</span>
+export const Popover = ( { children, className, anchor, focusOnMount, noArrow, onClose } ) => (
+	<div className={ className } data-testid="popover">
+		{ children }
+	</div>
+);
+Popover.Slot = () => <span>popover-slot</span>;

--- a/__mocks__/react-day-picker.js
+++ b/__mocks__/react-day-picker.js
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export const DayPicker = ( props ) => (
+	<div className="DayPicker-mock" data-testid="day-picker">
+		<span className="DayPicker-mode">{ props.mode }</span>
+		{ props.selected && (
+			<span className="DayPicker-selected">
+				{ props.selected instanceof Date ? props.selected.toISOString() : String( props.selected ) }
+			</span>
+		) }
+		{ props.month && (
+			<span className="DayPicker-month">
+				{ props.month instanceof Date ? props.month.toISOString() : String( props.month ) }
+			</span>
+		) }
+		{ props.startMonth && (
+			<span className="DayPicker-startMonth">
+				{ props.startMonth instanceof Date ? props.startMonth.toISOString() : String( props.startMonth ) }
+			</span>
+		) }
+		{ props.endMonth && (
+			<span className="DayPicker-endMonth">
+				{ props.endMonth instanceof Date ? props.endMonth.toISOString() : String( props.endMonth ) }
+			</span>
+		) }
+		{ props.disabled && (
+			<span className="DayPicker-disabled">{ JSON.stringify( props.disabled ) }</span>
+		) }
+		{ props.modifiers && (
+			<span className="DayPicker-modifiers">{ JSON.stringify( props.modifiers ) }</span>
+		) }
+		<button
+			className="DayPicker-select"
+			onClick={ () => props.onSelect?.( props.selected || new Date( '2026-01-15' ), new Date(), {}, {} ) }
+		>
+			Select
+		</button>
+	</div>
+);
+
+export default DayPicker;

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	presets: [ '@wordpress/babel-preset-default' ],
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -11,5 +11,11 @@ module.exports = {
 		'\\.(css|pcss)$': 'identity-obj-proxy',
 		'\\.(svg)$': '<rootDir>/__mocks__/icons.js',
 	},
+	transform: {
+		'^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
+	},
+	transformIgnorePatterns: [
+		'/node_modules/(?!(react-day-picker|@wordpress)/)',
+	],
 	testEnvironment: 'jest-environment-jsdom-global',
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -3,12 +3,8 @@
  */
 import moment from 'moment-timezone';
 import React from 'react';
-import renderer from 'react-test-renderer';
 import $ from 'jquery';
-import Enzyme, { shallow, render, mount } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
-
-Enzyme.configure( { adapter: new Adapter() } );
+import renderer from 'react-test-renderer';
 
 global.jQuery = $;
 global.$ = $;
@@ -21,10 +17,32 @@ global.wp = {
 	blockEditor: {},
 	editor: {},
 	hooks: {},
+	i18n: {
+		_x: (input) => input,
+	},
 };
-global.shallow = shallow;
-global.render = render;
-global.mount = mount;
+
 global.renderer = renderer;
+
+/**
+ * Mock DateFormatter — a WordPress global provided by PHP scripts.
+ */
+global.DateFormatter = class DateFormatter {
+	parseDate( value, format ) {
+		if ( ! value ) {
+			return undefined;
+		}
+		const d = new Date( value );
+		return isNaN( d.getTime() ) ? undefined : d;
+	}
+
+	formatDate( date, format ) {
+		if ( ! date ) {
+			return '';
+		}
+		const options = { year: 'numeric', month: 'long', day: 'numeric' };
+		return date.toLocaleDateString( 'en-US', options );
+	}
+};
 
 moment.tz.setDefault( 'UTC' );

--- a/src/modules/elements/day-picker-input/__tests__/__snapshots__/element.test.js.snap
+++ b/src/modules/elements/day-picker-input/__tests__/__snapshots__/element.test.js.snap
@@ -2,16 +2,13 @@
 
 exports[`DayPickerInput element Should render the component 1`] = `
 <div
-  className="tribe-editor__day-picker-input DayPickerInput"
+  className="tribe-editor__date-input__container"
 >
   <input
-    onBlur={[Function]}
+    className="tribe-editor__date-input"
     onChange={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    placeholder="YYYY-M-D"
+    onMouseDown={[Function]}
     value="September 7, 2019"
   />
 </div>

--- a/src/modules/elements/day-picker-input/__tests__/__snapshots__/element.test.js.snap
+++ b/src/modules/elements/day-picker-input/__tests__/__snapshots__/element.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`DayPickerInput element Should render the component 1`] = `
 <div
-  className="tribe-editor__date-input__container"
+  className="tribe-editor__date-input__container tribe-editor__day-picker-input DayPickerInput"
 >
   <input
     className="tribe-editor__date-input"

--- a/src/modules/elements/day-picker-input/__tests__/element.test.js
+++ b/src/modules/elements/day-picker-input/__tests__/element.test.js
@@ -1,27 +1,517 @@
 /**
  * Internal dependencies
  */
+import React from 'react';
+import renderer from 'react-test-renderer';
 import DayPickerInput from '../element.js';
 
+const buildDate = ( dateString ) => new Date( dateString );
+
 describe( 'DayPickerInput element', () => {
+	const july1 = buildDate( '2026-07-01T00:00:00Z' );
+	const august15 = buildDate( '2026-08-15T00:00:00Z' );
+	const september7 = buildDate( '2019-09-07T00:00:00Z' );
+
 	it( 'Should render the component', () => {
-		const seriesEndsOnDate = 'September 7, 2019';
-		const seriesEndsOnDateObj = new Date( seriesEndsOnDate );
 		const component = renderer.create(
 			<DayPickerInput
-				value={ seriesEndsOnDate }
-				format={ 'LL' }
+				value="September 7, 2019"
+				format="LL"
 				formatDate={ jest.fn() }
 				parseDate={ jest.fn() }
 				dayPickerProps={ {
 					modifiers: {
-						start: seriesEndsOnDateObj,
-						end: seriesEndsOnDateObj,
+						start: september7,
+						end: september7,
 					},
 				} }
 				onDayChange={ jest.fn() }
 			/>,
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
+	} );
+
+	it( 'renders with empty value and no selected date highlighted', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+		const tree = component.toJSON();
+		// Input should show empty value.
+		const input = tree.children[0];
+		expect( input.props.value ).toBe( '' );
+	} );
+
+	it( 'renders with a valid date value and displays it in the input', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value="September 7, 2019"
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+		const tree = component.toJSON();
+		// Input should show the formatted value.
+		const input = tree.children[0];
+		expect( input.props.value ).toBe( 'September 7, 2019' );
+	} );
+
+	it( 'passes dayPickerProps.disabledDays to DayPicker as disabled', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				dayPickerProps={ {
+					disabledDays: { before: july1 },
+				} }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		// Open the calendar.
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		expect( dayPicker ).toBeDefined();
+
+		const disabledEl = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-disabled'
+		)[0];
+
+		expect( disabledEl ).toBeDefined();
+		expect( disabledEl.children[0] ).toContain( '2026-07-01' );
+	} );
+
+	it( 'passes dayPickerProps.modifiers to DayPicker', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				dayPickerProps={ {
+					modifiers: { start: july1, end: august15 },
+				} }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		const modifiersEl = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-modifiers'
+		)[0];
+
+		expect( modifiersEl ).toBeDefined();
+		expect( modifiersEl.children[0] ).toContain( 'start' );
+		expect( modifiersEl.children[0] ).toContain( 'end' );
+	} );
+
+	it( 'passes dayPickerProps.fromMonth to DayPicker as startMonth', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				dayPickerProps={ { fromMonth: july1 } }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		const startMonthEl = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-startMonth'
+		)[0];
+
+		expect( startMonthEl ).toBeDefined();
+		expect( startMonthEl.children[0] ).toContain( '2026-07-01' );
+	} );
+
+	it( 'passes dayPickerProps.toMonth to DayPicker as endMonth', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				dayPickerProps={ { toMonth: august15 } }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		const endMonthEl = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-endMonth'
+		)[0];
+
+		expect( endMonthEl ).toBeDefined();
+		expect( endMonthEl.children[0] ).toContain( '2026-08-15' );
+	} );
+
+	it( 'uses dayPickerProps.month when no date is selected', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				dayPickerProps={ { month: july1 } }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		const monthEl = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-month'
+		)[0];
+
+		expect( monthEl ).toBeDefined();
+		expect( monthEl.children[0] ).toContain( '2026-07-01' );
+	} );
+
+	it( 'prefers selectedDate over dayPickerProps.month for the displayed month', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value="August 15, 2026"
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				dayPickerProps={ { month: july1 } }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		const monthEl = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-month'
+		)[0];
+
+		const selectedEl = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-selected'
+		)[0];
+
+		expect( monthEl ).toBeDefined();
+		expect( selectedEl ).toBeDefined();
+		// Month should reflect the selected date (August), not dayPickerProps.month (July).
+		expect( monthEl.children[0] ).toContain( '2026-08-15' );
+	} );
+
+	it( 'falls back to current date for month when neither selectedDate nor dayPickerProps.month is set', () => {
+		const before = new Date();
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+		const after = new Date();
+
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		const monthEl = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-month'
+		)[0];
+
+		expect( monthEl ).toBeDefined();
+		// The month should be a timestamp near "now".
+		const monthTimestamp = new Date( monthEl.children[0] ).getTime();
+		expect( monthTimestamp ).toBeGreaterThanOrEqual( before.getTime() - 1000 );
+		expect( monthTimestamp ).toBeLessThanOrEqual( after.getTime() + 1000 );
+	} );
+
+	it( 'toggles calendar visibility on input click', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		// Calendar should not be visible initially.
+		let tree = component.toJSON();
+		expect( JSON.stringify( tree ) ).not.toContain( 'DayPicker-mock' );
+
+		// Click to open.
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		tree = component.toJSON();
+		expect( JSON.stringify( tree ) ).toContain( 'DayPicker-mock' );
+
+		// Click to close.
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		tree = component.toJSON();
+		expect( JSON.stringify( tree ) ).not.toContain( 'DayPicker-mock' );
+	} );
+
+	it( 'calls onDayChange when a day is selected', () => {
+		const onDayChange = jest.fn();
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ onDayChange }
+			/>,
+		);
+
+		// Open the calendar.
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		// Find the "Select" button in the mock and click it.
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		const selectBtn = dayPicker.findByType( 'button' );
+		renderer.act( () => {
+			selectBtn.props.onClick();
+		} );
+
+		expect( onDayChange ).toHaveBeenCalledTimes( 1 );
+		expect( onDayChange.mock.calls[0][0] ).toBeInstanceOf( Date );
+	} );
+
+	it( 'syncs selectedDate when value prop changes after mount (React 17)', () => {
+		const onDayChange = jest.fn();
+
+		// Mount with empty value.
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ onDayChange }
+			/>,
+		);
+
+		// Open the calendar.
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		let dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		// No selected date when value is empty.
+		let selectedEls = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-selected'
+		);
+		expect( selectedEls ).toHaveLength( 0 );
+
+		// Update the value prop — simulates Redux arriving after mount.
+		renderer.act( () => {
+			component.update(
+				<DayPickerInput
+					value="September 7, 2019"
+					format="LL"
+					formatDate={ jest.fn() }
+					parseDate={ jest.fn() }
+					onDayChange={ onDayChange }
+				/>,
+			);
+		} );
+
+		dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		selectedEls = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-selected'
+		);
+
+		expect( selectedEls ).toHaveLength( 1 );
+		expect( selectedEls[0].children[0] ).toContain( '2019-09-07' );
+	} );
+
+	it( 'clears selectedDate when value prop becomes empty', () => {
+		const onDayChange = jest.fn();
+
+		// Mount with a valid date value.
+		const component = renderer.create(
+			<DayPickerInput
+				value="September 7, 2019"
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ onDayChange }
+			/>,
+		);
+
+		// Open the calendar.
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		let dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		// Should have selected date initially.
+		let selectedEls = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-selected'
+		);
+		expect( selectedEls ).toHaveLength( 1 );
+
+		// Clear the value prop.
+		renderer.act( () => {
+			component.update(
+				<DayPickerInput
+					value=""
+					format="LL"
+					formatDate={ jest.fn() }
+					parseDate={ jest.fn() }
+					onDayChange={ onDayChange }
+				/>,
+			);
+		} );
+
+		dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		selectedEls = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-selected'
+		);
+
+		// Selected date should be cleared.
+		expect( selectedEls ).toHaveLength( 0 );
+	} );
+
+	it( 'calls onDayChange with formatted date string when day selected', () => {
+		const onDayChange = jest.fn();
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ onDayChange }
+			/>,
+		);
+
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+
+		const selectBtn = dayPicker.findByType( 'button' );
+		renderer.act( () => {
+			selectBtn.props.onClick();
+		} );
+
+		// The third argument should be the formatted date string.
+		const formattedValue = onDayChange.mock.calls[0][2];
+		expect( typeof formattedValue ).toBe( 'string' );
+		expect( formattedValue.length ).toBeGreaterThan( 0 );
+	} );
+
+	it( 'ignores undefined or null dayPickerProps gracefully', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				dayPickerProps={ null }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		// Should not throw.
+		const input = component.root.findByType( 'input' );
+		expect( () => {
+			renderer.act( () => {
+				input.props.onClick();
+			} );
+		} ).not.toThrow();
+
+		const tree = component.toJSON();
+		expect( JSON.stringify( tree ) ).toContain( 'DayPicker-mock' );
 	} );
 } );

--- a/src/modules/elements/day-picker-input/element.js
+++ b/src/modules/elements/day-picker-input/element.js
@@ -1,13 +1,13 @@
 /**
  * External dependencies
  */
-import React, { useState, useRef, useMemo, useCallback, useEffect } from 'react';
-import classNames from 'classnames';
-import 'react-day-picker/src/style.css';
-import { DayPicker } from 'react-day-picker';
 import { Popover } from '@wordpress/components';
 import { getSettings as getDateSettings } from '@wordpress/date';
+import classNames from 'classnames';
 import { parse as parseDate } from 'date-fns';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { DayPicker } from 'react-day-picker';
+import 'react-day-picker/src/style.css';
 
 /**
  * Internal dependencies
@@ -24,7 +24,7 @@ const DatePickerInput = ( props ) => {
 	const { setPopoverAnchor, inputRef, onDayChange, ...inputProps } = props;
 
 	return (
-		<div ref={ setPopoverAnchor } className={ classNames( 'tribe-editor__date-input__container' ) }>
+		<div ref={ setPopoverAnchor } className={ classNames( 'tribe-editor__date-input__container', 'tribe-editor__day-picker-input', 'DayPickerInput' ) }>
 			<input
 				ref={ inputRef } // Attach the ref to the input element
 				className={ classNames( 'tribe-editor__date-input' ) }

--- a/src/modules/elements/day-picker-input/element.js
+++ b/src/modules/elements/day-picker-input/element.js
@@ -51,6 +51,7 @@ const momentToDateFnsFormatter = ( momentFormat ) => {
 const DayPickerInput = ( props ) => {
 	const popoverAnchor = useRef( null ); // Ref for the Popover anchor
 	const inputRef = useRef( null ); // Ref for the input field
+	const popoverRef = useRef( null ); // Ref for the popover portal element
 	const isVisibleRef = useRef( false );
 	const [ isVisible, setIsVisible ] = useState( false );
 	// Do not memoize this: it could be changed in the context of the Block Editor elsewhere.
@@ -77,14 +78,18 @@ const DayPickerInput = ( props ) => {
 		} );
 	};
 
-	const { value, onDayChange, formatDate, format } = props;
+	const { value, onDayChange, formatDate, format, dayPickerProps } = props;
 
 	// Convert the format from the moment.js one to date-fns one using Unicode characters.
 	const dateFnsFormat = momentToDateFnsFormatter( format );
 
 	const getSelectedDateInitialState = useCallback(
 		( value ) => {
-			// Try and parse the value using teh date-fns format.
+			if ( ! value ) {
+				return undefined;
+			}
+
+			// Try and parse the value using the date-fns format.
 			const d = parseDate( value, dateFnsFormat, new Date() );
 
 			if ( d instanceof Date && ! isNaN( d ) ) {
@@ -92,32 +97,16 @@ const DayPickerInput = ( props ) => {
 			}
 
 			// Try and parse the value using the PHP date format.
-			const parsed = parsePhpDate( value );
-
-			return parsed;
+			return parsePhpDate( value );
 		},
 		[ dateFnsFormat, parsePhpDate ]
 	);
 
-	const [ selectedDate, setSelectedDate ] = useState( value ? getSelectedDateInitialState( value ) : new Date() );
+	const [ selectedDate, setSelectedDate ] = useState( () => getSelectedDateInitialState( value ) );
 
+	// Sync selectedDate when the value prop changes (e.g. Redux state arrives after mount in React 17).
 	useEffect( () => {
-		if ( ! value ) {
-			return;
-		}
-
-		const nextDate = getSelectedDateInitialState( value );
-
-		setSelectedDate( ( previousDate ) => {
-			if (
-				previousDate?.getTime?.() === nextDate?.getTime?.() &&
-				! isNaN( previousDate?.getTime?.() )
-			) {
-				return previousDate;
-			}
-
-			return nextDate;
-		} );
+		setSelectedDate( getSelectedDateInitialState( value ) );
 	}, [ value, getSelectedDateInitialState ] );
 
 	useEffect( () => {
@@ -140,6 +129,40 @@ const DayPickerInput = ( props ) => {
 	}, [] );
 
 	useEffect( () => registerDatePickerCloseHandler( closeCalendar ), [ closeCalendar ] );
+
+	const clickOutsideHandlerRef = useRef( null );
+	clickOutsideHandlerRef.current = ( event ) => {
+		const { target } = event;
+		const anchorEl = popoverAnchor.current;
+		const popoverEl = popoverRef.current;
+
+		if ( anchorEl && anchorEl.contains( target ) ) {
+			return;
+		}
+
+		if ( popoverEl && popoverEl.contains( target ) ) {
+			return;
+		}
+
+		closeCalendar();
+	};
+
+	useEffect( () => {
+		if ( ! isVisible ) {
+			return;
+		}
+
+		const onMouseDown = ( event ) => clickOutsideHandlerRef.current( event );
+
+		const timerId = setTimeout( () => {
+			document.addEventListener( 'mousedown', onMouseDown );
+		}, 0 );
+
+		return () => {
+			clearTimeout( timerId );
+			document.removeEventListener( 'mousedown', onMouseDown );
+		};
+	}, [ isVisible ] );
 
 	/**
 	 * Formats the datepicker Date object to the datepicker format.
@@ -171,16 +194,23 @@ const DayPickerInput = ( props ) => {
 					noArrow={ false }
 					onClose={ closeCalendar }
 				>
-					<DayPicker
-						mode="single"
-						selected={ selectedDate }
-						onSelect={ ( date ) => {
-							onDayChange( date, {}, formatDatepickerValue( date ) );
-							setSelectedDate( date );
-							closeCalendar();
-						} }
-						isSelected={ true }
-					/>
+					<div ref={ popoverRef }>
+						<DayPicker
+							mode="single"
+							selected={ selectedDate }
+							onSelect={ ( date ) => {
+								onDayChange( date, {}, formatDatepickerValue( date ) );
+								setSelectedDate( date );
+								closeCalendar();
+							} }
+							disabled={ dayPickerProps?.disabledDays }
+							modifiers={ dayPickerProps?.modifiers }
+							month={ selectedDate || dayPickerProps?.month || new Date() }
+							startMonth={ dayPickerProps?.fromMonth }
+							endMonth={ dayPickerProps?.toMonth }
+							isSelected={ true }
+						/>
+					</div>
 				</Popover>
 			) }
 		</>


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-3335](https://linear.app/nexcess/issue/SOFT-3335/updated-block-ui)

### 🗒️ Description

Fixes two bugs in DayPickerInput that affect the RSVP duration picker in the event-tickets block editor:
1. Datepicker opens to "today" instead of the start/selected date — the component ignored dayPickerProps passed by parent DateTimeRangePicker, so the calendar always defaulted to the current month.
2. React 17 race condition — Redux state (e.g., RSVP start date) could arrive after the component mounted, leaving selectedDate initialized to new Date() with no way to sync.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/83b94dcf2e1a4719891a1a1c3368ecf5

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
