### PR TITLE
[SMTNC-1797] fix: _load_textdomain_just_in_time notice bug

### DIFF
--- a/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
+++ b/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fix
 
-Added tribe_run_on_action() and tribe_run_on_filter() helpers to run or defer a callback based on whether an action/filter has already fired, used to fix a _load_textdomain_just_in_time notice in The Events Calendar.
+Added `tribe_run_on_action()` and `tribe_run_on_filter()` helpers to run or defer a callback based on whether an action/filter has already fired, used to fix a `_load_textdomain_just_in_time` notice in The Events Calendar.

--- a/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
+++ b/changelog/fix-smtnc-1797-global-load_textdomain-notice-flooding-logs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Added tribe_run_on_action() and tribe_run_on_filter() helpers to run or defer a callback based on whether an action/filter has already fired, used to fix a _load_textdomain_just_in_time notice in The Events Calendar.

--- a/src/functions/utils.php
+++ b/src/functions/utils.php
@@ -1479,3 +1479,76 @@ if ( ! function_exists( 'tec_json_unpack' ) ) {
 		return tribe( Json_Packer::class )->unpack( $json, $fail_on_error, $allowed_classes );
 	}
 }
+
+if ( ! function_exists( 'tribe_run_on_action' ) ) {
+	/**
+	 * Runs a callback immediately if the given action has already fired (or is currently
+	 * firing), otherwise defers it to run once that action fires.
+	 *
+	 * Useful for avoiding "ran too early" bugs (e.g. translation functions, or hooks that
+	 * depend on them, called before `init`) when some code needs to happen no earlier than
+	 * a given action, regardless of how early the registering code itself runs.
+	 *
+	 * For the same problem where the pivot hook is a filter rather than an action, use
+	 * `tribe_run_on_filter()` instead — WordPress tracks action and filter execution counts
+	 * separately, so `did_action()`/`doing_action()` cannot answer "has this filter run yet".
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $action   The action hook to check against / defer to.
+	 * @param callable $callback The callback to run now or on that action.
+	 * @param int      $priority Priority to use if the callback has to be deferred.
+	 *
+	 * @return void
+	 */
+	function tribe_run_on_action( $action, callable $callback, $priority = 10 ) {
+		if ( did_action( $action ) || doing_action( $action ) ) {
+			$callback();
+
+			return;
+		}
+
+		$wrapper = static function () use ( $action, $callback, &$wrapper ) {
+			remove_action( $action, $wrapper );
+			$callback();
+		};
+
+		add_action( $action, $wrapper, $priority );
+	}
+}
+
+if ( ! function_exists( 'tribe_run_on_filter' ) ) {
+	/**
+	 * Runs a callback immediately if the given filter has already been applied (or is
+	 * currently being applied), otherwise defers it to run the next time that filter runs.
+	 *
+	 * The filter counterpart to `tribe_run_on_action()`. Uses `did_filter()`/`doing_filter()`
+	 * rather than `did_action()`/`doing_action()`, since WordPress tracks how many times a
+	 * filter has been applied separately from how many times an action has fired — checking
+	 * a filter's state with the action-specific functions would silently always report "no".
+	 *
+	 * @since TBD
+	 *
+	 * @param string   $filter   The filter hook to check against / defer to.
+	 * @param callable $callback The callback to run now or the next time that filter runs.
+	 * @param int      $priority Priority to use if the callback has to be deferred.
+	 *
+	 * @return void
+	 */
+	function tribe_run_on_filter( $filter, callable $callback, $priority = 10 ) {
+		if ( did_filter( $filter ) || doing_filter( $filter ) ) {
+			$callback();
+
+			return;
+		}
+
+		$wrapper = static function ( $value ) use ( $filter, $callback, &$wrapper ) {
+			remove_filter( $filter, $wrapper );
+			$callback();
+
+			return $value;
+		};
+
+		add_filter( $filter, $wrapper, $priority, 1 );
+	}
+}

