### PR TITLE
[SMTNC-2031] Tribe Common (TEC/ET)

### DIFF
--- a/changelog/smtnc-2031-tribe-common-tecet.yaml
+++ b/changelog/smtnc-2031-tribe-common-tecet.yaml
@@ -1,0 +1,5 @@
+significance: minor
+type: feature
+entry: Added an admin notice prompting administrators to update WordPress when a
+  core update is available.
+timestamp: 2026-08-17T21:51:45.648Z

--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,6 @@
       "phpstan/extension-installer": true
     }
   },
-  "repositories": [
-    {
-      "type": "vcs",
-      "url": "git@github.com:stellarwp/core-update-notice.git"
-    }
-  ],
   "require": {
     "firebase/php-jwt": "~6.3.0",
     "lucatume/di52": "^3.3.7",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,12 @@
       "phpstan/extension-installer": true
     }
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "git@github.com:stellarwp/core-update-notice.git"
+    }
+  ],
   "require": {
     "firebase/php-jwt": "~6.3.0",
     "lucatume/di52": "^3.3.7",
@@ -30,6 +36,7 @@
     "stellarwp/arrays": "^1.3",
     "stellarwp/assets": "^1.5",
     "stellarwp/container-contract": "^1.0.4",
+    "stellarwp/core-update-notice": "dev-main",
     "stellarwp/db": "^1.0.3",
     "stellarwp/harbor": "^1.6.0",
     "stellarwp/installer": "^1.1.0",
@@ -139,6 +146,7 @@
         "stellarwp/arrays",
         "stellarwp/assets",
         "stellarwp/container-contract",
+        "stellarwp/core-update-notice",
         "stellarwp/db",
         "stellarwp/harbor",
         "stellarwp/models",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "369ea9c111c1eb3029f86ee3112ce4f8",
+    "content-hash": "9b5cbfaebff94e1f6d139bcf7d1d9c5e",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -842,13 +842,13 @@
             "version": "dev-main",
             "source": {
                 "type": "git",
-                "url": "git@github.com:stellarwp/core-update-notice.git",
-                "reference": "3ea14c9c104b395c4a4fb7a392d8eb2dafffa89a"
+                "url": "https://github.com/stellarwp/core-update-notice.git",
+                "reference": "c3c243e3fc3e5318b7209314c875f15f10339dfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/core-update-notice/zipball/3ea14c9c104b395c4a4fb7a392d8eb2dafffa89a",
-                "reference": "3ea14c9c104b395c4a4fb7a392d8eb2dafffa89a",
+                "url": "https://api.github.com/repos/stellarwp/core-update-notice/zipball/c3c243e3fc3e5318b7209314c875f15f10339dfd",
+                "reference": "c3c243e3fc3e5318b7209314c875f15f10339dfd",
                 "shasum": ""
             },
             "require": {
@@ -858,10 +858,10 @@
             "require-dev": {
                 "brain/monkey": "^2.6",
                 "phpstan/extension-installer": "^1.4",
-                "phpstan/phpstan": "^1.12",
+                "phpstan/phpstan": "^2.2",
                 "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.9",
-                "szepeviktor/phpstan-wordpress": "^1.3"
+                "szepeviktor/phpstan-wordpress": "^2.0"
             },
             "default-branch": true,
             "type": "library",
@@ -870,30 +870,7 @@
                     "StellarWP\\CoreUpdateNotice\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "StellarWP\\CoreUpdateNotice\\Tests\\": "tests/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "phpunit"
-                ],
-                "phpstan": [
-                    "phpstan analyse --memory-limit=512M"
-                ],
-                "phpcs": [
-                    "phpcs"
-                ],
-                "phpcbf": [
-                    "phpcbf"
-                ],
-                "check": [
-                    "@phpcs",
-                    "@phpstan",
-                    "@test"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -905,10 +882,10 @@
             ],
             "description": "A WordPress admin notice prompting site administrators to update WordPress, with a dismissal flag shared across the plugins that display it.",
             "support": {
-                "source": "https://github.com/stellarwp/core-update-notice/tree/main",
-                "issues": "https://github.com/stellarwp/core-update-notice/issues"
+                "issues": "https://github.com/stellarwp/core-update-notice/issues",
+                "source": "https://github.com/stellarwp/core-update-notice/tree/main"
             },
-            "time": "2026-08-18T01:32:12+00:00"
+            "time": "2026-08-18T06:42:06+00:00"
         },
         {
             "name": "stellarwp/db",

--- a/composer.lock
+++ b/composer.lock
@@ -843,17 +843,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/stellarwp/core-update-notice.git",
-                "reference": "c3c243e3fc3e5318b7209314c875f15f10339dfd"
+                "reference": "4b2177c542a22ad7e37b90bf822a2265b75cac98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/stellarwp/core-update-notice/zipball/c3c243e3fc3e5318b7209314c875f15f10339dfd",
-                "reference": "c3c243e3fc3e5318b7209314c875f15f10339dfd",
+                "url": "https://api.github.com/repos/stellarwp/core-update-notice/zipball/4b2177c542a22ad7e37b90bf822a2265b75cac98",
+                "reference": "4b2177c542a22ad7e37b90bf822a2265b75cac98",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.4 || ^8.0",
-                "stellarwp/container-contract": "^1.1"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "brain/monkey": "^2.6",
@@ -861,6 +860,7 @@
                 "phpstan/phpstan": "^2.2",
                 "phpunit/phpunit": "^9.5",
                 "squizlabs/php_codesniffer": "^3.9",
+                "stellarwp/nexcess-coding-standards": "^2.0",
                 "szepeviktor/phpstan-wordpress": "^2.0"
             },
             "default-branch": true,
