### PR TITLE
[SOFT-4175] fix Restore month navigation in RSVP datepicker

### DIFF
--- a/__mocks__/react-day-picker.js
+++ b/__mocks__/react-day-picker.js
@@ -1,41 +1,88 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-export const DayPicker = ( props ) => (
-	<div className="DayPicker-mock" data-testid="day-picker">
-		<span className="DayPicker-mode">{ props.mode }</span>
-		{ props.selected && (
-			<span className="DayPicker-selected">
-				{ props.selected instanceof Date ? props.selected.toISOString() : String( props.selected ) }
-			</span>
-		) }
-		{ props.month && (
+/**
+ * Shifts a Date by a number of months, preserving the UTC day-of-month
+ * representation used throughout these tests (dates are built from ISO strings).
+ *
+ * @param {Date}   date   The date to shift.
+ * @param {number} offset Number of months to shift (negative goes back).
+ * @return {Date|undefined} The shifted date, or undefined when the input is invalid.
+ */
+const shiftMonth = ( date, offset ) => {
+	if ( ! ( date instanceof Date ) || isNaN( date ) ) {
+		return undefined;
+	}
+
+	return new Date( Date.UTC( date.getUTCFullYear(), date.getUTCMonth() + offset, 1 ) );
+};
+
+/**
+ * Mock for react-day-picker that mirrors its month-navigation semantics:
+ *
+ * - When `month` is provided (controlled), the displayed month always comes
+ *   from the prop and navigation only fires `onMonthChange`.
+ * - When `month` is omitted, the calendar keeps its own display month,
+ *   initialized from `defaultMonth`, and navigation updates it internally.
+ *
+ * This lets tests catch regressions where a controlled `month` prop is passed
+ * without an `onMonthChange` handler, which makes month navigation dead.
+ *
+ * @param {Object} props DayPicker props.
+ */
+export const DayPicker = ( props ) => {
+	const isControlled = props.month !== undefined;
+	const [ internalMonth, setInternalMonth ] = useState( props.month || props.defaultMonth || new Date() );
+
+	const displayMonth = isControlled ? props.month : internalMonth;
+
+	const goToMonth = ( offset ) => {
+		const nextMonth = shiftMonth( displayMonth, offset );
+
+		if ( isControlled ) {
+			props.onMonthChange?.( nextMonth );
+			return;
+		}
+
+		setInternalMonth( nextMonth );
+	};
+
+	return (
+		<div className="DayPicker-mock" data-testid="day-picker">
+			<span className="DayPicker-mode">{ props.mode }</span>
+			{ props.selected && (
+				<span className="DayPicker-selected">
+					{ props.selected instanceof Date ? props.selected.toISOString() : String( props.selected ) }
+				</span>
+			) }
 			<span className="DayPicker-month">
-				{ props.month instanceof Date ? props.month.toISOString() : String( props.month ) }
+				{ displayMonth instanceof Date ? displayMonth.toISOString() : String( displayMonth ) }
 			</span>
-		) }
-		{ props.startMonth && (
-			<span className="DayPicker-startMonth">
-				{ props.startMonth instanceof Date ? props.startMonth.toISOString() : String( props.startMonth ) }
-			</span>
-		) }
-		{ props.endMonth && (
-			<span className="DayPicker-endMonth">
-				{ props.endMonth instanceof Date ? props.endMonth.toISOString() : String( props.endMonth ) }
-			</span>
-		) }
-		{ props.disabled && (
-			<span className="DayPicker-disabled">{ JSON.stringify( props.disabled ) }</span>
-		) }
-		{ props.modifiers && (
-			<span className="DayPicker-modifiers">{ JSON.stringify( props.modifiers ) }</span>
-		) }
-		<button
-			className="DayPicker-select"
-			onClick={ () => props.onSelect?.( props.selected || new Date( '2026-01-15' ), new Date(), {}, {} ) }
-		>
-			Select
-		</button>
-	</div>
-);
+			{ props.startMonth && (
+				<span className="DayPicker-startMonth">
+					{ props.startMonth instanceof Date ? props.startMonth.toISOString() : String( props.startMonth ) }
+				</span>
+			) }
+			{ props.endMonth && (
+				<span className="DayPicker-endMonth">
+					{ props.endMonth instanceof Date ? props.endMonth.toISOString() : String( props.endMonth ) }
+				</span>
+			) }
+			{ props.disabled && <span className="DayPicker-disabled">{ JSON.stringify( props.disabled ) }</span> }
+			{ props.modifiers && <span className="DayPicker-modifiers">{ JSON.stringify( props.modifiers ) }</span> }
+			<button className="DayPicker-nav-prev" onClick={ () => goToMonth( -1 ) }>
+				Previous month
+			</button>
+			<button className="DayPicker-nav-next" onClick={ () => goToMonth( 1 ) }>
+				Next month
+			</button>
+			<button
+				className="DayPicker-select"
+				onClick={ () => props.onSelect?.( props.selected || new Date( '2026-01-15' ), new Date(), {}, {} ) }
+			>
+				Select
+			</button>
+		</div>
+	);
+};
 
 export default DayPicker;

