### PR TITLE
[SMTNC-2280] Event Ticket Sale End Date Reverts to Event Date in Block Editor

### DIFF
--- a/changelog/fix-smtnc-2280-event-ticket-sale-end-date-reverts-to-event-date-in-block.yaml
+++ b/changelog/fix-smtnc-2280-event-ticket-sale-end-date-reverts-to-event-date-in-block.yaml
@@ -1,0 +1,5 @@
+significance: patch
+type: fix
+entry: Resolved an issue where the date picker input kept showing a stale date
+  when its value was updated asynchronously after the initial render.
+timestamp: 2026-08-28T06:08:17.120Z

--- a/src/modules/elements/day-picker-input/__tests__/element.test.js
+++ b/src/modules/elements/day-picker-input/__tests__/element.test.js
@@ -24,4 +24,33 @@ describe( 'DayPickerInput element', () => {
 		);
 		expect( component.toJSON() ).toMatchSnapshot();
 	} );
+
+	it( 'Should re-sync the input value when the value prop changes', () => {
+		const firstValue = 'September 7, 2019';
+		const secondValue = 'October 10, 2019';
+
+		const component = renderer.create(
+			<DayPickerInput
+				value={ firstValue }
+				format={ 'LL' }
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		expect( component.toJSON().props.value ).toBe( firstValue );
+
+		component.update(
+			<DayPickerInput
+				value={ secondValue }
+				format={ 'LL' }
+				formatDate={ jest.fn() }
+				parseDate={ jest.fn() }
+				onDayChange={ jest.fn() }
+			/>,
+		);
+
+		expect( component.toJSON().props.value ).toBe( secondValue );
+	} );
 } );

--- a/src/modules/elements/day-picker-input/element.js
+++ b/src/modules/elements/day-picker-input/element.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import React, { useState, useRef, useMemo, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useMemo, useCallback } from 'react';
 import classNames from 'classnames';
 import 'react-day-picker/src/style.css';
 import { DayPicker } from 'react-day-picker';
@@ -79,6 +79,14 @@ const DayPickerInput = ( props ) => {
 	);
 
 	const [ selectedDate, setSelectedDate ] = useState( value ? getSelectedDateInitialState( value ) : new Date() );
+
+	// Keep the selected date in sync when the store updates the value (e.g. after
+	// the ticket fetch completes); otherwise the input shows a stale date.
+	useEffect( () => {
+		if ( value ) {
+			setSelectedDate( getSelectedDateInitialState( value ) );
+		}
+	}, [ value, getSelectedDateInitialState ] );
 
 	/**
 	 * Formats the datepicker Date object to the datepicker format.


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2280](https://linear.app/nexcess/issue/SMTNC-2280/event-ticket-sale-end-date-reverts-to-event-date-in-block)

### 🗒️ Description

**Fix** (bug fix - date picker showed a stale date when the value updated asynchronously)

Fixed an issue where the DayPickerInput element initialized its selected date once from the value prop and never re-synced when the store updated the value after an async fetch, leaving the input displaying a stale date. The component now re-syncs its selected date whenever the value prop changes, covered by a new regression test.

This is the display half of the SMTNC-2280 fix; the sale end date logic lives in the event-tickets plugin PR.
https://github.com/the-events-calendar/event-tickets/pull/4435

### 🎥 Artifacts <!-- if applicable-->
https://www.loom.com/share/7ca20b14e1af42d79aaf8c3d1a7cf855

### ✔️ Checklist
- [ ] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [ ] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [ ] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.
