### PR TITLE
[SMTNC-2016] supports_async_process() blocks 10-33s per request and never persists the negative result

### DIFF
--- a/changelog/fix-async-process-detection-persist-negative-result
+++ b/changelog/fix-async-process-detection-persist-negative-result
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Resolved an issue where async process feature detection could block for 10–33 seconds per request and never persist a negative result on hosts where the loopback request fails.

--- a/src/Tribe/Feature_Detection.php
+++ b/src/Tribe/Feature_Detection.php
@@ -54,7 +54,7 @@ class Tribe__Feature_Detection {
 	 * @return bool Whether async, AJAX-based, background processing is supported or not.
 	 */
 	public function supports_async_process( $force = false ) {
-		static $cached_supports_async_process = null;
+		$cache_var_name = __METHOD__;
 
 		/**
 		 * Filters whether async, AJAX-based, processing is supported or not.
@@ -77,6 +77,7 @@ class Tribe__Feature_Detection {
 		 * The loopback check is costly; memoize its result so repeated calls within
 		 * the same request do not re-run it. A `$force` request re-runs the check.
 		 */
+		$cached_supports_async_process = tribe_get_var( $cache_var_name, null );
 		if ( ! $force && null !== $cached_supports_async_process ) {
 			return $cached_supports_async_process;
 		}
@@ -137,6 +138,7 @@ class Tribe__Feature_Detection {
 		}
 
 		$cached_supports_async_process = tribe_is_truthy( $supports_async_process );
+		tribe_set_var( $cache_var_name, $cached_supports_async_process );
 
 		return $cached_supports_async_process;
 	}

--- a/src/Tribe/Feature_Detection.php
+++ b/src/Tribe/Feature_Detection.php
@@ -43,8 +43,8 @@ class Tribe__Feature_Detection {
 	/**
 	 * Checks whether async, AJAX-based, background processing is supported or not.
 	 *
-	 * To avoid making this costly check on each load the result of this check is cached
-	 * in the `tribe_feature_detection` transient, under the `supports_async_process` key.
+	 * The result of this check is cached in a timed option and memoized for the
+	 * request lifetime, so the costly loopback check is not repeated on every load.
 	 *
 	 * @since 4.7.23
 	 *
@@ -54,6 +54,8 @@ class Tribe__Feature_Detection {
 	 * @return bool Whether async, AJAX-based, background processing is supported or not.
 	 */
 	public function supports_async_process( $force = false ) {
+		static $cached_supports_async_process = null;
+
 		/**
 		 * Filters whether async, AJAX-based, processing is supported or not.
 		 *
@@ -68,7 +70,15 @@ class Tribe__Feature_Detection {
 		 */
 		$supports_async_process = apply_filters( 'tribe_supports_async_process', null, $force );
 		if ( null !== $supports_async_process ) {
-			return (bool) $supports_async_process;
+			return tribe_is_truthy( $supports_async_process );
+		}
+
+		/*
+		 * The loopback check is costly; memoize its result so repeated calls within
+		 * the same request do not re-run it. A `$force` request re-runs the check.
+		 */
+		if ( ! $force && null !== $cached_supports_async_process ) {
+			return $cached_supports_async_process;
 		}
 
 		$this->lock_option_name = 'tribe_feature_support_check_lock';
@@ -104,8 +114,7 @@ class Tribe__Feature_Detection {
 			$supports_async_process = false;
 
 			while ( time() <= $start + $wait_up_to ) {
-				// We want to force a refetch from the database on each check.
-				$supports_async_process = (bool) tec_timed_option()->get( $transient_name );
+				$supports_async_process = tribe_is_truthy( tec_timed_option()->get( $transient_name ) );
 
 				if ( $supports_async_process ) {
 					break;
@@ -114,14 +123,22 @@ class Tribe__Feature_Detection {
 			}
 
 			$this->unlock();
+
 			if ( $supports_async_process ) {
 				tribe( 'logger' )->log( 'AJAX-based async processing is supported.', Tribe__Log::DEBUG );
 			} else {
+				/*
+				 * Persist the negative result with a bounded TTL so the costly
+				 * loopback check is not re-run on every request.
+				 */
+				tec_timed_option()->set( $transient_name, 0, HOUR_IN_SECONDS );
 				tribe( 'logger' )->log( 'AJAX-based async processing is not supported; background processing will rely on WP Cron.', Tribe__Log::DEBUG );
 			}
 		}
 
-		return (bool) $supports_async_process;
+		$cached_supports_async_process = tribe_is_truthy( $supports_async_process );
+
+		return $cached_supports_async_process;
 	}
 
 	/**

--- a/tests/wpunit/Tribe/Feature_DetectionTest.php
+++ b/tests/wpunit/Tribe/Feature_DetectionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tribe;
+
+use Tribe__Feature_Detection as Feature_Detection;
+use Tribe__Process__Tester as Tester;
+
+class Feature_DetectionTest extends \Codeception\TestCase\WPTestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		delete_option( 'tribe_feature_support_check_lock' );
+		tec_timed_option()->delete( Tester::TRANSIENT_NAME );
+	}
+
+	public function tearDown() {
+		remove_all_filters( 'tribe_supports_async_process' );
+
+		delete_option( 'tribe_feature_support_check_lock' );
+		tec_timed_option()->delete( Tester::TRANSIENT_NAME );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 * it should return the value set by the tribe_supports_async_process filter
+	 */
+	public function it_should_return_the_value_set_by_the_filter() {
+		$sut = $this->make_instance();
+
+		add_filter(
+			'tribe_supports_async_process',
+			static function () {
+				return 'yes';
+			}
+		);
+
+		$this->assertTrue( $sut->supports_async_process() );
+	}
+
+	/**
+	 * @test
+	 * it should honor a persisted negative result without re-running the loopback check
+	 */
+	public function it_should_honor_a_persisted_negative_result_without_re_running_the_check() {
+		$sut = $this->make_instance();
+
+		tec_timed_option()->set( Tester::TRANSIENT_NAME, 0, HOUR_IN_SECONDS );
+
+		$this->assertFalse( $sut->supports_async_process() );
+		$this->assertEmpty( get_option( 'tribe_feature_support_check_lock' ) );
+	}
+
+	/**
+	 * @return Feature_Detection
+	 */
+	private function make_instance() {
+		return new Feature_Detection();
+	}
+}

--- a/tests/wpunit/Tribe/Feature_DetectionTest.php
+++ b/tests/wpunit/Tribe/Feature_DetectionTest.php
@@ -12,6 +12,7 @@ class Feature_DetectionTest extends \Codeception\TestCase\WPTestCase {
 
 		delete_option( 'tribe_feature_support_check_lock' );
 		tec_timed_option()->delete( Tester::TRANSIENT_NAME );
+		tribe_unset_var( 'Tribe__Feature_Detection::supports_async_process' );
 	}
 
 	public function tearDown() {
@@ -19,6 +20,7 @@ class Feature_DetectionTest extends \Codeception\TestCase\WPTestCase {
 
 		delete_option( 'tribe_feature_support_check_lock' );
 		tec_timed_option()->delete( Tester::TRANSIENT_NAME );
+		tribe_unset_var( 'Tribe__Feature_Detection::supports_async_process' );
 
 		parent::tearDown();
 	}

--- a/tests/wpunit/Tribe/Feature_DetectionTest.php
+++ b/tests/wpunit/Tribe/Feature_DetectionTest.php
@@ -45,11 +45,31 @@ class Feature_DetectionTest extends \Codeception\TestCase\WPTestCase {
 	 * it should honor a persisted negative result without re-running the loopback check
 	 */
 	public function it_should_honor_a_persisted_negative_result_without_re_running_the_check() {
-		$sut = $this->make_instance();
+		$sut            = $this->make_instance();
+		$added_option   = false;
+		$updated_option = false;
+
+		$added_option_callback   = static function () use ( &$added_option ) {
+			$added_option = true;
+		};
+		$updated_option_callback = static function ( $option ) use ( &$updated_option ) {
+			if ( 'tribe_feature_support_check_lock' === $option ) {
+				$updated_option = true;
+			}
+		};
+
+		add_action( 'added_option_tribe_feature_support_check_lock', $added_option_callback );
+		add_action( 'updated_option', $updated_option_callback );
 
 		tec_timed_option()->set( Tester::TRANSIENT_NAME, 0, HOUR_IN_SECONDS );
 
 		$this->assertFalse( $sut->supports_async_process() );
+
+		remove_action( 'added_option_tribe_feature_support_check_lock', $added_option_callback );
+		remove_action( 'updated_option', $updated_option_callback );
+
+		$this->assertFalse( $added_option );
+		$this->assertFalse( $updated_option );
 		$this->assertEmpty( get_option( 'tribe_feature_support_check_lock' ) );
 	}
 


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2016](https://linear.app/nexcess/issue/SMTNC-2016/tec-supports-async-process-blocks-10-33s-per-request-and-never)

### 🎥 Artifacts

> Test before

<img width="913" height="444" alt="image" src="https://github.com/user-attachments/assets/a0cd37f8-f101-4998-8dce-8f4ec94f1be1" />

> Test after fix

<img width="913" height="437" alt="image" src="https://github.com/user-attachments/assets/24fcc5db-27cc-4109-bd61-5eb2f738224f" />

### 🗒️ Description

Resolved an issue where `supports_async_process()` could block 10–33 seconds per request and never persist a negative result on hosts where the loopback self-request fails. The result is now memoized for the request lifetime and the negative result is persisted to the timed option with a bounded TTL, so background processing falls back to WP-Cron without repeated blocking.

### Testing

Use the help of this plugin to test: https://drive.google.com/file/d/14tcahj6lFN4RfrP4612a3nggMyT4eeXK/view?usp=sharing

Access `/wp-admin/admin.php?page=smtnc-1860-perf-qa`

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing? (slic unavailable locally — not run)
- [x ] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