--- a/tests/wpunit/Tribe/functions/utilsTest.php
+++ b/tests/wpunit/Tribe/functions/utilsTest.php
@@ -579,4 +579,129 @@ class utilsTest extends \Codeception\TestCase\WPTestCase {
 	public function test_tec_sanitize_string( $input, $expected ) {
 		$this->assertEquals( $expected, tec_sanitize_string( $input ) );
 	}
+
+	public function test_tribe_run_on_action_runs_immediately_if_action_already_fired() {
+		do_action( 'tribe_test_run_on_action_fired' );
+
+		$ran = false;
+		tribe_run_on_action( 'tribe_test_run_on_action_fired', function () use ( &$ran ) {
+			$ran = true;
+		} );
+
+		$this->assertTrue( $ran );
+		$this->assertFalse( has_action( 'tribe_test_run_on_action_fired' ) );
+	}
+
+	public function test_tribe_run_on_action_runs_immediately_while_action_is_firing() {
+		$ran = false;
+
+		add_action( 'tribe_test_run_on_action_doing', function () use ( &$ran ) {
+			tribe_run_on_action( 'tribe_test_run_on_action_doing', function () use ( &$ran ) {
+				$ran = true;
+			} );
+		} );
+
+		do_action( 'tribe_test_run_on_action_doing' );
+
+		$this->assertTrue( $ran );
+	}
+
+	public function test_tribe_run_on_action_defers_until_action_fires() {
+		$ran = false;
+
+		tribe_run_on_action( 'tribe_test_run_on_action_deferred', function () use ( &$ran ) {
+			$ran = true;
+		} );
+
+		$this->assertFalse( $ran );
+
+		do_action( 'tribe_test_run_on_action_deferred' );
+
+		$this->assertTrue( $ran );
+	}
+
+	public function test_tribe_run_on_action_deferred_callback_runs_only_once() {
+		$runs = 0;
+
+		tribe_run_on_action( 'tribe_test_run_on_action_once', function () use ( &$runs ) {
+			$runs++;
+		} );
+
+		do_action( 'tribe_test_run_on_action_once' );
+		do_action( 'tribe_test_run_on_action_once' );
+
+		$this->assertEquals( 1, $runs );
+	}
+
+	public function test_tribe_run_on_action_honors_priority() {
+		$order = [];
+
+		add_action( 'tribe_test_run_on_action_priority', function () use ( &$order ) {
+			$order[] = 'default';
+		} );
+
+		tribe_run_on_action( 'tribe_test_run_on_action_priority', function () use ( &$order ) {
+			$order[] = 'early';
+		}, 0 );
+
+		do_action( 'tribe_test_run_on_action_priority' );
+
+		$this->assertEquals( [ 'early', 'default' ], $order );
+	}
+
+	public function test_tribe_run_on_filter_runs_immediately_if_filter_already_applied() {
+		apply_filters( 'tribe_test_run_on_filter_applied', 'value' );
+
+		$ran = false;
+		tribe_run_on_filter( 'tribe_test_run_on_filter_applied', function () use ( &$ran ) {
+			$ran = true;
+		} );
+
+		$this->assertTrue( $ran );
+		$this->assertFalse( has_filter( 'tribe_test_run_on_filter_applied' ) );
+	}
+
+	public function test_tribe_run_on_filter_defers_until_filter_runs_and_passes_value_through() {
+		$ran = false;
+
+		tribe_run_on_filter( 'tribe_test_run_on_filter_deferred', function () use ( &$ran ) {
+			$ran = true;
+		} );
+
+		$this->assertFalse( $ran );
+
+		$result = apply_filters( 'tribe_test_run_on_filter_deferred', 'unchanged' );
+
+		$this->assertTrue( $ran );
+		$this->assertEquals( 'unchanged', $result );
+	}
+
+	public function test_tribe_run_on_filter_deferred_callback_runs_only_once() {
+		$runs = 0;
+
+		tribe_run_on_filter( 'tribe_test_run_on_filter_once', function () use ( &$runs ) {
+			$runs++;
+		} );
+
+		apply_filters( 'tribe_test_run_on_filter_once', 'a' );
+		apply_filters( 'tribe_test_run_on_filter_once', 'b' );
+
+		$this->assertEquals( 1, $runs );
+	}
+
+	public function test_tribe_run_on_filter_does_not_treat_matching_action_as_fired() {
+		// An action with the same name firing must not be mistaken for the filter having run.
+		do_action( 'tribe_test_run_on_filter_vs_action' );
+
+		$ran = false;
+		tribe_run_on_filter( 'tribe_test_run_on_filter_vs_action', function () use ( &$ran ) {
+			$ran = true;
+		} );
+
+		$this->assertFalse( $ran );
+
+		apply_filters( 'tribe_test_run_on_filter_vs_action', 'value' );
+
+		$this->assertTrue( $ran );
+	}
 }


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1797](https://linear.app/nexcess/issue/SMTNC-1797/global-load-textdomain-notice-flooding-logs)
<!-- Ticket ID, if there's any put it between brackets -->

### 🗒️ Description

We are having a bug with `_load_textdomain_just_in_time` being triggered when some plugins are installed with TEC.
This fix address to prevent the user log to be flooded by these notice messages.
The main goal of these helpers is to centralize the way that we deal with these edge cases.

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/a0d0bf72d6fe407085c17fdf50d7dffe

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