@@ -880,12 +880,12 @@
                     "email": "dev@stellarwp.com"
                 }
             ],
-            "description": "A WordPress admin notice prompting site administrators to update WordPress, with a dismissal flag shared across the plugins that display it.",
+            "description": "A WordPress core update notice scoped to consuming plugins' admin pages, with dismissal shared across plugins.",
             "support": {
                 "issues": "https://github.com/stellarwp/core-update-notice/issues",
                 "source": "https://github.com/stellarwp/core-update-notice/tree/main"
             },
-            "time": "2026-08-18T06:42:06+00:00"
+            "time": "2026-08-18T17:56:47+00:00"
         },
         {
             "name": "stellarwp/db",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4ca736deb646c33f2ec724141277a50",
+    "content-hash": "369ea9c111c1eb3029f86ee3112ce4f8",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -836,6 +836,79 @@
                 "source": "https://github.com/stellarwp/container-contract/tree/1.1.1"
             },
             "time": "2023-09-05T20:08:29+00:00"
+        },
+        {
+            "name": "stellarwp/core-update-notice",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "git@github.com:stellarwp/core-update-notice.git",
+                "reference": "3ea14c9c104b395c4a4fb7a392d8eb2dafffa89a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/stellarwp/core-update-notice/zipball/3ea14c9c104b395c4a4fb7a392d8eb2dafffa89a",
+                "reference": "3ea14c9c104b395c4a4fb7a392d8eb2dafffa89a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "stellarwp/container-contract": "^1.1"
+            },
+            "require-dev": {
+                "brain/monkey": "^2.6",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^9.5",
+                "squizlabs/php_codesniffer": "^3.9",
+                "szepeviktor/phpstan-wordpress": "^1.3"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "StellarWP\\CoreUpdateNotice\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "StellarWP\\CoreUpdateNotice\\Tests\\": "tests/"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ],
+                "phpstan": [
+                    "phpstan analyse --memory-limit=512M"
+                ],
+                "phpcs": [
+                    "phpcs"
+                ],
+                "phpcbf": [
+                    "phpcbf"
+                ],
+                "check": [
+                    "@phpcs",
+                    "@phpstan",
+                    "@test"
+                ]
+            },
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "StellarWP",
+                    "email": "dev@stellarwp.com"
+                }
+            ],
+            "description": "A WordPress admin notice prompting site administrators to update WordPress, with a dismissal flag shared across the plugins that display it.",
+            "support": {
+                "source": "https://github.com/stellarwp/core-update-notice/tree/main",
+                "issues": "https://github.com/stellarwp/core-update-notice/issues"
+            },
+            "time": "2026-08-18T01:32:12+00:00"
         },
         {
             "name": "stellarwp/db",
@@ -7753,15 +7826,16 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "stellarwp/core-update-notice": 20,
         "stellarwp/coding-standards": 20,
         "the-events-calendar/tec-testing-facilities": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,
-    "platform": {},
-    "platform-dev": {},
+    "platform": [],
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/Common/Libraries/Core_Update_Notice.php
+++ b/src/Common/Libraries/Core_Update_Notice.php
@@ -25,7 +25,7 @@ use TEC\Common\StellarWP\CoreUpdateNotice\Register;
  */
 class Core_Update_Notice extends Controller_Contract {
 	/**
-	 * Registers the controller.
+	 * Register the controller.
 	 *
 	 * @since TBD
 	 *
@@ -39,7 +39,7 @@ class Core_Update_Notice extends Controller_Contract {
 	}
 
 	/**
-	 * Unregisters the controller.
+	 * Unregister the controller.
 	 *
 	 * @since TBD
 	 *
@@ -50,7 +50,7 @@ class Core_Update_Notice extends Controller_Contract {
 	}
 
 	/**
-	 * Registers the shared WordPress core update notice.
+	 * Register the shared WordPress core update notice.
 	 *
 	 * The copy is passed in rather than left to the library's English defaults so that it is
 	 * extracted into this plugin's text domain.

--- a/src/Common/Libraries/Core_Update_Notice.php
+++ b/src/Common/Libraries/Core_Update_Notice.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * The Controller to set up the Core Update Notice library.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Libraries
+ */
+
+namespace TEC\Common\Libraries;
+
+use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
+use TEC\Common\StellarWP\CoreUpdateNotice\Config;
+use TEC\Common\StellarWP\CoreUpdateNotice\Register;
+
+/**
+ * Controller for setting up the Core Update Notice library.
+ *
+ * The library carries its dismissal flag in an unprefixed site option, so a site running several
+ * StellarWP plugins that show this notice only has to dismiss it once.
+ *
+ * @since TBD
+ *
+ * @package TEC\Common\Libraries
+ */
+class Core_Update_Notice extends Controller_Contract {
+	/**
+	 * Registers the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function do_register(): void {
+		Config::setContainer( $this->container );
+
+		/* Deferred so the copy below is translated; the library hooks admin_init, which is later still. */
+		add_action( 'init', [ $this, 'register_notice' ] );
+	}
+
+	/**
+	 * Unregisters the controller.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function unregister(): void {
+		remove_action( 'init', [ $this, 'register_notice' ] );
+	}
+
+	/**
+	 * Registers the shared WordPress core update notice.
+	 *
+	 * The copy is passed in rather than left to the library's English defaults so that it is
+	 * extracted into this plugin's text domain.
+	 *
+	 * @since TBD
+	 *
+	 * @return void
+	 */
+	public function register_notice(): void {
+		Register::notice(
+			[
+				'heading' => __( 'Keep your site protected. Update to the latest version of WordPress.', 'tribe-common' ),
+				'body'    => __( 'Your site is running on an outdated version of WordPress, which can leave it vulnerable to security issues. To decrease your risk of exposure, please update your WordPress install to the latest version.', 'tribe-common' ),
+				'dismiss' => __( 'Dismiss this notice.', 'tribe-common' ),
+			]
+		);
+	}
+}

--- a/src/Common/Libraries/Core_Update_Notice.php
+++ b/src/Common/Libraries/Core_Update_Notice.php
@@ -10,14 +10,15 @@
 namespace TEC\Common\Libraries;
 
 use TEC\Common\Contracts\Provider\Controller as Controller_Contract;
-use TEC\Common\StellarWP\CoreUpdateNotice\Config;
+use TEC\Common\StellarWP\CoreUpdateNotice\CoreUpdateNotice;
 use TEC\Common\StellarWP\CoreUpdateNotice\Register;
 
 /**
  * Controller for setting up the Core Update Notice library.
  *
- * The library carries its dismissal flag in an unprefixed site option, so a site running several
- * StellarWP plugins that show this notice only has to dismiss it once.
+ * The library keys its dismissal on the offered WordPress version in an unprefixed site option, so
+ * a site running several StellarWP plugins that show this notice dismisses it once, and a later
+ * release brings it back. Each bundled copy declares a version and only the highest one renders.
  *
  * @since TBD
  *
@@ -32,9 +33,10 @@ class Core_Update_Notice extends Controller_Contract {
 	 * @return void
 	 */
 	public function do_register(): void {
-		Config::setContainer( $this->container );
-
-		/* Deferred so the copy below is translated; the library hooks admin_init, which is later still. */
+		/*
+		 * Deferred so the copy below is translated. The library refuses to register after
+		 * admin_init, and init runs before it.
+		 */
 		add_action( 'init', [ $this, 'register_notice' ] );
 	}
 
@@ -61,11 +63,28 @@ class Core_Update_Notice extends Controller_Contract {
 	 */
 	public function register_notice(): void {
 		Register::notice(
-			[
-				'heading' => __( 'Keep your site protected. Update to the latest version of WordPress.', 'tribe-common' ),
-				'body'    => __( 'Your site is running on an outdated version of WordPress, which can leave it vulnerable to security issues. To decrease your risk of exposure, please update your WordPress install to the latest version.', 'tribe-common' ),
-				'dismiss' => __( 'Dismiss this notice.', 'tribe-common' ),
-			]
+			new CoreUpdateNotice(
+				[
+					'heading' => __( 'Keep your site protected. Update to the latest version of WordPress.', 'tribe-common' ),
+					'body'    => __( 'Your site is running on an outdated version of WordPress, which can leave it vulnerable to security issues. To decrease your risk of exposure, please update your WordPress install to the latest version.', 'tribe-common' ),
+					'dismiss' => __( 'Dismiss this notice.', 'tribe-common' ),
+				]
+			),
+			[ $this, 'is_plugin_page' ]
 		);
+	}
+
+	/**
+	 * Whether the current screen belongs to this plugin's family.
+	 *
+	 * Derived from the admin helper rather than a screen list of its own, so it keeps matching
+	 * whatever TEC and ET register.
+	 *
+	 * @since TBD
+	 *
+	 * @return bool Whether the notice may render on the current screen.
+	 */
+	public function is_plugin_page(): bool {
+		return tribe( 'admin.helpers' )->is_screen();
 	}
 }

--- a/src/Common/Libraries/Provider.php
+++ b/src/Common/Libraries/Provider.php
@@ -49,6 +49,7 @@ class Provider extends Service_Provider {
 
 		$this->container->register( Shepherd::class );
 		$this->container->register( Harbor::class );
+		$this->container->register( Core_Update_Notice::class );
 	}
 
 	/**

--- a/tests/wpunit/TEC/Common/Libraries/Core_Update_NoticeTest.php
+++ b/tests/wpunit/TEC/Common/Libraries/Core_Update_NoticeTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace TEC\Common\Libraries;
+
+use Codeception\TestCase\WPTestCase;
+use TEC\Common\StellarWP\CoreUpdateNotice\Config;
+use TEC\Common\StellarWP\CoreUpdateNotice\CoreUpdateNotice;
+
+/**
+ * Covers this plugin's integration with stellarwp/core-update-notice: that the container is handed
+ * over, that the copy passed from the controller reaches the output, and that the shared dismissal
+ * flag is honoured.
+ */
+class Core_Update_NoticeTest extends WPTestCase {
+	/**
+	 * @after
+	 */
+	public function reset_update_state(): void {
+		delete_site_transient( 'update_core' );
+		delete_option( CoreUpdateNotice::DISMISSED_OPTION );
+		unset( $GLOBALS[ CoreUpdateNotice::RENDER_GUARD ] );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_hand_the_tec_container_to_the_library(): void {
+		tribe( Core_Update_Notice::class )->do_register();
+
+		$this->assertSame( tribe(), Config::getContainer() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_render_the_copy_in_the_tribe_common_text_domain(): void {
+		$this->given_core_update_response( 'upgrade', '9.9.9' );
+		$this->given_current_user_is( 'administrator' );
+
+		$html = $this->render_notice();
+
+		$this->assertStringContainsString( 'Keep your site protected. Update to the latest version of WordPress.', $html );
+		$this->assertStringContainsString( 'To decrease your risk of exposure, please update your WordPress install to the latest version.', $html );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_not_render_when_wordpress_is_up_to_date(): void {
+		$this->given_core_update_response( 'latest', '9.9.9' );
+		$this->given_current_user_is( 'administrator' );
+
+		$this->assertSame( '', $this->render_notice() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_not_render_to_a_user_who_cannot_update_core(): void {
+		$this->given_core_update_response( 'upgrade', '9.9.9' );
+		$this->given_current_user_is( 'editor' );
+
+		$this->assertSame( '', $this->render_notice() );
+	}
+
+	/**
+	 * The flag is deliberately unprefixed and shared, so a site running several StellarWP plugins
+	 * that carry this notice dismisses it once rather than once per plugin.
+	 *
+	 * @test
+	 */
+	public function should_honour_the_shared_dismissal_flag(): void {
+		$this->given_core_update_response( 'upgrade', '9.9.9' );
+		$this->given_current_user_is( 'administrator' );
+
+		update_option( CoreUpdateNotice::DISMISSED_OPTION, true, false );
+
+		$this->assertSame( '', $this->render_notice() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_render_only_once_per_request_across_plugins(): void {
+		$this->given_core_update_response( 'upgrade', '9.9.9' );
+		$this->given_current_user_is( 'administrator' );
+
+		$this->assertNotSame( '', $this->render_notice() );
+		$this->assertSame( '', $this->render_notice(), 'A second copy of the notice should be suppressed.' );
+	}
+
+	/**
+	 * Captures one `admin_notices` pass of the configured notice.
+	 *
+	 * @return string The rendered markup, empty when the notice declined to render.
+	 */
+	protected function render_notice(): string {
+		$notice = new CoreUpdateNotice(
+			[
+				'heading' => __( 'Keep your site protected. Update to the latest version of WordPress.', 'tribe-common' ),
+				'body'    => __( 'Your site is running on an outdated version of WordPress, which can leave it vulnerable to security issues. To decrease your risk of exposure, please update your WordPress install to the latest version.', 'tribe-common' ),
+				'dismiss' => __( 'Dismiss this notice.', 'tribe-common' ),
+			]
+		);
+
+		ob_start();
+		$notice->render();
+
+		return ob_get_clean() ?: '';
+	}
+
+	/**
+	 * Seeds the transient `get_core_updates()` reads to decide whether an update is pending.
+	 *
+	 * @param string $response The core update response, `upgrade` when one is available.
+	 * @param string $version  The version the update points at.
+	 */
+	protected function given_core_update_response( string $response, string $version ): void {
+		set_site_transient(
+			'update_core',
+			(object) [
+				'updates' => [
+					(object) [
+						'response' => $response,
+						'current'  => $version,
+						'locale'   => 'en_US',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * @param string $role The role to create the current user with.
+	 */
+	protected function given_current_user_is( string $role ): void {
+		wp_set_current_user( static::factory()->user->create( [ 'role' => $role ] ) );
+	}
+}

--- a/tests/wpunit/TEC/Common/Libraries/Core_Update_NoticeTest.php
+++ b/tests/wpunit/TEC/Common/Libraries/Core_Update_NoticeTest.php
@@ -3,13 +3,12 @@
 namespace TEC\Common\Libraries;
 
 use Codeception\TestCase\WPTestCase;
-use TEC\Common\StellarWP\CoreUpdateNotice\Config;
 use TEC\Common\StellarWP\CoreUpdateNotice\CoreUpdateNotice;
 
 /**
- * Covers this plugin's integration with stellarwp/core-update-notice: that the container is handed
- * over, that the copy passed from the controller reaches the output, and that the shared dismissal
- * flag is honoured.
+ * Covers this plugin's integration with stellarwp/core-update-notice: that the copy passed from the
+ * controller reaches the output, that the screen gate is wired to the admin helper, and that the
+ * shared version-keyed dismissal is honoured.
  */
 class Core_Update_NoticeTest extends WPTestCase {
 	/**
@@ -18,16 +17,25 @@ class Core_Update_NoticeTest extends WPTestCase {
 	public function reset_update_state(): void {
 		delete_site_transient( 'update_core' );
 		delete_option( CoreUpdateNotice::DISMISSED_OPTION );
-		unset( $GLOBALS[ CoreUpdateNotice::RENDER_GUARD ] );
+		unset( $GLOBALS['current_screen'] );
 	}
 
 	/**
 	 * @test
 	 */
-	public function should_hand_the_tec_container_to_the_library(): void {
-		tribe( Core_Update_Notice::class )->do_register();
+	public function should_gate_rendering_on_tec_screens(): void {
+		$this->given_a_tec_admin_screen();
 
-		$this->assertSame( tribe(), Config::getContainer() );
+		$this->assertTrue( tribe( Core_Update_Notice::class )->is_plugin_page() );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_not_gate_rendering_open_outside_tec_screens(): void {
+		set_current_screen( 'dashboard' );
+
+		$this->assertFalse( tribe( Core_Update_Notice::class )->is_plugin_page() );
 	}
 
 	/**
@@ -69,28 +77,47 @@ class Core_Update_NoticeTest extends WPTestCase {
 	 *
 	 * @test
 	 */
-	public function should_honour_the_shared_dismissal_flag(): void {
+	public function should_honour_the_shared_dismissal_for_the_offered_version(): void {
 		$this->given_core_update_response( 'upgrade', '9.9.9' );
 		$this->given_current_user_is( 'administrator' );
 
-		update_option( CoreUpdateNotice::DISMISSED_OPTION, true, false );
+		update_option( CoreUpdateNotice::DISMISSED_OPTION, [ '9.9.9' => true ], false );
 
 		$this->assertSame( '', $this->render_notice() );
 	}
 
 	/**
+	 * Dismissals are keyed on the offered version so one release cannot silence the next.
+	 *
 	 * @test
 	 */
-	public function should_render_only_once_per_request_across_plugins(): void {
-		$this->given_core_update_response( 'upgrade', '9.9.9' );
+	public function should_render_again_once_a_newer_release_is_offered(): void {
 		$this->given_current_user_is( 'administrator' );
 
-		$this->assertNotSame( '', $this->render_notice() );
-		$this->assertSame( '', $this->render_notice(), 'A second copy of the notice should be suppressed.' );
+		update_option( CoreUpdateNotice::DISMISSED_OPTION, [ '9.9.9' => true ], false );
+		$this->given_core_update_response( 'upgrade', '10.0.0' );
+
+		$this->assertStringContainsString( 'Keep your site protected.', $this->render_notice() );
+	}
+
+	/**
+	 * Exercises the controller's own call into the library, which is the line that breaks if the
+	 * package changes its registration signature.
+	 *
+	 * @test
+	 */
+	public function should_register_the_notice_hooks_through_the_library(): void {
+		tribe( Core_Update_Notice::class )->register_notice();
+
+		$this->assertNotFalse( has_filter( CoreUpdateNotice::DISPLAY_WINNER_FILTER ), 'The display winner filter should be registered.' );
+		$this->assertNotFalse( has_action( 'admin_notices' ), 'The notice should hook admin_notices.' );
 	}
 
 	/**
 	 * Captures one `admin_notices` pass of the configured notice.
+	 *
+	 * The library only renders the winner of its display filter, which `Register::notice()` wires
+	 * up before `admin_init`; that has already fired here, so the filter is attached directly.
 	 *
 	 * @return string The rendered markup, empty when the notice declined to render.
 	 */
@@ -103,10 +130,15 @@ class Core_Update_NoticeTest extends WPTestCase {
 			]
 		);
 
+		add_filter( CoreUpdateNotice::DISPLAY_WINNER_FILTER, [ $notice, 'selectWinner' ] );
+
 		ob_start();
 		$notice->render();
+		$html = ob_get_clean() ?: '';
 
-		return ob_get_clean() ?: '';
+		remove_filter( CoreUpdateNotice::DISPLAY_WINNER_FILTER, [ $notice, 'selectWinner' ] );
+
+		return $html;
 	}
 
 	/**
@@ -128,6 +160,13 @@ class Core_Update_NoticeTest extends WPTestCase {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Puts the request on a TEC admin screen, which is also what makes `is_admin()` true.
+	 */
+	protected function given_a_tec_admin_screen(): void {
+		set_current_screen( 'tribe_events_page_tec-events-settings' );
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2031](https://linear.app/nexcess/issue/SMTNC-2031/tribe-common-tecet)

### 🎥 Artifacts

<img width="1898" height="1001" alt="image" src="https://github.com/user-attachments/assets/190a29ae-f9a7-4400-b548-e3490de2103f" />

### 🗒️ Description

Adds a dismissible WordPress admin notice prompting site administrators to update WordPress while a core update is available, via the shared `stellarwp/core-update-notice` library so the dismissal carries across every StellarWP plugin that displays it.

### ⚠️ Blockers

None.