### PR TITLE
Update Harbor to v1.6.0

### DIFF
--- a/changelog/chore-bump-harbor-1-6-0.yaml
+++ b/changelog/chore-bump-harbor-1-6-0.yaml
@@ -1,0 +1,4 @@
+significance: patch
+type: tweak
+entry: Improved the unified licensing page experience.
+timestamp: 2026-07-29T20:34:05.186Z

--- a/changelog/tweak-update-harbor-1.6.0
+++ b/changelog/tweak-update-harbor-1.6.0
@@ -1,4 +1,0 @@
-Significance: patch
-Type: tweak
-
-Updated Harbor to 1.6.0, split the products list into Installed and  Available Features, added an Activate link to the product header, and improved license handling on staging and preview sites.

--- a/changelog/tweak-update-harbor-1.6.0
+++ b/changelog/tweak-update-harbor-1.6.0
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Update Harbor to 1.6.0, splitting the products list into Installed and Available Features, adding an Activate link to the product header, and improving license handling on staging and preview sites.

--- a/changelog/tweak-update-harbor-1.6.0
+++ b/changelog/tweak-update-harbor-1.6.0
@@ -1,4 +1,4 @@
 Significance: patch
 Type: tweak
 
-Update Harbor to 1.6.0, splitting the products list into Installed and Available Features, adding an Activate link to the product header, and improving license handling on staging and preview sites.
+Updated Harbor to 1.6.0, split the products list into Installed and  Available Features, added an Activate link to the product header, and improved license handling on staging and preview sites.

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "stellarwp/assets": "^1.5",
     "stellarwp/container-contract": "^1.0.4",
     "stellarwp/db": "^1.0.3",
-    "stellarwp/harbor": "^1.4",
+    "stellarwp/harbor": "^1.6.0",
     "stellarwp/installer": "^1.1.0",
     "stellarwp/telemetry": "^2.3.4",
     "stellarwp/uplink": "2.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3af55c29ec587b9a48fe41ecbcf19dbe",
+    "content-hash": "d4ca736deb646c33f2ec724141277a50",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -895,16 +895,16 @@
         },
         {
             "name": "stellarwp/harbor",
-            "version": "v1.4.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/harbor.git",
-                "reference": "0d21b6e6da4352364610168c053ed0ec9d59253d"
+                "reference": "e0253fa5512522a50dd73abe990d3591017494fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/0d21b6e6da4352364610168c053ed0ec9d59253d",
-                "reference": "0d21b6e6da4352364610168c053ed0ec9d59253d",
+                "url": "https://api.github.com/repos/stellarwp/harbor/zipball/e0253fa5512522a50dd73abe990d3591017494fb",
+                "reference": "e0253fa5512522a50dd73abe990d3591017494fb",
                 "shasum": ""
             },
             "require": {
@@ -959,9 +959,9 @@
             "description": "A library that integrates a WordPress product with the Liquid Web licensing system.",
             "support": {
                 "issues": "https://github.com/stellarwp/harbor/issues",
-                "source": "https://github.com/stellarwp/harbor/tree/v1.4.0"
+                "source": "https://github.com/stellarwp/harbor/tree/v1.6.0"
             },
-            "time": "2026-05-21T17:13:36+00:00"
+            "time": "2026-07-27T14:52:06+00:00"
         },
         {
             "name": "stellarwp/installer",
@@ -1564,68 +1564,6 @@
         }
     ],
     "packages-dev": [
-        {
-            "name": "automattic/jetpack-changelogger",
-            "version": "v4.2.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Automattic/jetpack-changelogger.git",
-                "reference": "81a4c2beba9df2b8f1907b52c4b71ce152067e2e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-changelogger/zipball/81a4c2beba9df2b8f1907b52c4b71ce152067e2e",
-                "reference": "81a4c2beba9df2b8f1907b52c4b71ce152067e2e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0",
-                "symfony/console": "^3.4 || ^4.4 || ^5.2 || ^6.0 || ^7.0",
-                "symfony/process": "^3.4 || ^4.4 || ^5.2 || ^6.0 || ^7.0"
-            },
-            "require-dev": {
-                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0",
-                "yoast/phpunit-polyfills": "^1.1.1"
-            },
-            "bin": [
-                "bin/changelogger"
-            ],
-            "type": "project",
-            "extra": {
-                "autotagger": true,
-                "branch-alias": {
-                    "dev-trunk": "4.2.x-dev"
-                },
-                "mirror-repo": "Automattic/jetpack-changelogger",
-                "version-constants": {
-                    "::VERSION": "src/Application.php"
-                },
-                "changelogger": {
-                    "link-template": "https://github.com/Automattic/jetpack-changelogger/compare/${old}...${new}"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Automattic\\Jetpack\\Changelog\\": "lib",
-                    "Automattic\\Jetpack\\Changelogger\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "description": "Jetpack Changelogger tool. Allows for managing changelogs by dropping change files into a changelog directory with each PR.",
-            "keywords": [
-                "changelog",
-                "cli",
-                "dev",
-                "keepachangelog"
-            ],
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-changelogger/tree/v4.2.8"
-            },
-            "time": "2024-11-04T09:23:29+00:00"
-        },
         {
             "name": "automattic/vipwpcs",
             "version": "3.0.1",


### PR DESCRIPTION
Updates the bundled Harbor library from v1.4.0 to v1.6.0.

Verified with a fresh `composer install` — both `vendor/stellarwp/harbor` and the Strauss-prefixed copy report `1.6.0`.

Note: composer also pruned `automattic/jetpack-changelogger` from the lock. It was an orphan — not in `composer.json` and not required by anything in the previous lock.

[SMTNC-1872](https://linear.app/nexcess/issue/SMTNC-1872/update-harbor-to-v160-in-tribe-common)