--- a/src/modules/elements/day-picker-input/__tests__/element.test.js
+++ b/src/modules/elements/day-picker-input/__tests__/element.test.js
@@ -187,6 +187,54 @@ describe( 'DayPickerInput element', () => {
 		expect( endMonthEl.children[0] ).toContain( '2026-08-15' );
 	} );
 
+	it( 'navigates to the next month when clicking the next-month button', () => {
+		const component = renderer.create(
+			<DayPickerInput
+				value=""
+				format="LL"
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				dayPickerProps={ { month: july1 } }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		// Open the calendar.
+		const input = component.root.findByType( 'input' );
+		renderer.act( () => {
+			input.props.onClick();
+		} );
+
+		const getMonthText = () => {
+			const dayPicker = component.root.findAll(
+				( node ) => node.props?.['data-testid'] === 'day-picker'
+			)[0];
+			const monthEl = dayPicker.findAll(
+				( node ) => node.props.className === 'DayPicker-month'
+			)[0];
+
+			return monthEl.children[0];
+		};
+
+		// Calendar opens on the initial month (July).
+		expect( getMonthText() ).toContain( '2026-07-01' );
+
+		// Click the next-month navigation button.
+		const dayPicker = component.root.findAll(
+			( node ) => node.props?.['data-testid'] === 'day-picker'
+		)[0];
+		const nextBtn = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-nav-next'
+		)[0];
+
+		renderer.act( () => {
+			nextBtn.props.onClick();
+		} );
+
+		// The calendar must advance to August.
+		expect( getMonthText() ).toContain( '2026-08-01' );
+	} );
+
 	it( 'uses dayPickerProps.month when no date is selected', () => {
 		const component = renderer.create(
 			<DayPickerInput
@@ -340,7 +388,9 @@ describe( 'DayPickerInput element', () => {
 			( node ) => node.props?.['data-testid'] === 'day-picker'
 		)[0];
 
-		const selectBtn = dayPicker.findByType( 'button' );
+		const selectBtn = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-select'
+		)[0];
 		renderer.act( () => {
 			selectBtn.props.onClick();
 		} );
@@ -480,7 +530,9 @@ describe( 'DayPickerInput element', () => {
 			( node ) => node.props?.['data-testid'] === 'day-picker'
 		)[0];
 
-		const selectBtn = dayPicker.findByType( 'button' );
+		const selectBtn = dayPicker.findAll(
+			( node ) => node.props.className === 'DayPicker-select'
+		)[0];
 		renderer.act( () => {
 			selectBtn.props.onClick();
 		} );

--- a/src/modules/elements/day-picker-input/element.js
+++ b/src/modules/elements/day-picker-input/element.js
@@ -205,7 +205,7 @@ const DayPickerInput = ( props ) => {
 							} }
 							disabled={ dayPickerProps?.disabledDays }
 							modifiers={ dayPickerProps?.modifiers }
-							month={ selectedDate || dayPickerProps?.month || new Date() }
+							defaultMonth={ selectedDate || dayPickerProps?.month || new Date() }
 							startMonth={ dayPickerProps?.fromMonth }
 							endMonth={ dayPickerProps?.toMonth }
 							isSelected={ true }

--- a/tests/_bootstrap.php
+++ b/tests/_bootstrap.php
@@ -9,6 +9,14 @@ $GLOBALS['wp_filter']['lw_harbor/premium_plugin_exists'][ 10 ][ md5( 'lw_harbor/
 	'accepted_args' => 1,
 ];
 
+// PHPUnit's global-state snapshotter cannot serialize $wp_filter when WordPress
+// attaches the closure-backed object-cache drop-in filter during runtime init.
+// Remove the filter before the serializer snapshots the globals during the test
+// run without touching WordPress core.
+if ( isset( $GLOBALS['wp_filter']['enable_loading_object_cache_dropin'] ) ) {
+	unset( $GLOBALS['wp_filter']['enable_loading_object_cache_dropin'] );
+}
+
 require_once dirname( __DIR__, 1 ) . '/tribe-autoload.php';
 Autoload::addNamespace( 'Tribe\\Tests', __DIR__ . '/_support' );
 // Silence the logger in the tests.


### PR DESCRIPTION
### 🎫 Ticket

[SOFT-4175](https://linear.app/nexcess/issue/SOFT-4175/block-editor-cannot-change-months-in-rsvp-datepicker)


### 🗒️ Description

DayPickerInput rendered react-day-picker v9 with a controlled `month` prop and no `onMonthChange` handler, which makes react-day-picker discard month navigation. Switched to `defaultMonth` so the calendar manages its displayed month internally. Updated the react-day-picker mock to model controlled/uncontrolled month semantics and added a regression test that fails without this fix.

https://www.loom.com/share/4a08bf8621f2405b94459d1faeeb9ecb

### ✔️ Checklist

- [x] Code is covered by **NEW** tests.
- [x] Code is covered by **EXISTING** tests.
- [ ] Changelog item has been added. If not required for this change, the `No Changelog Needed` label should be added.
- [ ] All CI checks have passed, or any expected failures are explained in the Description section.
- [x] Have you added Artifacts?
- [ ] Have you added Testing Instructions for QA?