### PR TITLE
[SMTNC-2413] Use a lower case change name in the OpenSpec example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ store as `tec-plans`.
 
 ### Working on a ticket
 
-1. **Create the change before writing code**, named after the ticket:
-   `openspec new change SOFT-1234 --store tec-plans --description "what this does"`
+1. **Create the change before writing code**, named after the ticket in lower
+   case. OpenSpec requires kebab-case and rejects anything else, so the ticket
+   `SOFT-1234` becomes the change `soft-1234`:
+   `openspec new change soft-1234 --store tec-plans --description "what this does"`
 2. Write the proposal, then commit and push it in the plans repo.
 3. Branch as usual: `feat/SOFT-1234/short-desc`.
 4. Implement. If the work shows the plan was wrong — it often does — update the


### PR DESCRIPTION
### 🎫 Ticket

[SMTNC-2413](https://linear.app/nexcess/issue/SMTNC-2413)

Follow-up to #2999, which is already merged. Part of [SMTNC-2410](https://linear.app/nexcess/issue/SMTNC-2410), Enforce OpenSpec for TEC products.

### 📋 Plan

_None._ A one line correction to an example command.

### 🗒️ Description

The OpenSpec section that landed in #2999 shows this:

```
openspec new change SOFT-1234 --store tec-plans --description "what this does"
```

That command does not work. OpenSpec requires change names to be lower case kebab-case and refuses anything else outright:

```
✖ Error: Change name must be lowercase (use kebab-case)
```

So anyone following the readme hits an error on the first step. The example now uses `soft-1234` and says why, since the branch name keeps the upper case ticket (`feat/SOFT-1234/short-desc`) and only the change name is lowercased.

### 🎥 Artifacts

_Not applicable, documentation only._

### ✔️ Verification

Reproduced against the real CLI before and after: `openspec new change SOFT-9999` fails with the error above, `openspec new change soft-9999` succeeds. The same correction is going to the other fifteen repositories that received this section, and to the CI check, which was looking the change up by its upper case name and would have reported every plan as missing.

### ✔️ Checklist
- [ ] Ran `npm run changelog` — not applicable, documentation only.
- [x] Base branch checked: `main`.
- [ ] Code is covered by tests — not applicable, no code changed.

### 🤖 AI usage

Claude Opus 5 found the error and wrote the correction, in a working session with me.
