### PR TITLE
[SMTNC-1857] FSE Single Event template saves create single-event-N duplicates and revert the active template to default

### DIFF
--- a/changelog/smtnc-1857-fse-single-event-template-saves-create-single-event-n.yaml
+++ b/changelog/smtnc-1857-fse-single-event-template-saves-create-single-event-n.yaml
@@ -1,0 +1,6 @@
+significance: patch
+type: fix
+entry: Resolved an issue where saving a Full Site Editing template could store
+  the change on a duplicate template and revert the active template to its
+  default layout.
+timestamp: 2026-08-28T22:43:35.308Z

--- a/src/Common/Editor/Full_Site/Template_Utils.php
+++ b/src/Common/Editor/Full_Site/Template_Utils.php
@@ -106,8 +106,8 @@ class Template_Utils {
 		$wp_query_args  = [
 			'post_name__in'  => [ $post_name ],
 			'post_type'      => 'wp_template',
-			'post_status'    => [ 'auto-draft', 'draft', 'publish', 'trash' ],
-			'posts_per_page' => 1,
+			'post_status'    => [ 'auto-draft', 'draft', 'publish' ],
+			'posts_per_page' => -1,
 			'no_found_rows'  => true,
 			'tax_query'      => [
 				[
@@ -125,7 +125,17 @@ class Template_Utils {
 			return null;
 		}
 
-		$post = $posts[0] ?? null;
+		$posts = self::sort_block_template_claimants( $posts );
+		$post  = array_shift( $posts );
+
+		/*
+		 * More than one row claiming the slug is what makes the Site Editor save ambiguous: core's own
+		 * unique-slug guard then renames the row being saved, so the edit lands on a slug nothing
+		 * resolves. Move the losers aside so a single row owns the slug from here on.
+		 */
+		foreach ( $posts as $duplicate ) {
+			self::rename_duplicate_block_template( $duplicate, $post_name );
+		}
 
 		// Validate our query result.
 		if ( ! $post instanceof WP_Post ) {
@@ -175,6 +185,18 @@ class Template_Utils {
 			return null;
 		}
 
+		/*
+		 * `wp_insert_post()` only honours `tax_input` for a user who can `assign_terms`, and `wp_theme`
+		 * declares no capabilities so it inherits `edit_posts`. A resolution served to a visitor would
+		 * otherwise store a termless row that no lookup can ever match, and insert another one on every
+		 * subsequent request.
+		 */
+		if ( is_array( $insert['tax_input'] ) ) {
+			foreach ( $insert['tax_input'] as $taxonomy => $terms ) {
+				wp_set_object_terms( $id, $terms, $taxonomy );
+			}
+		}
+
 		return self::hydrate_block_template_by_post( get_post( $id ) );
 	}
 
@@ -212,5 +234,62 @@ class Template_Utils {
 		$template->modified       = $post->post_modified;
 
 		return $template;
+	}
+
+	/**
+	 * Orders the posts claiming a template slug so the canonical one comes first.
+	 *
+	 * Published rows outrank the rest, then the oldest row wins: when this bug has been reseeding
+	 * templates the newest row is the plugin's default markup and the oldest one still holds the
+	 * customization.
+	 *
+	 * @since TBD
+	 *
+	 * @param array<WP_Post> $posts The posts claiming the slug.
+	 *
+	 * @return array<WP_Post> The posts, canonical one first.
+	 */
+	private static function sort_block_template_claimants( array $posts ): array {
+		usort(
+			$posts,
+			static function ( WP_Post $a, WP_Post $b ): int {
+				$a_rank = 'publish' === $a->post_status ? 0 : 1;
+				$b_rank = 'publish' === $b->post_status ? 0 : 1;
+
+				if ( $a_rank !== $b_rank ) {
+					return $a_rank <=> $b_rank;
+				}
+
+				if ( $a->post_date_gmt !== $b->post_date_gmt ) {
+					return strcmp( $a->post_date_gmt, $b->post_date_gmt );
+				}
+
+				return $a->ID <=> $b->ID;
+			}
+		);
+
+		return $posts;
+	}
+
+	/**
+	 * Moves a duplicate template off the slug it is contesting.
+	 *
+	 * The row is renamed rather than trashed: a site running with `EMPTY_TRASH_DAYS` at 0 deletes on
+	 * trash, which would destroy the only copy of a layout this bug has stranded on a duplicate.
+	 *
+	 * @since TBD
+	 *
+	 * @param WP_Post $post      The duplicate to rename.
+	 * @param string  $post_name The slug being contested.
+	 *
+	 * @return void
+	 */
+	private static function rename_duplicate_block_template( WP_Post $post, string $post_name ): void {
+		wp_update_post(
+			[
+				'ID'        => $post->ID,
+				'post_name' => $post_name . '-duplicate',
+			]
+		);
 	}
 }

--- a/src/Common/Editor/Full_Site/Template_Utils.php
+++ b/src/Common/Editor/Full_Site/Template_Utils.php
@@ -277,6 +277,10 @@ class Template_Utils {
 	 * The row is renamed rather than trashed: a site running with `EMPTY_TRASH_DAYS` at 0 deletes on
 	 * trash, which would destroy the only copy of a layout this bug has stranded on a duplicate.
 	 *
+	 * The ID is part of the new slug because core returns from `wp_unique_post_slug()` before the
+	 * `wp_template` dedupe filter for draft statuses, so several renamed drafts would otherwise land
+	 * on one slug and recreate the ambiguity being cleaned up here.
+	 *
 	 * @since TBD
 	 *
 	 * @param WP_Post $post      The duplicate to rename.
@@ -288,7 +292,7 @@ class Template_Utils {
 		wp_update_post(
 			[
 				'ID'        => $post->ID,
-				'post_name' => $post_name . '-duplicate',
+				'post_name' => $post_name . '-duplicate-' . $post->ID,
 			]
 		);
 	}

--- a/src/Common/Editor/Full_Site/Template_Utils.php
+++ b/src/Common/Editor/Full_Site/Template_Utils.php
@@ -245,9 +245,9 @@ class Template_Utils {
 	 *
 	 * @since TBD
 	 *
-	 * @param array<WP_Post> $posts The posts claiming the slug.
+	 * @param array<int, WP_Post> $posts The posts claiming the slug.
 	 *
-	 * @return array<WP_Post> The posts, canonical one first.
+	 * @return array<int, WP_Post> The posts, canonical one first.
 	 */
 	private static function sort_block_template_claimants( array $posts ): array {
 		usort(

--- a/src/Common/Editor/Full_Site/Template_Utils.php
+++ b/src/Common/Editor/Full_Site/Template_Utils.php
@@ -3,6 +3,7 @@
 namespace TEC\Common\Editor\Full_Site;
 
 use InvalidArgumentException;
+use TEC\Common\StellarWP\DB\DB;
 use WP_Block_Template;
 use WP_Post;
 use WP_Query;
@@ -273,11 +274,12 @@ class Template_Utils {
 	 * Moves a duplicate template off the slug it is contesting.
 	 *
 	 * The row is renamed rather than trashed: a site running with `EMPTY_TRASH_DAYS` at 0 deletes on
-	 * trash, which would destroy the only copy of a layout this bug has stranded on a duplicate.
+	 * trash, and the duplicate can be holding the only copy of a layout. The ID keeps each renamed row
+	 * distinct.
 	 *
-	 * The ID is part of the new slug because core returns from `wp_unique_post_slug()` before the
-	 * `wp_template` dedupe filter for draft statuses, so several renamed drafts would otherwise land
-	 * on one slug and recreate the ambiguity being cleaned up here.
+	 * Only the slug column is written. `wp_update_post()` re-saves the whole row, and this can run
+	 * while a resolution is served to a visitor, so `post_content` would go through kses and lose the
+	 * markup inside any `core/html` block.
 	 *
 	 * @since TBD
 	 *
@@ -287,11 +289,12 @@ class Template_Utils {
 	 * @return void
 	 */
 	private static function rename_duplicate_block_template( WP_Post $post, string $post_name ): void {
-		wp_update_post(
-			[
-				'ID'        => $post->ID,
-				'post_name' => $post_name . '-duplicate-' . $post->ID,
-			]
+		DB::update(
+			DB::prefix( 'posts' ),
+			[ 'post_name' => $post_name . '-duplicate-' . $post->ID ],
+			[ 'ID' => $post->ID ]
 		);
+
+		clean_post_cache( $post->ID );
 	}
 }

--- a/src/Common/Editor/Full_Site/Template_Utils.php
+++ b/src/Common/Editor/Full_Site/Template_Utils.php
@@ -239,9 +239,7 @@ class Template_Utils {
 	/**
 	 * Orders the posts claiming a template slug so the canonical one comes first.
 	 *
-	 * Published rows outrank the rest, then the oldest row wins: when this bug has been reseeding
-	 * templates the newest row is the plugin's default markup and the oldest one still holds the
-	 * customization.
+	 * Published rows outrank the rest, then the oldest row wins.
 	 *
 	 * @since TBD
 	 *

--- a/tests/wpunit/TEC/Common/Editor/Full_Site/Template_UtilsTest.php
+++ b/tests/wpunit/TEC/Common/Editor/Full_Site/Template_UtilsTest.php
@@ -105,11 +105,135 @@ class Template_UtilsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * The `wp_theme` taxonomy inherits the `edit_posts` capability for `assign_terms`, so a front-end
+	 * resolution by a visitor used to store a termless row that no lookup could ever find again.
+	 *
+	 * @test
+	 */
+	public function should_attach_theme_term_without_the_assign_terms_capability() {
+		wp_set_current_user( 0 );
+
+		$template = Template_Utils::save_block_template(
+			[
+				'post_name'    => 'termless',
+				'tax_input'    => [ 'wp_theme' => 'tec' ],
+				'post_content' => 'Lorem ipsum...',
+			]
+		);
+
+		$this->assertInstanceOf( WP_Block_Template::class, $template );
+		$this->assertEquals( 'tec', $template->theme );
+		$this->assertEquals( 'tec//termless', $template->id );
+		$this->assertEquals( [ 'tec' ], wp_get_object_terms( $template->wp_id, 'wp_theme', [ 'fields' => 'names' ] ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_return_the_oldest_published_claimant() {
+		$oldest = $this->given_a_claimant( 'many-claimants', 'publish', '2020-01-01 00:00:00' );
+		$middle = $this->given_a_claimant( 'many-claimants', 'publish', '2021-01-01 00:00:00' );
+		$newest = $this->given_a_claimant( 'many-claimants', 'publish', '2022-01-01 00:00:00' );
+
+		$template = Template_Utils::find_block_template_by_post( 'many-claimants' );
+
+		$this->assertInstanceOf( WP_Block_Template::class, $template );
+		$this->assertEquals( $oldest, $template->wp_id );
+		$this->assertNotEquals( $middle, $template->wp_id );
+		$this->assertNotEquals( $newest, $template->wp_id );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_rename_the_losing_claimants_without_trashing_them() {
+		$winner = $this->given_a_claimant( 'renamed-losers', 'publish', '2020-01-01 00:00:00' );
+		$loser  = $this->given_a_claimant( 'renamed-losers', 'publish', '2021-01-01 00:00:00' );
+
+		Template_Utils::find_block_template_by_post( 'renamed-losers' );
+
+		$this->assertEquals( 'renamed-losers', get_post( $winner )->post_name );
+		$this->assertStringStartsWith( 'renamed-losers-duplicate', get_post( $loser )->post_name );
+		$this->assertEquals( 'publish', get_post( $loser )->post_status );
+	}
+
+	/**
+	 * The draft is the newer row, so the default `post_date DESC` ordering would hand it back.
+	 *
+	 * @test
+	 */
+	public function should_prefer_a_published_claimant_over_a_newer_draft() {
+		$published = $this->given_a_claimant( 'draft-and-publish', 'publish', '2020-01-01 00:00:00' );
+		$draft     = $this->given_a_claimant( 'draft-and-publish', 'draft', '2021-01-01 00:00:00' );
+
+		$template = Template_Utils::find_block_template_by_post( 'draft-and-publish' );
+
+		$this->assertInstanceOf( WP_Block_Template::class, $template );
+		$this->assertEquals( $published, $template->wp_id );
+		$this->assertNotEquals( $draft, $template->wp_id );
+	}
+
+	/**
+	 * The row is stored as trash rather than run through `wp_trash_post()`, which would append the
+	 * `__trashed` suffix and take the row out of the slug query on its own.
+	 *
+	 * @test
+	 */
+	public function should_never_resolve_to_a_trashed_claimant() {
+		$live    = $this->given_a_claimant( 'trashed-claimant', 'publish', '2020-01-01 00:00:00' );
+		$trashed = $this->given_a_claimant( 'trashed-claimant', 'trash', '2021-01-01 00:00:00' );
+
+		$template = Template_Utils::find_block_template_by_post( 'trashed-claimant' );
+
+		$this->assertInstanceOf( WP_Block_Template::class, $template );
+		$this->assertEquals( $live, $template->wp_id );
+		$this->assertNotEquals( $trashed, $template->wp_id );
+	}
+
+	/**
+	 * @test
+	 */
+	public function should_return_null_when_every_claimant_is_trashed() {
+		$this->given_a_claimant( 'only-trash', 'trash', '2020-01-01 00:00:00' );
+
+		$this->assertNull( Template_Utils::find_block_template_by_post( 'only-trash' ) );
+	}
+
+	/**
 	 * @test
 	 */
 	public function should_throw_exception_missing_params_on_create_block_template_post() {
 		$this->expectException( InvalidArgumentException::class );
 		Template_Utils::save_block_template( [ 'tax_input' => 'bob' ] );
 		Template_Utils::save_block_template( [ 'post_name' => 'bob' ] );
+	}
+
+	/**
+	 * Stores a `wp_template` row claiming a slug under the `tec` theme.
+	 *
+	 * The term is attached directly rather than through `tax_input` so the fixture does not depend on
+	 * the behaviour under test.
+	 *
+	 * @param string $slug   The `post_name` the row claims.
+	 * @param string $status The `post_status` to store the row with.
+	 * @param string $date   The `post_date` to store the row with, in site time.
+	 *
+	 * @return int The stored post ID.
+	 */
+	private function given_a_claimant( string $slug, string $status, string $date ): int {
+		$id = wp_insert_post(
+			[
+				'post_name'     => $slug,
+				'post_type'     => 'wp_template',
+				'post_status'   => $status,
+				'post_content'  => 'Lorem ipsum...',
+				'post_date'     => $date,
+				'post_date_gmt' => get_gmt_from_date( $date ),
+			]
+		);
+
+		wp_set_object_terms( $id, 'tec', 'wp_theme' );
+
+		return $id;
 	}
 }

--- a/tests/wpunit/TEC/Common/Editor/Full_Site/Template_UtilsTest.php
+++ b/tests/wpunit/TEC/Common/Editor/Full_Site/Template_UtilsTest.php
@@ -219,7 +219,7 @@ class Template_UtilsTest extends \Codeception\TestCase\WPTestCase {
 		];
 
 		$this->assertEquals( 'draft-claimants', $names[0] );
-		$this->assertCount( 3, array_unique( $names ) );
+		$this->assertCount( count( $names ), array_unique( $names ) );
 	}
 
 	/**

--- a/tests/wpunit/TEC/Common/Editor/Full_Site/Template_UtilsTest.php
+++ b/tests/wpunit/TEC/Common/Editor/Full_Site/Template_UtilsTest.php
@@ -200,6 +200,29 @@ class Template_UtilsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * Core returns early from `wp_unique_post_slug()` for draft statuses, before the `wp_template`
+	 * dedupe filter runs, so nothing else keeps the renamed losers apart.
+	 *
+	 * @test
+	 */
+	public function should_give_each_renamed_draft_claimant_a_distinct_slug() {
+		$winner  = $this->given_a_claimant( 'draft-claimants', 'draft', '2020-01-01 00:00:00' );
+		$loser_a = $this->given_a_claimant( 'draft-claimants', 'draft', '2021-01-01 00:00:00' );
+		$loser_b = $this->given_a_claimant( 'draft-claimants', 'draft', '2022-01-01 00:00:00' );
+
+		Template_Utils::find_block_template_by_post( 'draft-claimants' );
+
+		$names = [
+			get_post( $winner )->post_name,
+			get_post( $loser_a )->post_name,
+			get_post( $loser_b )->post_name,
+		];
+
+		$this->assertEquals( 'draft-claimants', $names[0] );
+		$this->assertCount( 3, array_unique( $names ) );
+	}
+
+	/**
 	 * @test
 	 */
 	public function should_throw_exception_missing_params_on_create_block_template_post() {

--- a/tests/wpunit/TEC/Common/Editor/Full_Site/Template_UtilsTest.php
+++ b/tests/wpunit/TEC/Common/Editor/Full_Site/Template_UtilsTest.php
@@ -105,8 +105,8 @@ class Template_UtilsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
-	 * The `wp_theme` taxonomy inherits the `edit_posts` capability for `assign_terms`, so a front-end
-	 * resolution by a visitor used to store a termless row that no lookup could ever find again.
+	 * The `wp_theme` taxonomy inherits the `edit_posts` capability for `assign_terms`, so `tax_input`
+	 * is dropped for a visitor, and a termless row is one no lookup can find again.
 	 *
 	 * @test
 	 */
@@ -223,6 +223,30 @@ class Template_UtilsTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * The rename runs while a resolution is being served, so the current user can be a visitor with no
+	 * `unfiltered_html`: re-saving the row through the post pipeline would put its markup through kses.
+	 *
+	 * @test
+	 */
+	public function should_leave_the_renamed_claimant_markup_untouched() {
+		$content = "<!-- wp:html -->\n<script>console.log( 'kept' );</script>\n<!-- /wp:html -->";
+		$author  = static::factory()->user->create( [ 'role' => 'administrator' ] );
+
+		wp_set_current_user( $author );
+
+		$winner = $this->given_a_claimant( 'markup-claimants', 'publish', '2020-01-01 00:00:00' );
+		$loser  = $this->given_a_claimant( 'markup-claimants', 'publish', '2021-01-01 00:00:00', $content );
+
+		wp_set_current_user( 0 );
+
+		Template_Utils::find_block_template_by_post( 'markup-claimants' );
+
+		$this->assertEquals( 'markup-claimants', get_post( $winner )->post_name );
+		$this->assertStringStartsWith( 'markup-claimants-duplicate', get_post( $loser )->post_name );
+		$this->assertEquals( $content, get_post( $loser )->post_content );
+	}
+
+	/**
 	 * @test
 	 */
 	public function should_throw_exception_missing_params_on_create_block_template_post() {
@@ -237,19 +261,20 @@ class Template_UtilsTest extends \Codeception\TestCase\WPTestCase {
 	 * The term is attached directly rather than through `tax_input` so the fixture does not depend on
 	 * the behaviour under test.
 	 *
-	 * @param string $slug   The `post_name` the row claims.
-	 * @param string $status The `post_status` to store the row with.
-	 * @param string $date   The `post_date` to store the row with, in site time.
+	 * @param string $slug    The `post_name` the row claims.
+	 * @param string $status  The `post_status` to store the row with.
+	 * @param string $date    The `post_date` to store the row with, in site time.
+	 * @param string $content The `post_content` to store the row with.
 	 *
 	 * @return int The stored post ID.
 	 */
-	private function given_a_claimant( string $slug, string $status, string $date ): int {
+	private function given_a_claimant( string $slug, string $status, string $date, string $content = 'Lorem ipsum...' ): int {
 		$id = wp_insert_post(
 			[
 				'post_name'     => $slug,
 				'post_type'     => 'wp_template',
 				'post_status'   => $status,
-				'post_content'  => 'Lorem ipsum...',
+				'post_content'  => $content,
 				'post_date'     => $date,
 				'post_date_gmt' => get_gmt_from_date( $date ),
 			]


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-1857](https://linear.app/nexcess/issue/SMTNC-1857/fse-single-event-template-saves-create-single-event-n-duplicates-and)

### 🗒️ Description

Resolves the Full Site Editing template lookup to a single canonical row when several claim the same slug, and attaches the `wp_theme` term after insert so repeat resolutions stop creating new template rows.

### ⚠️ Blockers
None 

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [ ] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [x] Are all the **required** tests passing?
- [x] Automated code review comments are addressed.
- [x] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [x] Add your PR to the project board for the release.
