### PR TITLE
fix(Models) do not re-serialize model properties restored from cache

### DIFF
--- a/changelog/smtnc-2354-investigate-orm-fatal-error-with-object-caching
+++ b/changelog/smtnc-2354-investigate-orm-fatal-error-with-object-caching
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Stopped post type models from re-serializing properties that were restored from an already warm object cache, and made lazy collections resolve to an empty array instead of throwing a fatal error when they have no callback left to call.

--- a/src/Tribe/Models/Post_Types/Base.php
+++ b/src/Tribe/Models/Post_Types/Base.php
@@ -278,6 +278,7 @@ abstract class Base {
 	 * object properties will be "scalarized".
 	 *
 	 * @since 5.0.3
+	 * @since TBD Do not write again over an entry that is already cached.
 	 *
 	 * @param string $cache_slug The cache slug of the post type model.
 	 * @param string $filter     The filter to cache the model for.
@@ -289,6 +290,15 @@ abstract class Base {
 		$cache = new Cache();
 
 		return function () use ( $cache, $cache_key, $filter ) {
+			if ( false !== $this->get_cached_properties( $filter ) ) {
+				/*
+				 * The entry is already cached: `get_properties` would hand back the objects restored from
+				 * that entry and serializing those a second time is lossy, since restored objects only
+				 * carry their values, not the callbacks used to build them.
+				 */
+				return;
+			}
+
 			$properties = $this->get_properties( $filter );
 			$pre_serialized_properties = [];
 
@@ -355,6 +365,8 @@ abstract class Base {
 
 	/**
 	 * Commits the model properties to cache immediately.
+	 *
+	 * If the properties are already cached for the filter, this is a no-op.
 	 *
 	 * @since 5.0.3
 	 *

--- a/src/Tribe/Utils/Lazy_Collection.php
+++ b/src/Tribe/Utils/Lazy_Collection.php
@@ -76,14 +76,19 @@ class Lazy_Collection implements Collection_Interface {
 	/**
 	 * Fills the array elements from the callback if required.
 	 *
+	 * A collection restored from cache carries its items, not its callback: if the items could not be
+	 * restored there is nothing left to fetch them with, so the collection resolves to an empty array
+	 * rather than blowing up on an invalid callback.
+	 *
 	 * @since 4.9.14
+	 * @since TBD Do not call the callback if it's not callable.
 	 */
 	protected function resolve() {
 		if ( null !== $this->items ) {
 			return;
 		}
 
-		$items       = call_user_func( $this->callback );
+		$items       = is_callable( $this->callback ) ? call_user_func( $this->callback ) : [];
 		$this->items = (array) $items;
 		$this->resolved();
 	}

--- a/tests/wpunit/Tribe/Utils/Lazy_CollectionTest.php
+++ b/tests/wpunit/Tribe/Utils/Lazy_CollectionTest.php
@@ -117,6 +117,33 @@ class Lazy_CollectionTest extends \Codeception\TestCase\WPTestCase {
 	}
 
 	/**
+	 * It should resolve to an empty array when the callback is not callable
+	 *
+	 * A collection restored from a stale or malformed cache entry has neither items nor a callback:
+	 * reading it should come up empty, not fatal.
+	 *
+	 * @test
+	 */
+	public function should_resolve_to_an_empty_array_when_the_callback_is_not_callable() {
+		$collection = new Lazy_Collection( '__return_empty_array' );
+
+		$callback = new \ReflectionProperty( Lazy_Collection::class, 'callback' );
+		$callback->setAccessible( true );
+		$callback->setValue( $collection, null );
+
+		$this->assertEquals( [], $collection->all() );
+		$this->assertEquals( 0, $collection->count() );
+		$this->assertFalse( $collection->first() );
+
+		$got = [];
+		foreach ( $collection as $item ) {
+			$got[] = $item;
+		}
+
+		$this->assertEquals( [], $got );
+	}
+
+	/**
 	 * It should allow accessing the collection methods as properties
 	 *
 	 * @test


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2354](https://linear.app/nexcess/issue/SMTNC-2354/investigate-orm-fatal-error-with-object-caching)

### 🗒️ Description

Bug fix. Pairs with the-events-calendar/the-events-calendar#5753 — both are needed, this one first.

Reported at https://wordpress.org/support/topic/fatal-error-using-orm-with-object-caching: on a site with a persistent object cache, `tribe_events()->by( 'id', $id )->first()->venues` throws

```
TypeError: call_user_func(): Argument #1 ($callback) must be a valid callback, no array or string given
  .../common/src/Tribe/Utils/Lazy_Collection.php(86)
```

**What goes wrong**

`Base::get_object_cache_callback()` returns a closure hooked on `shutdown`. That closure called `$this->get_properties( $filter )` without forcing a rebuild, so if the entry was already in the object cache it read the properties back out and serialized them a second time.

Objects restored from a cache entry only carry their values, not the callbacks that produced them. Serializing them again therefore writes an entry that can no longer rebuild itself. On the TEC side that lands as a `Lazy_Post_Collection` with neither items nor a callback, and the next read is fatal.

The everyday trigger is any forced fetch on a warm cache, e.g. `Template_Modifications::get_post_classes()` in TEC calls `tribe_get_event( $event, OBJECT, 'raw', true )` on the `post_class` filter, which runs on every event render. That is also why clearing Redis does not help: the next page load writes the bad entry again.

**Changes**

- `Base::get_object_cache_callback()` — the closure returns early when `get_cached_properties()` already has the entry. Nothing to write, and it avoids the lossy second serialization. This also skips a redundant serialize plus cache write on every forced fetch.
- `Lazy_Collection::resolve()` — guards the callback with `is_callable()`. A collection with nothing left to call now resolves to an empty array instead of throwing. Every accessor (`all`, `first`, `count`, `valid`, `offsetGet`, `jsonSerialize`) routes through `resolve()`, so this covers all of them, including the broken entries already sitting in people's caches.

**Note for reviewers**

`commit_to_cache()` reuses the same closure, so it is now a no-op when the entry is already cached. I checked TEC, ET, ETP, Pro, Filter Bar, Community and Eventbrite: it has no callers.

Existing bad cache entries are not purged. They cannot be exploited (the `null` callback is rejected by the allow list on the TEC side and then by `is_callable()` here) and they self-clear on the next post save, since `Tribe__Cache::get_id()` salts the key with `tribe_last_save_post`. Until then the affected event renders with no venues or organizers rather than fataling.

### 🎥 Artifacts

n/a, back end only.

### ✔️ Checklist
- [x] Ran `npm run changelog` to add changelog file(s). More info [here](https://docs.theeventscalendar.com/developer/git/changelogs/#process)
- [x] Code is covered by **NEW** `wpunit` or `integration` tests.
- [x] Code is covered by **EXISTING** `wpunit` or `integration` tests.
- [ ] Are all the **required** tests passing?
- [ ] Automated code review comments are addressed.
- [ ] Have you added Artifacts?
- [x] Check the base branch for your PR.
- [ ] Add your PR to the project board for the release.

